### PR TITLE
fix: create .beads directories with private permissions

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -2278,7 +2278,7 @@ func ProvisionPrimeMD(beadsDir string) error {
 	}
 
 	// Create .beads directory if it doesn't exist
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
 		return fmt.Errorf("creating beads dir: %w", err)
 	}
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -25,6 +25,15 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestProvisionPrimeMDCreatesPrivateBeadsDirectory(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := ProvisionPrimeMD(beadsDir); err != nil {
+		t.Fatalf("ProvisionPrimeMD: %v", err)
+	}
+
+	assertPrivateDirectory(t, beadsDir)
+}
+
 // TestListOptions verifies ListOptions defaults.
 func TestListOptions(t *testing.T) {
 	opts := ListOptions{

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -117,7 +117,7 @@ func RemoveRoute(townRoot string, prefix string) error {
 // WriteRoutes writes routes to routes.jsonl, overwriting existing content.
 func WriteRoutes(beadsDir string, routes []Route) error {
 	// Ensure beads directory exists
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
 		return fmt.Errorf("creating beads directory: %w", err)
 	}
 

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -3,11 +3,36 @@ package beads
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/config"
 )
+
+func assertPrivateDirectory(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX directory permissions")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Fatalf("directory permissions = %04o, want 0700", got)
+	}
+}
+
+func TestWriteRoutesCreatesPrivateBeadsDirectory(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown"}}); err != nil {
+		t.Fatalf("WriteRoutes: %v", err)
+	}
+
+	assertPrivateDirectory(t, beadsDir)
+}
 
 func TestGetPrefixForRig(t *testing.T) {
 	// Create a temporary directory with routes.jsonl

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3520,7 +3520,7 @@ func EnsureMetadataForBeadsDir(townRoot, beadsDir, rigName string, doltDatabase 
 		effectiveDB = doltDatabase[0]
 	}
 
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
 		return fmt.Errorf("creating beads directory: %w", err)
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -45,6 +45,26 @@ func TestFormatBytes(t *testing.T) {
 	}
 }
 
+func TestEnsureMetadataForBeadsDirCreatesPrivateDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX directory permissions")
+	}
+
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, "rig", ".beads")
+	if err := EnsureMetadataForBeadsDir(townRoot, beadsDir, "rig"); err != nil {
+		t.Fatalf("EnsureMetadataForBeadsDir: %v", err)
+	}
+
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		t.Fatalf("stat beads directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Fatalf("directory permissions = %04o, want 0700", got)
+	}
+}
+
 func TestDirSize(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1142,7 +1142,7 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	// If so, create a redirect file instead of a new database.
 	if _, err := os.Stat(mayorRigBeads); err == nil {
 		// Tracked beads exist - create redirect to mayor/rig/.beads
-		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		if err := os.MkdirAll(beadsDir, 0700); err != nil {
 			return err
 		}
 		redirectPath := filepath.Join(beadsDir, "redirect")
@@ -1153,7 +1153,7 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	}
 
 	// No tracked beads - create local database
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
 		return err
 	}
 

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -591,6 +591,7 @@ func TestInitBeads_TrackedBeads_CreatesRedirect(t *testing.T) {
 	if string(content) != expected {
 		t.Errorf("redirect content = %q, want %q", string(content), expected)
 	}
+	assertPrivateBeadsDirectory(t, filepath.Join(rigPath, ".beads"))
 
 	// Verify no local database was created (no config.yaml at rig level)
 	rigConfigPath := filepath.Join(rigPath, ".beads", "config.yaml")
@@ -639,6 +640,22 @@ exit 0
 	beadsDir := filepath.Join(rigPath, ".beads")
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		t.Errorf("expected .beads directory to be created")
+	}
+	assertPrivateBeadsDirectory(t, beadsDir)
+}
+
+func assertPrivateBeadsDirectory(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX directory permissions")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat beads directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Fatalf("directory permissions = %04o, want 0700", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Create Gas Town-managed .beads directories with mode 0700 instead of 0755.
- Cover PRIME provisioning, route writes, Dolt metadata, and both rig initialization paths.
- Add focused regressions for every affected creation path.

Prepared with OpenAI Codex assistance after reading the current CONTRIBUTING.md, AGENTS.md, pull request template, Code of Conduct, security policy, license, and README.

## Related Issue

Fixes #4511

## Changes

- switch the five accepted issue call sites from 0755 to 0700
- verify the resulting POSIX directory mode in focused unit tests
- skip only the POSIX mode assertions on Windows

## Testing

- [x] Focused permission regressions pass in internal/beads, internal/doltserver, and internal/rig
- [x] Full CLI build passes
- [x] go vet ./... passes
- [x] gofmt and git diff --check pass
- [ ] The full go test ./... run is not clean in this macOS environment. It completes with unrelated existing failures involving /var versus /private/var fixture paths, temporary command stubs, unavailable Docker/Dolt, tmux window assumptions, unsigned directly-built binaries, and the repository disk-space guard. The five new regressions pass independently, and internal/rig passes in the full run.

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable; behavior now matches the existing bd recommendation)
- [x] No breaking changes