### PR TITLE
fix(patrol): preserve completed patrols for reports

### DIFF
--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -117,6 +117,31 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 	return "", "", false, nil
 }
 
+// findPatrolForReport finds the newest patrol that can receive a cycle report.
+// Unlike findActivePatrol, this lookup intentionally does not inspect children
+// or clean up patrols: a legitimately completed patrol has no open children,
+// and the report command must be able to summarize and close that root itself.
+func findPatrolForReport(cfg PatrolConfig) (patrolID, patrolLine string, found bool, err error) {
+	b := cfg.Beads
+	if b == nil {
+		b = beads.New(cfg.BeadsDir)
+	}
+
+	hookedBeads, listErr := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
+	if listErr != nil {
+		return "", "", false, fmt.Errorf("listing reportable patrol work: %w", listErr)
+	}
+
+	// listAssignedActiveWorkAcrossStatuses returns newest work first, so the
+	// first matching root is the current patrol when stale roots also exist.
+	for _, bead := range hookedBeads {
+		if strings.HasPrefix(bead.Title, cfg.PatrolMolName) {
+			return bead.ID, formatBeadLine(bead), true, nil
+		}
+	}
+	return "", "", false, nil
+}
+
 // checkHasOpenChildren returns true if the given parent has any children
 // that are not in closed status (i.e., open or in_progress).
 // Returns an error if the child listing fails, so the caller can avoid

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
@@ -14,8 +15,10 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	beadsdk "github.com/steveyegge/beads"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -801,6 +804,126 @@ echo stdin:%stdin% >> %BD_STUB_LOG%
 }
 
 // --- Patrol discovery tests (findActivePatrol) ---
+
+type patrolReportLookupStore struct {
+	beadsdk.Storage
+	issues    []*beadsdk.Issue
+	closedIDs []string
+}
+
+func (s *patrolReportLookupStore) SearchIssues(_ context.Context, _ string, filter beadsdk.IssueFilter) ([]*beadsdk.Issue, error) {
+	var matches []*beadsdk.Issue
+	for _, issue := range s.issues {
+		if filter.Status != nil && issue.Status != *filter.Status {
+			continue
+		}
+		if filter.Assignee != nil && issue.Assignee != *filter.Assignee {
+			continue
+		}
+		if filter.SkipWisps && issue.Ephemeral {
+			continue
+		}
+		if filter.Ephemeral != nil && issue.Ephemeral != *filter.Ephemeral {
+			continue
+		}
+		if filter.ParentID != nil && !hasTestParent(issue, *filter.ParentID) {
+			continue
+		}
+		matches = append(matches, issue)
+	}
+	return matches, nil
+}
+
+func (s *patrolReportLookupStore) CloseIssue(_ context.Context, id, _, _, _ string) error {
+	s.closedIDs = append(s.closedIDs, id)
+	return nil
+}
+
+func hasTestParent(issue *beadsdk.Issue, parentID string) bool {
+	for _, dep := range issue.Dependencies {
+		if dep.Type == beadsdk.DepParentChild && dep.DependsOnID == parentID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFindPatrolForReportReturnsCompletedPatrolWithoutCleanup(t *testing.T) {
+	now := time.Now().UTC()
+	assignee := "testrig/witness"
+	molName := "mol-test-patrol"
+	currentID := "gt-current"
+	store := &patrolReportLookupStore{issues: []*beadsdk.Issue{
+		{
+			ID:        "gt-unrelated",
+			Title:     "some-other-work",
+			Status:    beadsdk.Status(beads.StatusHooked),
+			Assignee:  assignee,
+			CreatedAt: now.Add(time.Minute),
+			UpdatedAt: now.Add(time.Minute),
+			Ephemeral: true,
+		},
+		{
+			ID:        "gt-old",
+			Title:     molName + " (wisp)",
+			Status:    beadsdk.Status(beads.StatusHooked),
+			Assignee:  assignee,
+			CreatedAt: now.Add(-time.Hour),
+			UpdatedAt: now.Add(-time.Hour),
+			Ephemeral: true,
+		},
+		{
+			ID:        currentID,
+			Title:     molName + " (wisp)",
+			Status:    beadsdk.Status(beads.StatusHooked),
+			Assignee:  assignee,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Ephemeral: true,
+		},
+		{
+			ID:        "gt-current-step",
+			Title:     "final-step",
+			Status:    beadsdk.StatusClosed,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Ephemeral: true,
+			Dependencies: []*beadsdk.Dependency{{
+				IssueID:     "gt-current-step",
+				DependsOnID: currentID,
+				Type:        beadsdk.DepParentChild,
+			}},
+		},
+	}}
+
+	b := beads.NewWithStore(t.TempDir(), store)
+	hasOpen, err := checkHasOpenChildren(b, currentID)
+	if err != nil {
+		t.Fatalf("checkHasOpenChildren error: %v", err)
+	}
+	if hasOpen {
+		t.Fatal("fixture must represent a completed patrol with no open children")
+	}
+
+	patrolID, _, found, err := findPatrolForReport(PatrolConfig{
+		PatrolMolName: molName,
+		BeadsDir:      t.TempDir(),
+		Assignee:      assignee,
+		Beads:         b,
+	})
+	if err != nil {
+		t.Fatalf("findPatrolForReport error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the just-completed patrol to remain reportable")
+	}
+	if patrolID != currentID {
+		t.Fatalf("patrolID = %q, want newest matching patrol %q", patrolID, currentID)
+	}
+	if len(store.closedIDs) != 0 {
+		t.Fatalf("report lookup closed patrols %v; lookup must be non-destructive", store.closedIDs)
+	}
+}
 
 func requireBd(t *testing.T) {
 	t.Helper()

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -82,8 +82,10 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unsupported role for patrol report: %q", roleName)
 	}
 
-	// Find the active patrol
-	patrolID, _, hasPatrol, findErr := findActivePatrol(cfg)
+	// Find the patrol to report without using child status as a liveness signal.
+	// A completed patrol has no open children but must remain available here so
+	// this command can record its summary and close it with the correct reason.
+	patrolID, _, hasPatrol, findErr := findPatrolForReport(cfg)
 	if findErr != nil {
 		return fmt.Errorf("finding active patrol: %w", findErr)
 	}


### PR DESCRIPTION
## Summary

Keep a just-completed patrol root available to `gt patrol report` so the command can record its summary and close it with the correct completion reason.

The report path previously reused `findActivePatrol`, which treats an all-closed child set as stale and force-closes the root. That state is also the normal state immediately before a patrol report, so the lookup could destroy the record it was meant to consume.

## Related Issue

Fixes #4506

## Changes

- add a non-destructive lookup dedicated to reportable patrol roots
- select the newest matching hooked patrol without using child status as a liveness signal
- keep the existing stale-cleanup behavior for ordinary patrol discovery
- add an in-process regression test covering a completed patrol, older stale root, and newer unrelated work

## Testing

- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed
- [x] Focused regression passes:
  `go test -ldflags='-X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1' ./internal/cmd -run '^TestFindPatrolForReportReturnsCompletedPatrolWithoutCleanup$' -count=1 -v`
- [x] `go vet ./...`
- [x] `cmd/gt` builds with the repository's `BuiltProperly` linker flag
- [x] `git diff --check`

`go test ./...` was run but is not green in this environment. Failures are outside the changed patrol paths and include external-tool call-log fixtures, tmux integration assumptions, a Dolt purge stub mismatch, and the repository's 97%-disk-use guard. The focused regression and affected Beads package pass; Docker-backed patrol tests could not run because no Docker daemon is available.

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable; internal behavior is covered by code comments and a regression test)
- [x] No breaking changes (or documented in summary)

## AI assistance

Implementation, testing, and PR preparation were performed with OpenAI Codex.
