### PR TITLE
fix(rig): fail rig add when bd refuses the schema gt just created

### DIFF
--- a/internal/rig/legacy_beads_refusal_test.go
+++ b/internal/rig/legacy_beads_refusal_test.go
@@ -1,0 +1,80 @@
+package rig
+
+import (
+	"strings"
+	"testing"
+)
+
+// bdLegacyRefusalOutput is the verbatim message bd prints when its
+// legacy-upgrade guard classifies the workspace as belonging to an older
+// storage era (beads cmd/bd/legacy_upgrade_guard.go). Rig init must treat this
+// as fatal, not as a skippable warning.
+const bdLegacyRefusalOutput = "Error: legacy Dolt server workspace detected; " +
+	"explicit migration is required before this bd version can open or modify " +
+	"the workspace. Preserve .beads unchanged and follow " +
+	"docs/getting-started/upgrading.md#cross-era-upgrades"
+
+func TestIsLegacyBeadsRefusal(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "legacy dolt server workspace",
+			output: bdLegacyRefusalOutput,
+			want:   true,
+		},
+		{
+			name:   "historical sqlite workspace",
+			output: "Error: historical SQLite workspace detected; explicit migration is required before this bd version can open or modify the workspace.",
+			want:   true,
+		},
+		{
+			name:   "versioned legacy workspace",
+			output: "Error: legacy Dolt server workspace from bd 0.58.0 detected; explicit migration is required before this bd version can open or modify the workspace.",
+			want:   true,
+		},
+		{
+			name:   "bd not installed",
+			output: `exec: "bd": executable file not found in $PATH`,
+			want:   false,
+		},
+		{
+			name:   "already initialized",
+			output: "Error: beads workspace already initialized (use --force to reinitialize)",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLegacyBeadsRefusal(tt.output); got != tt.want {
+				t.Errorf("isLegacyBeadsRefusal(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLegacyBeadsRefusalErrorIsActionable(t *testing.T) {
+	err := legacyBeadsRefusalError("customer_code_miner", bdLegacyRefusalOutput)
+	if err == nil {
+		t.Fatal("legacyBeadsRefusalError returned nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"customer_code_miner",
+		"explicit migration is required",
+		"go install github.com/steveyegge/gastown/cmd/gt@latest",
+		"gt rig remove customer_code_miner --force",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -640,6 +640,10 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			cmd.Dir = mayorRigPath
 			cmd.Env = sourceBdEnv
 			if output, err := cmd.CombinedOutput(); err != nil {
+				// A cross-era refusal is fatal: see isLegacyBeadsRefusal.
+				if isLegacyBeadsRefusal(string(output)) {
+					return nil, legacyBeadsRefusalError(opts.Name, string(output))
+				}
 				fmt.Printf("  Warning: Could not init bd database: %v (%s)\n", err, strings.TrimSpace(string(output)))
 			}
 			// Drop orphan databases created by bd init (gh#3562, gt-sv1h).
@@ -1073,6 +1077,45 @@ func warnDeprecatedRigConfigKeys(data []byte, path string) {
 	}
 }
 
+// legacyBeadsRefusalMarker is the stable fragment of bd's cross-era upgrade
+// refusal ("... detected; explicit migration is required before this bd version
+// can open or modify the workspace."). bd emits it from its legacy-upgrade guard
+// for every command, including `bd init`.
+const legacyBeadsRefusalMarker = "explicit migration is required"
+
+// isLegacyBeadsRefusal reports whether bd refused to open the workspace because
+// it classifies the on-disk schema as belonging to an older storage era.
+//
+// This is not a cosmetic distinction. Rig provisioning creates the rig's Dolt
+// database and its beads schema through the beads library compiled into gt
+// (doltserver.InitRig -> EnsureRigIssuePrefix) *before* it shells out to the
+// installed `bd` binary. When that binary is from a newer storage era than gt's
+// compiled-in library, it refuses the schema gt just created, `bd init` fails,
+// and the rig is left with a database no bd command can ever open or migrate:
+// `bd list`, `bd ready`, `bd migrate` and `gt sling` into that rig all fail with
+// the refusal, and `gt reaper scan` fails separately because the rig's
+// wisp_dependencies table never gets the split depends_on_* columns.
+//
+// Nothing repairs this after the fact — `gt dolt fix-metadata` only rewrites
+// metadata, it cannot backfill missing tables — so the failure must abort
+// `gt rig add` loudly instead of being reported as a successful rig.
+func isLegacyBeadsRefusal(output string) bool {
+	return strings.Contains(output, legacyBeadsRefusalMarker)
+}
+
+// legacyBeadsRefusalError explains a bd/gt storage-era mismatch in terms the
+// operator can act on.
+func legacyBeadsRefusalError(rigName, output string) error {
+	return fmt.Errorf("bd refused to initialize beads for rig %q: %s\n\n"+
+		"The installed bd binary is from a newer beads storage era than the beads\n"+
+		"library compiled into this gt binary, so bd cannot open the schema gt just\n"+
+		"created. Continuing would leave the rig with a database no bd command can\n"+
+		"open or migrate. Upgrade gt (and bd) so both come from the same era:\n"+
+		"  go install github.com/steveyegge/gastown/cmd/gt@latest\n"+
+		"then remove the partially-created rig with `gt rig remove %s --force` and retry",
+		rigName, strings.TrimSpace(output), rigName)
+}
+
 // dropRigOrphanDBs drops orphan Dolt databases that bd init creates as a side
 // effect of `bd init --prefix <prefix>`. The orphan name depends on bd version:
 //
@@ -1180,10 +1223,17 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	cmd := exec.Command("bd", initArgs...)
 	cmd.Dir = rigPath
 	cmd.Env = filteredEnv
-	_, bdInitErr := cmd.CombinedOutput()
+	bdInitOut, bdInitErr := cmd.CombinedOutput()
 	if bdInitErr != nil {
 		// bd might not be installed or failed — the shared helper below will
 		// create config.yaml with the required defaults as a fallback.
+		//
+		// A cross-era refusal is the one failure that must not fall through:
+		// the fallback config.yaml would make the rig look initialized while
+		// every bd command against it fails forever (see isLegacyBeadsRefusal).
+		if isLegacyBeadsRefusal(string(bdInitOut)) {
+			return legacyBeadsRefusalError(rigName, string(bdInitOut))
+		}
 	} else {
 		// bd init succeeded - configure the Dolt database
 


### PR DESCRIPTION
## Summary

`gt rig add` provisions a new rig's Dolt database and beads schema with the **beads library compiled into the gt binary** — `doltserver.InitRig` → `EnsureRigIssuePrefix` → `openRigStoreFromConfig` → `beadssdk.OpenFromConfig` (`internal/doltserver/doltserver.go:2666-2729`) — and only *afterwards* shells out to the installed `bd` binary (`internal/rig/manager.go:664-677`).

When the installed `bd` is from a newer beads storage era than gt's compiled-in library, bd's legacy-upgrade guard (`beads cmd/bd/legacy_upgrade_guard.go:49-58`) refuses the schema gt just created and `bd init` fails. Both call sites swallowed that failure — `AddRig` (`manager.go:642`) printed `Warning: Could not init bd database`, `InitBeads` (`manager.go:1183`) discarded the output and fell through to its `config.yaml` fallback — so `gt rig add` printed `✓ Rig created` for a rig that is permanently unusable:

- `bd list` / `bd ready` / `bd migrate` in that rig all fail with `legacy Dolt server workspace detected; explicit migration is required before this bd version can open or modify the workspace`, which also kills `gt sling` into the rig.
- `gt reaper scan` fails separately, because the rig's `wisp_dependencies` never receives the split `depends_on_issue_id` / `depends_on_wisp_id` / `depends_on_external` columns.
- Nothing repairs it afterwards — `gt dolt fix-metadata` only rewrites metadata and cannot backfill missing tables — so the wedge survives a clean `gt rig remove` + re-add with the same binaries.

No breaking changes: provisioning order and SQL are untouched; only a known-fatal failure stops being ignored.

## Related Issue

Root cause of the town-side bead `hq-1cs` (repeated HIGH-severity escalations from a rig wedged this way). No matching GitHub issue found; related background in #1302.

## Field evidence

A live town running `gt 1.2.1` built from `319d33a9` (pins `github.com/steveyegge/beads v1.0.0`) against `bd 1.1.0`: the affected rig's database came up with a pre-migration-framework schema — no `schema_migrations`, `local_metadata`, `leases`, `ignored_schema_migrations`, `wisp_child_counters`, `bd_events_journal`, `bd_events_seq`, `provenance_events`, and a single `depends_on_id` column on `wisp_dependencies` — and no `.beads/.local_version` witness, so bd's guard classified it as legacy forever. Sibling rigs added by earlier binaries were fine.

Reproduced in an isolated town on a throwaway Dolt server (port 13307, own data dir):

| gt build | linked beads | rig outcome |
|---|---|---|
| `319d33a9` (deployed) | v1.0.0 | 24 tables, `wisp_dependencies.depends_on_id`, no `.local_version`, `bd list` → legacy refusal |
| `main` @ `649b832` | v1.0.5 | 32 tables, split `depends_on_*`, `.local_version` = 1.1.0, `bd list` OK |

The v1.0.0 → v1.0.5 bump already fixed the specific skew that bit this town, but the fragility is structural: whenever `bd` moves an era ahead of gt's pinned library, `gt rig add` silently produces a dead rig again.

## Changes

- `internal/rig/manager.go`: add `isLegacyBeadsRefusal` / `legacyBeadsRefusalError`, and abort rig init at both `bd init` call sites when bd emits its cross-era refusal, with an actionable message (upgrade gt/bd, then remove and re-add the rig).
- Every other `bd init` failure (bd not installed, already initialized, ...) keeps its existing tolerant behavior, including the `config.yaml` fallback.
- `internal/rig/legacy_beads_refusal_test.go`: table-driven coverage for the detector (all three guard reason variants, plus non-refusal failures) and for the error text.

## Testing

- [x] Unit tests pass (`go test ./internal/rig/`)
- [x] Manual testing performed

Isolated throwaway town (own Dolt server on port 13307, own data dir), gt built from this branch:

- **Happy path** (real `bd 1.1.0`): `gt rig add` succeeds; rig DB has the full current-era table set including `schema_migrations`, `leases`, `provenance_events`, `bd_events_journal`, split `wisp_dependencies.depends_on_*` columns, and `.beads/.local_version`; `bd list` works.
- **Failure path** (PATH shim whose `bd init` emits the guard's refusal verbatim and exits 1, all other subcommands passed through to the real bd): `gt rig add` now aborts with the new error instead of printing `✓ Rig created`.

## Checklist

- [x] Code follows project style
- [ ] Documentation updated (if applicable) — no docs change; error message is self-explanatory
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)