### PR TITLE
fix: resolve sling PRs in target rig repo

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -245,15 +245,6 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	if (slingResumeBranch != "" || slingResumePR != 0) && slingBaseBranch != "" {
 		return fmt.Errorf("--base-branch cannot be combined with --branch or --pr (resume implies starting on the existing branch)")
 	}
-	if slingResumePR != 0 {
-		resolved, err := resolvePRBranch(slingResumePR)
-		if err != nil {
-			return fmt.Errorf("resolving --pr %d: %w", slingResumePR, err)
-		}
-		slingResumeBranch = resolved
-		fmt.Printf("%s --pr %d resolved to branch %s\n", style.Dim.Render("→"), slingResumePR, resolved)
-	}
-
 	// Disable Dolt auto-commit for all bd commands run during sling (gt-u6n6a).
 	// Under concurrent load (batch slinging), auto-commits from individual bd writes
 	// cause manifest contention and 'database is read only' errors. The Dolt server
@@ -301,6 +292,15 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Note: Internal agent IDs like "mayor/" are outputs, not user inputs.
 	for i := range args {
 		args[i] = strings.TrimRight(args[i], "/")
+	}
+
+	if slingResumePR != 0 {
+		resolved, err := resolveSlingPRBranch(slingResumePR, townRoot, args)
+		if err != nil {
+			return fmt.Errorf("resolving --pr %d: %w", slingResumePR, err)
+		}
+		slingResumeBranch = resolved
+		fmt.Printf("%s --pr %d resolved to branch %s\n", style.Dim.Render("→"), slingResumePR, resolved)
 	}
 
 	// --crew flag: expand target from "<rig>" to "<rig>/crew/<name>"
@@ -1342,11 +1342,25 @@ func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
 	return nil, fmt.Errorf("timed out acquiring assignee sling lock for %s after %ds (another sling may be stuck)", targetAgent, maxAttempts*retryInterval/1000)
 }
 
+// resolveSlingPRBranch resolves a PR from the explicitly targeted rig repository.
+// Targets without a registered rig retain the existing caller-cwd behavior.
+func resolveSlingPRBranch(prNumber int, townRoot string, args []string) (string, error) {
+	repoDir := ""
+	if len(args) > 1 {
+		targetRig := strings.SplitN(args[len(args)-1], "/", 2)[0]
+		if rigName, ok := IsRigName(targetRig); ok {
+			repoDir = filepath.Join(townRoot, rigName, "mayor", "rig")
+		}
+	}
+	return resolvePRBranch(prNumber, repoDir)
+}
+
 // resolvePRBranch resolves a GitHub PR number to its head branch name via `gh pr view`.
 // Used by `gt sling --pr <number>` to convert the PR number into a branch name that
 // the polecat worktree can check out.
-func resolvePRBranch(prNumber int) (string, error) {
+func resolvePRBranch(prNumber int, repoDir string) (string, error) {
 	cmd := exec.Command("gh", "pr", "view", fmt.Sprintf("%d", prNumber), "--json", "headRefName", "-q", ".headRefName")
+	cmd.Dir = repoDir
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -4770,6 +4770,91 @@ func TestRunSlingResumeFlagValidation(t *testing.T) {
 	}
 }
 
+func TestResolveSlingPRBranchUsesTargetRigRepository(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"version":1}`), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+
+	rigRepo := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(rigRepo, 0755); err != nil {
+		t.Fatalf("mkdir target rig repo: %v", err)
+	}
+	rigs := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{
+		"gastown": {
+			GitURL:  "git@github.com:test/gastown.git",
+			AddedAt: time.Now().Truncate(time.Second),
+		},
+	}}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), rigs); err != nil {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	ghCWDPath := filepath.Join(townRoot, "gh-cwd.txt")
+	ghArgsPath := filepath.Join(townRoot, "gh-args.txt")
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\ncd > %GT_TEST_GH_CWD%\r\necho %* > %GT_TEST_GH_ARGS%\r\necho feature/pr-4377\r\n"
+		if err := os.WriteFile(filepath.Join(binDir, "gh.cmd"), []byte(script), 0644); err != nil {
+			t.Fatalf("write gh stub: %v", err)
+		}
+	} else {
+		script := "#!/bin/sh\npwd > \"$GT_TEST_GH_CWD\"\nprintf '%s\\n' \"$@\" > \"$GT_TEST_GH_ARGS\"\nprintf 'feature/pr-4377\\n'\n"
+		if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(script), 0755); err != nil {
+			t.Fatalf("write gh stub: %v", err)
+		}
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_TEST_GH_CWD", ghCWDPath)
+	t.Setenv("GT_TEST_GH_ARGS", ghArgsPath)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir town root: %v", err)
+	}
+
+	branch, err := resolveSlingPRBranch(4377, townRoot, []string{"gt-pr4377-refresh", "gastown"})
+	if err != nil {
+		t.Fatalf("resolveSlingPRBranch: %v", err)
+	}
+	if branch != "feature/pr-4377" {
+		t.Fatalf("branch = %q, want feature/pr-4377", branch)
+	}
+
+	ghCWD, err := os.ReadFile(ghCWDPath)
+	if err != nil {
+		t.Fatalf("read gh cwd: %v", err)
+	}
+	gotCWD := filepath.Clean(strings.TrimSpace(string(ghCWD)))
+	if runtime.GOOS == "windows" {
+		if !strings.EqualFold(gotCWD, filepath.Clean(rigRepo)) {
+			t.Fatalf("gh cwd = %q, want target rig repo %q", gotCWD, rigRepo)
+		}
+	} else if gotCWD != filepath.Clean(rigRepo) {
+		t.Fatalf("gh cwd = %q, want target rig repo %q", gotCWD, rigRepo)
+	}
+
+	ghArgs, err := os.ReadFile(ghArgsPath)
+	if err != nil {
+		t.Fatalf("read gh args: %v", err)
+	}
+	for _, want := range []string{"pr", "view", "4377", "headRefName"} {
+		if !strings.Contains(string(ghArgs), want) {
+			t.Fatalf("gh args %q missing %q", ghArgs, want)
+		}
+	}
+}
+
 // TestSlingStandaloneFormulaInDeferredMode is a regression test for gh#3917.
 //
 // When scheduler.max_polecats > 0 (deferred dispatch mode), `gt sling <formula> <rig>`


### PR DESCRIPTION
## Summary

Resolve `gt sling --pr` from the explicitly targeted rig repository instead of the caller's current working directory. This lets town-root invocations use the target rig's configured GitHub remotes.

## Related Issue

Fixes #4392

## Changes

- defer PR branch resolution until the town root and normalized target are available
- run `gh pr view` from the registered target rig's `mayor/rig` repository
- preserve caller-directory behavior when no registered target rig is explicit
- add a hermetic fake-`gh` regression for town-root invocation and branch resolution

## Testing

- [x] Focused resume-flag and target-rig PR resolution tests pass
- [x] Scoped vet passes (`CGO_ENABLED=0 go vet ./internal/cmd`)
- [x] CLI build passes (`CGO_ENABLED=0 go build ./cmd/gt`)
- [x] Diff and formatting checks pass
- [ ] Full command-package test suite passes (attempted; existing macOS `/var` path-alias, external call-log fixture, and direct-build guard failures remain unrelated)
- [ ] Manual testing performed (the regression uses a hermetic fake `gh`; no live rig claim is made)

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable; behavior is covered by a regression test)
- [x] No breaking changes

Implementation and regression test prepared with OpenAI Codex assistance.
