### PR TITLE
fix(hook): recognize patrol roots as formula work

### DIFF
--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -461,27 +462,16 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		status.HasWork = true
 		status.PinnedBead = hookBead
 
-		// Check for attached molecule
-		attachment := beads.ParseAttachmentFields(hookBead)
-		if attachment != nil {
-			status.AttachedMolecule = attachment.AttachedMolecule
-			status.AttachedFormula = attachment.AttachedFormula
-			status.AttachedAt = attachment.AttachedAt
-			status.AttachedArgs = attachment.AttachedArgs
-			status.AttachedVars = attachment.AttachedVars
+		populateHookedWorkMetadata(&status, hookBead)
 
-			status.IsWisp = strings.Contains(hookBead.Description, "wisp: true") ||
-				strings.Contains(hookBead.Description, "is_wisp: true")
-
-			if attachment.AttachedMolecule != "" {
-				progress, _ := getMoleculeProgressInfo(b, attachment.AttachedMolecule)
-				status.Progress = progress
-				status.NextAction = determineNextAction(status)
-			} else if attachment.AttachedFormula != "" {
-				progress, _ := getMoleculeProgressInfo(b, hookBead.ID)
-				status.Progress = progress
-				status.NextAction = determineNextAction(status)
-			}
+		if status.AttachedMolecule != "" {
+			progress, _ := getMoleculeProgressInfo(b, status.AttachedMolecule)
+			status.Progress = progress
+			status.NextAction = determineNextAction(status)
+		} else if status.AttachedFormula != "" {
+			progress, _ := getMoleculeProgressInfo(b, hookBead.ID)
+			status.Progress = progress
+			status.NextAction = determineNextAction(status)
 		}
 	}
 
@@ -504,6 +494,38 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Human-readable output
 	outputMoleculeStatus(status)
 	return nil
+}
+
+// populateHookedWorkMetadata reads explicit attachment fields first, then
+// recognizes patrol roots by the same title-prefix convention used by patrol
+// discovery. Patrol wisps intentionally have no attached_molecule: the root is
+// the formula work, so treating them as naked beads would suggest a mol attach
+// command that only accepts pinned handoff beads.
+func populateHookedWorkMetadata(status *MoleculeStatusInfo, hookBead *beads.Issue) {
+	if status == nil || hookBead == nil {
+		return
+	}
+
+	if attachment := beads.ParseAttachmentFields(hookBead); attachment != nil {
+		status.AttachedMolecule = attachment.AttachedMolecule
+		status.AttachedFormula = attachment.AttachedFormula
+		status.AttachedAt = attachment.AttachedAt
+		status.AttachedArgs = attachment.AttachedArgs
+		status.AttachedVars = attachment.AttachedVars
+		status.IsWisp = strings.Contains(hookBead.Description, "wisp: true") ||
+			strings.Contains(hookBead.Description, "is_wisp: true")
+	}
+
+	if status.AttachedFormula != "" || status.AttachedMolecule != "" {
+		return
+	}
+	for _, formulaName := range constants.PatrolFormulas() {
+		if strings.HasPrefix(hookBead.Title, formulaName) {
+			status.AttachedFormula = formulaName
+			status.IsWisp = true
+			return
+		}
+	}
 }
 
 // extractRoleFromIdentity extracts the role name from an agent identity string

--- a/internal/cmd/molecule_status_test.go
+++ b/internal/cmd/molecule_status_test.go
@@ -88,3 +88,55 @@ func TestOutputMoleculeStatus_FormulaWispShowsWorkflowContext(t *testing.T) {
 		t.Fatalf("expected workflow next action, got:\n%s", output)
 	}
 }
+
+func TestPopulateHookedWorkMetadata_RecognizesPatrolRoot(t *testing.T) {
+	status := MoleculeStatusInfo{}
+	bead := &beads.Issue{
+		ID:          "gt-wisp-demo",
+		Title:       "mol-witness-patrol (wisp)",
+		Description: "Rendered patrol checklist without attachment metadata",
+	}
+
+	populateHookedWorkMetadata(&status, bead)
+
+	if status.AttachedFormula != "mol-witness-patrol" {
+		t.Fatalf("AttachedFormula = %q, want mol-witness-patrol", status.AttachedFormula)
+	}
+	if status.AttachedMolecule != "" {
+		t.Fatalf("AttachedMolecule = %q, want empty for root-only patrol", status.AttachedMolecule)
+	}
+	if !status.IsWisp {
+		t.Fatal("expected inferred patrol root to be marked as a wisp")
+	}
+}
+
+func TestPopulateHookedWorkMetadata_PreservesExplicitFormula(t *testing.T) {
+	status := MoleculeStatusInfo{}
+	bead := &beads.Issue{
+		Title:       "mol-witness-patrol custom work",
+		Description: "attached_formula: operator-custom-patrol",
+	}
+
+	populateHookedWorkMetadata(&status, bead)
+
+	if status.AttachedFormula != "operator-custom-patrol" {
+		t.Fatalf("AttachedFormula = %q, want explicit metadata to win", status.AttachedFormula)
+	}
+}
+
+func TestPopulateHookedWorkMetadata_DoesNotOverrideExplicitMolecule(t *testing.T) {
+	status := MoleculeStatusInfo{}
+	bead := &beads.Issue{
+		Title:       "mol-witness-patrol custom work",
+		Description: "attached_molecule: gt-wisp-explicit",
+	}
+
+	populateHookedWorkMetadata(&status, bead)
+
+	if status.AttachedMolecule != "gt-wisp-explicit" {
+		t.Fatalf("AttachedMolecule = %q, want explicit attachment", status.AttachedMolecule)
+	}
+	if status.AttachedFormula != "" {
+		t.Fatalf("AttachedFormula = %q, want no inferred formula with explicit molecule", status.AttachedFormula)
+	}
+}


### PR DESCRIPTION
## Summary

Treat root-only patrol wisps as formula work in `gt hook` / `gt mol status` instead of suggesting an incompatible `gt mol attach` command.

## Related Issue

Fixes #4518

## Changes

- recognize deacon, witness, and refinery patrol roots using the established patrol-title prefix convention
- preserve explicit `attached_formula` and `attached_molecule` metadata as authoritative
- surface the inferred patrol formula through the existing formula-work status path
- add regression coverage for patrol inference and explicit-metadata precedence

## Root Cause

Patrol wisps intentionally use `status=hooked` without an `attached_molecule`; the root itself is the formula work. Hook status treated every bead without attachment metadata as naked work, so it recommended `gt mol attach`, which accepts pinned handoff beads rather than hooked patrol roots.

## Testing

- [x] Focused regression passes:
  `CGO_ENABLED=0 go test -ldflags='-X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1' ./internal/cmd -run 'Test(OutputMoleculeStatus|PopulateHookedWorkMetadata)' -count=1`
- [x] `CGO_ENABLED=0 go vet ./internal/cmd`
- [x] `git diff --check`
- [ ] Full `internal/cmd` suite is not green in this environment. The attempted run fails in unrelated macOS `/var` vs `/private/var` path assertions, external-tool call-log fixtures, and unavailable Dolt/tmux integration dependencies; the changed tests pass.

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable; this corrects status classification and adds regression tests)
- [x] No breaking changes

## AI assistance

Implementation, testing, and PR preparation were performed with OpenAI Codex.
