### PR TITLE
fix(formula): resolve composed formulas in prime

### DIFF
--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -114,15 +114,9 @@ func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 // extraVars is an optional list of "key=value" overrides that are substituted into
 // step descriptions before rendering, taking precedence over formula defaults.
 func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ...[]string) {
-	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
+	f, err := formula.ResolveFormula(formulaName, townRoot, rigName)
 	if err != nil {
-		style.PrintWarning("could not load formula %s: %v", formulaName, err)
-		return
-	}
-
-	f, err := formula.Parse(content)
-	if err != nil {
-		style.PrintWarning("could not parse formula %s: %v", formulaName, err)
+		style.PrintWarning("could not resolve formula %s: %v", formulaName, err)
 		return
 	}
 
@@ -162,14 +156,9 @@ func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]
 }
 
 func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) (string, error) {
-	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
+	f, err := formula.ResolveFormula(formulaName, townRoot, rigName)
 	if err != nil {
-		return "", fmt.Errorf("could not load formula %s: %w", formulaName, err)
-	}
-
-	f, err := formula.Parse(content)
-	if err != nil {
-		return "", fmt.Errorf("could not parse formula %s: %w", formulaName, err)
+		return "", fmt.Errorf("could not resolve formula %s: %w", formulaName, err)
 	}
 
 	if len(f.Steps) == 0 {

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -1055,6 +1055,26 @@ func TestCheckSlungWork_RalphModeUsesLoopDirective(t *testing.T) {
 	}
 }
 
+func TestRenderFormulaStepsFullResolvesExtendsCompose(t *testing.T) {
+	rendered, err := renderFormulaStepsFull("mol-polecat-work-monorepo-tdd", "", "", []string{
+		"feature=Formula resolution",
+		"issue=gt-test",
+	})
+	if err != nil {
+		t.Fatalf("renderFormulaStepsFull: %v", err)
+	}
+	for _, want := range []string{
+		"Formula Checklist",
+		"Write failing tests for:",
+		"Verify tests fail (red)",
+		"Implement to green:",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered checklist missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
 // TestCompactResumeReminder_PolecatGetsGtDone verifies that polecats get a
 // gt done reminder after context compaction. This is the regression test for
 // the polecats-no-gt-done bug: after long work sessions, compaction drops the

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -522,13 +522,14 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
 	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
 	// creates a wisp that's bonded to a separate base bead.
+	storedVars := formulaVarsForStandaloneWisp(wispRootID, slingVars)
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:      actor,
 		Args:            slingArgs,
-		Vars:            append([]string(nil), slingVars...),
+		Vars:            storedVars,
 		AttachedFormula: formulaName,
 		Mode:            &mode,
-		FormulaVars:     strings.Join(slingVars, "\n"),
+		FormulaVars:     strings.Join(storedVars, "\n"),
 	}
 	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1082,6 +1082,38 @@ func formulaVarsForBead(formulaName, beadID, title string, extraVars []string) [
 	return ensureFormulaRequiredVars(formulaName, formulaVars)
 }
 
+func formulaVarsForStandaloneWisp(wispRootID string, extraVars []string) []string {
+	formulaVars := append([]string(nil), extraVars...)
+	formulaVars = append(formulaVars, fmt.Sprintf("issue=%s", wispRootID))
+	return dedupeFormulaVarsLast(formulaVars)
+}
+
+func dedupeFormulaVarsLast(vars []string) []string {
+	indexes := make(map[string]int, len(vars))
+	deduped := make([]string, 0, len(vars))
+	for _, variable := range vars {
+		if strings.TrimSpace(variable) == "" {
+			continue
+		}
+		idx := strings.IndexByte(variable, '=')
+		if idx <= 0 {
+			deduped = append(deduped, variable)
+			continue
+		}
+		key := strings.TrimSpace(variable[:idx])
+		if key == "" {
+			continue
+		}
+		if existing, ok := indexes[key]; ok {
+			deduped[existing] = variable
+			continue
+		}
+		indexes[key] = len(deduped)
+		deduped = append(deduped, variable)
+	}
+	return deduped
+}
+
 // bondFormulaDirect attaches a formula to a bead through bd's canonical bond path.
 func bondFormulaDirect(bondTarget, formulaName, beadID, formulaWorkDir, townRoot string, vars []string) (string, error) {
 	bondArgs := []string{"mol", "bond", bondTarget, beadID, "--json", "--ephemeral"}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2202,7 +2202,7 @@ exit /b 0
 		slingRalph = prevRalph
 	})
 
-	slingVars = []string{"version=1.2.3", "channel=stable"}
+	slingVars = []string{"version=1.2.3", "issue=fake", "channel=stable"}
 	slingDryRun = false
 	slingNoBoot = true
 	slingRalph = true
@@ -2222,6 +2222,25 @@ exit /b 0
 	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
+	}
+	if strings.Contains(attachment, "issue=fake") {
+		t.Fatalf("standalone formula should persist the real wisp issue, not caller issue override:\n%s", attachment)
+	}
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: attachment})
+	if fields == nil {
+		t.Fatalf("parse attachment fields returned nil:\n%s", attachment)
+	}
+	if !strings.Contains(fields.FormulaVars, "issue=gt-wisp-xyz") {
+		t.Fatalf("formula_vars missing wisp issue: %#v", fields.FormulaVars)
+	}
+	foundIssue := false
+	for _, variable := range fields.AttachedVars {
+		if variable == "issue=gt-wisp-xyz" {
+			foundIssue = true
+		}
+	}
+	if !foundIssue {
+		t.Fatalf("attached_vars missing wisp issue: %#v", fields.AttachedVars)
 	}
 	if !strings.Contains(attachment, "mode: ralph") {
 		t.Fatalf("ralph mode missing from persisted standalone formula description:\n%s", attachment)

--- a/internal/formula/embed.go
+++ b/internal/formula/embed.go
@@ -78,6 +78,37 @@ func ResolveFormulaContent(name, townRoot, rigName string) ([]byte, error) {
 	return GetEmbeddedFormulaContent(name)
 }
 
+// ResolveFormula loads and resolves a formula using the same tier precedence
+// for the root formula and all extends/compose dependencies.
+func ResolveFormula(name, townRoot, rigName string) (*Formula, error) {
+	content, err := ResolveFormulaContent(name, townRoot, rigName)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse formula %q: %w", name, err)
+	}
+
+	resolved, err := Resolve(f, formulaSearchPaths(townRoot, rigName))
+	if err != nil {
+		return nil, fmt.Errorf("resolve formula %q: %w", name, err)
+	}
+	return resolved, nil
+}
+
+func formulaSearchPaths(townRoot, rigName string) []string {
+	var paths []string
+	if townRoot != "" && rigName != "" {
+		paths = append(paths, filepath.Join(townRoot, rigName, ".beads", "formulas"))
+	}
+	if townRoot != "" {
+		paths = append(paths, filepath.Join(townRoot, ".beads", "formulas"))
+	}
+	return paths
+}
+
 // GetEmbeddedFormulaContent returns the raw content of an embedded formula by name.
 // The name can be with or without the .formula.toml suffix.
 // Returns the content bytes, or an error if the formula is not found.

--- a/internal/formula/embed_test.go
+++ b/internal/formula/embed_test.go
@@ -956,6 +956,86 @@ func TestResolveFormulaContent(t *testing.T) {
 	})
 }
 
+func TestResolveFormulaUsesTierPrecedenceForDependencies(t *testing.T) {
+	tmpDir := t.TempDir()
+	townFormulasDir := filepath.Join(tmpDir, ".beads", "formulas")
+	rigFormulasDir := filepath.Join(tmpDir, "testrig", ".beads", "formulas")
+	if err := os.MkdirAll(townFormulasDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigFormulasDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFormula := func(dir, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFormula(townFormulasDir, "tier-child", `formula = "tier-child"
+type = "workflow"
+version = 1
+extends = ["shiny"]
+
+[compose]
+[[compose.expand]]
+target = "implement"
+with = "tdd-cycle"
+`)
+	writeFormula(townFormulasDir, "shiny", `formula = "shiny"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "implement"
+title = "Town Implement"
+description = "from town"
+`)
+	writeFormula(townFormulasDir, "tdd-cycle", `formula = "tdd-cycle"
+type = "expansion"
+version = 1
+
+[[template]]
+id = "{target}.town"
+title = "Town expansion {target.title}"
+description = "from town"
+`)
+	writeFormula(rigFormulasDir, "shiny", `formula = "shiny"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "implement"
+title = "Rig Implement"
+description = "from rig"
+`)
+	writeFormula(rigFormulasDir, "tdd-cycle", `formula = "tdd-cycle"
+type = "expansion"
+version = 1
+
+[[template]]
+id = "{target}.rig"
+title = "Rig expansion {target.title}"
+description = "from rig"
+`)
+
+	resolved, err := ResolveFormula("tier-child", tmpDir, "testrig")
+	if err != nil {
+		t.Fatalf("ResolveFormula: %v", err)
+	}
+	if len(resolved.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1: %#v", len(resolved.Steps), resolved.Steps)
+	}
+	if got, want := resolved.Steps[0].ID, "implement.rig"; got != want {
+		t.Fatalf("resolved step ID = %q, want %q", got, want)
+	}
+	if got, want := resolved.Steps[0].Title, "Rig expansion Rig Implement"; got != want {
+		t.Fatalf("resolved step title = %q, want %q", got, want)
+	}
+}
+
 // TestGetEmbeddedFormulaContent verifies extraction of individual embedded formulas.
 func TestGetEmbeddedFormulaContent(t *testing.T) {
 	// Known embedded formula should succeed

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -501,8 +501,8 @@ func (f *Formula) GetAspect(id string) *Aspect {
 // Resolve processes the extends and compose rules of a formula, returning a new
 // formula with all inherited steps merged and expansion rules applied.
 //
-// Parent formulas named in extends are loaded from the embedded formula FS first,
-// then from any additional searchPaths (in order). searchPaths may be nil.
+// Parent formulas named in extends are loaded from searchPaths in order, then
+// from the embedded formula FS. searchPaths may be nil.
 //
 // Cycles in extends chains are detected and reported as errors.
 func Resolve(formula *Formula, searchPaths []string) (*Formula, error) {
@@ -598,23 +598,25 @@ func resolveChain(formula *Formula, searchPaths []string, chain []string) (*Form
 	return merged, nil
 }
 
-// loadFormulaByName loads a formula by name: embedded FS first, then searchPaths.
+// loadFormulaByName loads a formula by name: searchPaths first, then embedded FS.
 func loadFormulaByName(name string, searchPaths []string) (*Formula, error) {
-	// Try the embedded formula filesystem first.
-	data, err := GetEmbeddedFormulaContent(name)
-	if err == nil {
-		return Parse(data)
+	filename := name
+	if !hasFormulaSuffix(filename) {
+		filename = filename + ".formula.toml"
 	}
-
-	// Fall back to on-disk search paths.
 	for _, dir := range searchPaths {
-		path := filepath.Join(dir, name+".formula.toml")
+		path := filepath.Join(dir, filename)
 		if data, err2 := os.ReadFile(path); err2 == nil { //nolint:gosec // G304: path from controlled search paths
 			return Parse(data)
 		}
 	}
 
-	return nil, fmt.Errorf("formula %q not found in embedded FS or search paths", name)
+	data, err := GetEmbeddedFormulaContent(name)
+	if err == nil {
+		return Parse(data)
+	}
+
+	return nil, fmt.Errorf("formula %q not found in search paths or embedded FS", name)
 }
 
 // applyExpandRule replaces a target step in steps with the template steps from an


### PR DESCRIPTION
Replacement/fixup for #4066 by @flipch. Carries forward the valid formula-resolution bug fix on current upstream/main while dropping stale sling.go and sling_dispatch.go changes. Original-PR: https://github.com/gastownhall/gastown/pull/4066. Original-Commit: df492747486c3506eb31a775fcbc43d2829e2004. Attribution: original work by @flipch, with original co-author Claude Opus 4.7 (1M context) <noreply@anthropic.com>. Changes: add shared tier-aware formula resolution for root and dependencies, render prime formula steps after resolving extends/compose, and persist issue=<wispRootID> for standalone formula slings. Verification: CGO_ENABLED=0 go test ./internal/formula ./internal/cmd. PR Sheriff note: original #4066 remains conflicting/status-review-failed and should not merge as-is; this PR is the narrow replacement candidate.