### PR TITLE
fix: context-check-interval preempts backoff, freezes idle counter

### DIFF
--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -389,11 +389,14 @@ func waitForEventFiles(ctx context.Context, eventDir string, contextCheckAfter t
 		return &AwaitEventResult{Reason: "timeout"}, nil
 	}
 
-	// Set up context-yield timer when requested.
-	// A nil channel is never selected, so when contextCheckAfter is zero
-	// the timer case never fires and existing behavior is preserved.
+	// Set up context-yield timer when requested, but only if the full timeout
+	// is significantly longer than the context-check interval. This prevents
+	// context-check from preempting exponential backoff at moderate idle counts.
+	// Context-check is intended for very long waits (e.g., idle 10+), not for
+	// routine backoff tiers (idle 5-7 = 8m-2m timeouts). Only yield if the wait
+	// is at least 2x the context-check interval.
 	var contextYieldC <-chan time.Time
-	if contextCheckAfter > 0 {
+	if contextCheckAfter > 0 && remaining > 2*contextCheckAfter {
 		t := time.NewTimer(contextCheckAfter)
 		defer t.Stop()
 		contextYieldC = t.C

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -523,6 +523,59 @@ func TestWaitForEventFilesNoContextYieldWhenZero(t *testing.T) {
 	}
 }
 
+func TestWaitForEventFilesContextYieldOnlyForLongWaits(t *testing.T) {
+	// Regression test for ci-73d: context-check should only fire when the
+	// timeout is significantly longer than the context-check interval (2x).
+	// This prevents context-check from preempting exponential backoff at
+	// moderate idle counts, freezing the idle counter.
+	dir := t.TempDir()
+
+	tests := []struct {
+		name           string
+		timeout        time.Duration
+		contextCheck   time.Duration
+		expectedReason string
+		description    string
+	}{
+		{
+			name:           "short wait (less than 2x context-check)",
+			timeout:        8 * time.Second,
+			contextCheck:   5 * time.Second,
+			expectedReason: "timeout",
+			description:    "8s timeout with 5s context-check: 8 < 10, so no yield",
+		},
+		{
+			name:           "very short wait (less than context-check)",
+			timeout:        3 * time.Second,
+			contextCheck:   5 * time.Second,
+			expectedReason: "timeout",
+			description:    "3s timeout with 5s context-check: 3 < 10, so no yield",
+		},
+		{
+			name:           "long wait (more than 2x context-check)",
+			timeout:        12 * time.Second,
+			contextCheck:   5 * time.Second,
+			expectedReason: "context-yield",
+			description:    "12s timeout with 5s context-check: 12 > 10, so yield at 5s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
+			defer cancel()
+
+			result, err := waitForEventFiles(ctx, dir, tt.contextCheck)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Reason != tt.expectedReason {
+				t.Errorf("expected reason %q (%s), got %q", tt.expectedReason, tt.description, result.Reason)
+			}
+		})
+	}
+}
+
 func TestEffortLevelContextYield(t *testing.T) {
 	// context-yield must produce EffortLevel "full" so context-check is
 	// not abbreviated.


### PR DESCRIPTION
## Summary
- \`await-event\`'s \`--context-check-interval\` yielded at a fixed wall-clock interval regardless of backoff timeout, so once backoff exceeded the interval (e.g. 8m wait vs 5m interval), the context check fired first and the idle counter never incremented — freezing patrol backoff progression.
- Fix: only yield for context check when the backoff timeout meaningfully exceeds the interval; otherwise let backoff complete naturally so idle increments and tiers advance.

Fixes ci-73d.