### PR TITLE
fix: persist standalone formula dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,8 +3,12 @@ name: Windows CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,14 @@ and full-suite parallelism — they all pass when isolated:
   `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
 - `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
   shared agent registry). It passes reliably via `go test ./internal/config/`.
+
+### mattpocock/skills
+
+The update script also installs [`mattpocock/skills`](https://github.com/mattpocock/skills) via the
+vercel `skills` CLI (`npx skills@latest add mattpocock/skills --agent cursor --skill '*' -g -y --copy`),
+which lands them under `~/.agents/skills/`. Because the Cursor Cloud agent discovers global skills from
+`~/.cursor/skills-cursor/` (not `~/.cursor/skills`, which is where the `skills` CLI's cursor preset
+points), the update script then mirrors each skill folder into `~/.cursor/skills-cursor/` so they are
+discoverable next session. This is deliberately global (user-level), not project-level, to avoid leaving
+untracked files in the repo working tree. The skills-refresh step is best-effort (`|| true`); a prior
+copy persists in the VM snapshot if the network fetch fails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,3 +183,44 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
+
+---
+
+## Cursor Cloud specific instructions
+
+Gas Town is a Go CLI (`gt`). The environment build already has: Go (base `go1.22.2`, but
+`go.mod` pins `go 1.26.2`, auto-fetched via `GOTOOLCHAIN=auto`), `libicu-dev` (required for the
+`go-icu-regex` CGo dependency), `golangci-lint` v2.11.4, `bd` (beads), and `dolt` v2.0.7. The
+update script runs `go mod download` to refresh module deps after a pull.
+
+### Build / lint / test / run
+
+- Build: `make build` → produces `gt`, `gt-proxy-server`, `gt-proxy-client` at repo root. First
+  build compiles a large dep tree (~1.5 min). `go run ./cmd/gt …` also works.
+- Lint: `golangci-lint run --timeout=5m` (installed at `~/go/bin`).
+  - GOTCHA: `golangci-lint` refuses to run if it was built with an older Go than `go.mod`'s
+    `1.26.2` ("the Go language version go1.25 ... is lower than the targeted Go version 1.26.2").
+    `go install ...@v2.11.4` picks the tool's own toolchain (1.25). It must be built with
+    `GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`.
+    The prebuilt binary in the snapshot is already correct.
+- Test (unit): `go test -short ./...`. Full suite is slow (~15-20 min) because many packages spawn
+  real `git`/`tmux` subprocesses.
+- Integration tests are build-tagged and need Dolt: `go test -tags=integration ./internal/cmd/...`.
+  Some use `internal/testutil` helpers that start Dolt Docker containers and skip gracefully when
+  prerequisites are missing.
+- Run the app: `gt install <path>` creates a town HQ and auto-starts a Dolt SQL server; then
+  `gt status`, `bd create/list/update/close` (beads work ledger), `gt rig add`, etc. `gt` must be on
+  `PATH` for hooks/crew workflows (`cp gt ~/go/bin/` or `make install` → `~/.local/bin`).
+
+### Known environment-induced test failures (NOT code bugs)
+
+Under a full `go test ./...` in the cloud VM, these fail purely due to the VM's global git config
+and full-suite parallelism — they all pass when isolated:
+
+- `internal/git` (`TestConfigurePushURL`, `TestGetPushURL_NoPushURL`, `TestClearPushURL`) and
+  `internal/doctor` (`TestBareRepoExistsCheck_*PushURL*`): the cloud VM injects Cursor-managed
+  `url.https://x-access-token:***@github.com/.insteadOf` rewrites into the global git config, so
+  round-tripped remote URLs don't match. Re-run with a clean config to confirm green, e.g.
+  `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
+- `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
+  shared agent registry). It passes reliably via `go test ./internal/config/`.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,47 @@
+# Coding standards
+
+## Tests
+
+- Strongly prefer integration and end-to-end tests over unit tests when behaviour crosses CLI, process, filesystem, tmux, Git, or Dolt boundaries.
+- Strongly prefer exercising real system behaviour over treating a green test suite as proof that the product works.
+- Mock only third-party services or process boundaries that we cannot control. Do not mock packages or business rules that we own.
+- For command and workflow changes, the default proof is to run the real command against a temporary town or rig and assert exit status, output, and persisted state.
+- Assert results produced by production code. Do not assert values assembled only by test helpers, copied production logic, or mocks configured by the same test.
+- Use `testutil.RequireDoltContainer`, `testutil.StartIsolatedDoltContainer`, or `testutil.RequireTownEnv` when a test needs those resources. Self-contained tests that create their own temporary town do not need an integration guard.
+- Keep concurrency tests deterministic. Synchronize on observable state or explicit test seams instead of sleeps when possible, and run race-sensitive packages with `go test -race ./path/to/package`.
+- Use `make test` as the repository-wide unit-test gate; it includes shell checks before `go test ./...`. Run tagged integration tests for affected command paths and use `make test-e2e-container` for installation or full-workspace behaviour.
+
+## Comments and docs
+
+- Code comments use ASD-STE100 Simplified Technical English: use short direct sentences, one instruction per sentence, and consistent terms.
+- Use established Gas Town domain terms consistently: town, rig, convoy, bead, molecule, wisp, polecat, crew, dog, hook, sling, and refinery. Use "merge request" for Gas Town's refinery queue and "pull request" for GitHub contributions. Do not invent synonyms for existing terms.
+- Do not write comments that only repeat what the code already makes clear. Explain invariants, boundary conditions, compatibility constraints, and non-obvious reasons.
+- Do not put brittle references in comments or docs, such as line numbers, temporary paths, current versions, or "as of today" claims, when those details can change.
+- Update user-facing docs when commands, configuration, output, or operational behaviour changes.
+
+## Common footguns
+
+- Tautological tests that assert a mock was called exactly as the test configured it.
+- Mocks of packages, modules, or services we own.
+- Treating a green suite as proof that a real agent, town, or rig can complete the workflow.
+- Encoding agent judgment in Go: behavioural heuristics and arbitrary decision thresholds belong in agents and formulas. Deterministic protocol rules and safety boundaries can remain in Go.
+- Confusing ephemeral wisps with durable Dolt-backed issues, or assuming every command reads the same Beads database.
+- Swallowing process, tmux, Git, or persistence errors and then reporting success.
+- Using sleeps to hide lifecycle races or relying on goroutine completion order for stable results.
+- Narrating comments, stale README claims, and hard-coded implementation details.
+- Evading complexity or quality gates with denser syntax, hidden branching, or indirection that does not reduce real complexity.
+
+## Go
+
+- Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
+- Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
+- Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.
+- Use existing package boundaries and production seams. Keep Cobra command wiring in `internal/cmd` thin, and put reusable domain behaviour in the relevant `internal` package.
+- Pass `context.Context` through blocking work. Give subprocesses and external operations explicit cancellation or timeouts.
+- Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
+- Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
+- Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
+- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
+- Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -42,6 +42,6 @@
 - Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
 - Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
 - Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
-- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- Run `make build` and `make test` before merging changes that can affect Go behaviour. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour. Markdown-only changes do not require Go builds or tests.
 - For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
 - Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -34,6 +34,8 @@
 ## Go
 
 - Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Production Go code changes should report no violations on the `messgo` rulesets `design`, `codesize`, and `unusedcode`.
+- Production Go code changes should report a covered-MSI of 80% or above from `mutago`.
 - Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
 - Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
 - Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2249,6 +2249,73 @@ func isFormulaCompletionBead(id string, issue *beads.Issue) bool {
 	return strings.Contains(id, "-wfs-") || issue != nil && beads.HasLabel(issue, formulaDispatchLabel)
 }
 
+func shouldCloseHookedWorkOnDone(exitType, hookedBeadID, beadsPath string, bd *beads.Beads) bool {
+	if hookedBeadID == "" {
+		return false
+	}
+	if exitType != ExitDeferred {
+		return true
+	}
+	if isFormulaCompletionBead(hookedBeadID, nil) {
+		return true
+	}
+	hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
+	if hookBd == nil {
+		hookBd = bd
+	}
+	hookedBead, err := hookBd.Show(hookedBeadID)
+	if err != nil {
+		style.PrintWarning("could not classify deferred work %s before completion: %v", hookedBeadID, err)
+		return false
+	}
+	return isFormulaCompletionBead(hookedBeadID, hookedBead)
+}
+
+func closeHookedWorkOnDone(hookBd *beads.Beads, hookedBeadID, townRoot, rig string) error {
+	hookedBead, err := hookBd.Show(hookedBeadID)
+	if err != nil || beads.IssueStatus(hookedBead.Status).IsTerminal() {
+		return nil
+	}
+
+	if beads.HasLabel(hookedBead, "gt:rig") {
+		fmt.Fprintf(os.Stderr, "Note: hooked bead %s is a rig identity bead (gt:rig) — skipping close\n", hookedBeadID)
+		return nil
+	}
+
+	if skipReason, fatal := doneSourceCloseSkipReason(hookBd, hookedBeadID, hookedBead); skipReason != "" {
+		style.PrintWarning("%s", skipReason)
+		fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
+		notifyDoneCloseSkipped(townRoot, rig, detectSender(), hookedBeadID, skipReason)
+		if fatal {
+			return fmt.Errorf("cannot complete hooked work: %s", skipReason)
+		}
+		return nil
+	}
+
+	attachment := beads.ParseAttachmentFields(hookedBead)
+	if attachment != nil && attachment.AttachedMolecule != "" {
+		if n := closeDescendants(hookBd, attachment.AttachedMolecule); n > 0 {
+			fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
+		}
+		if closeErr := hookBd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
+			if !errors.Is(closeErr, beads.ErrNotFound) {
+				fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
+				return nil
+			}
+		}
+	}
+
+	if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
+		style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
+		fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
+		return nil
+	}
+	if err := hookBd.Close(hookedBeadID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
+	}
+	return nil
+}
+
 func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
@@ -2323,91 +2390,16 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Workflow step beads (*-wfs-*) and standalone formula dispatch beads are
 	// formula-engine work. For these, DEFERRED means "formula complete, no code
 	// commits" rather than "work paused for resumption". Close them on DEFERRED.
-	isFormulaCompletion := isFormulaCompletionBead(hookedBeadID, nil)
-	if exitType == ExitDeferred && !isFormulaCompletion && hookedBeadID != "" {
-		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
-		hookedBead, err := hookBd.Show(hookedBeadID)
-		if err != nil {
-			return fmt.Errorf("classifying deferred work %s before completion: %w", hookedBeadID, err)
-		}
-		isFormulaCompletion = isFormulaCompletionBead(hookedBeadID, hookedBead)
-	}
-
-	if hookedBeadID != "" && (exitType != ExitDeferred || isFormulaCompletion) {
-		// BUG FIX (gt-pftz): Close hooked bead unless already terminal (closed/tombstone).
-		// Previously checked hookedBead.Status == StatusHooked, but polecats update
-		// their work bead to in_progress during work. The exact-match check caused
-		// gt done to skip closing the bead, leaving it as unassigned open work after
-		// the hook was cleared — triggering infinite dispatch loops.
-		//
-		// DEFERRED exits preserve ordinary work for resumption. Formula workflow
-		// steps and durable standalone-formula dispatch beads are closed — see above.
+	if shouldCloseHookedWorkOnDone(exitType, hookedBeadID, beadsPath, bd) {
 		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
 		if hookBd == nil {
 			hookBd = bd
 		}
-		if hookedBead, err := hookBd.Show(hookedBeadID); err == nil && !beads.IssueStatus(hookedBead.Status).IsTerminal() {
-			// Guard: never close a rig identity bead. Polecats dispatched with the
-			// rig bead as their hook (via mol-polecat-work) must not close permanent
-			// infrastructure. Skip close and fall through to idle state update.
-			if beads.HasLabel(hookedBead, "gt:rig") {
-				fmt.Fprintf(os.Stderr, "Note: hooked bead %s is a rig identity bead (gt:rig) — skipping close\n", hookedBeadID)
-				goto doneStateUpdate
-			}
-
-			if skipReason, fatal := doneSourceCloseSkipReason(hookBd, hookedBeadID, hookedBead); skipReason != "" {
-				style.PrintWarning("%s", skipReason)
-				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
-				if fatal {
-					return fmt.Errorf("cannot complete hooked work: %s", skipReason)
-				}
-				goto doneStateUpdate
-			}
-
-			// BUG FIX: Close attached molecule (wisp) BEFORE closing hooked bead.
-			// When using formula-on-bead (gt sling formula --on bead), the base bead
-			// has attached_molecule pointing to the wisp. Without this fix, gt done
-			// only closed the hooked bead, leaving the wisp orphaned.
-			// Order matters: wisp closes -> unblocks base bead -> base bead closes.
-			attachment := beads.ParseAttachmentFields(hookedBead)
-			if attachment != nil && attachment.AttachedMolecule != "" {
-				// Close molecule step descendants before closing the wisp root.
-				// bd close doesn't cascade — without this, open/in_progress steps
-				// from the molecule stay stuck forever after gt done completes.
-				// Order: step children -> wisp root -> base bead.
-				if n := closeDescendants(hookBd, attachment.AttachedMolecule); n > 0 {
-					fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
-				}
-
-				// Close the wisp root with --force and audit reason.
-				// ForceCloseWithReason handles any status (hooked, open, in_progress)
-				// and records the reason + session for attribution.
-				// Same pattern as gt mol burn/squash (#1879).
-				if closeErr := hookBd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
-					if !errors.Is(closeErr, beads.ErrNotFound) {
-						fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
-						// Don't try to close hookedBeadID - it may still be blocked.
-						// But DO clear hooks and update agent state (goto doneStateUpdate)
-						// so the polecat isn't stuck in 'working' state (za-o9e).
-						goto doneStateUpdate
-					}
-					// Not found = already burned/deleted by another path, continue
-				}
-			}
-
-			// Acceptance criteria gate: skip close if criteria are unchecked.
-			if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
-				style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
-				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-			} else if err := hookBd.Close(hookedBeadID); err != nil {
-				// Non-fatal: warn but continue
-				fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
-			}
+		if err := closeHookedWorkOnDone(hookBd, hookedBeadID, townRoot, ctx.Rig); err != nil {
+			return err
 		}
 	}
 
-doneStateUpdate:
 	// Clear hook_bead on the agent bead (gt-qbh). The hq-l6mm5 refactor made
 	// SetHookBead/ClearHookBead no-ops, but the witness still reads the
 	// hook_bead field from the agent bead snapshot. If the hooked bead is a

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2245,6 +2245,10 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // BUG FIX (hq-3xaxy): This function must be resilient to working directory deletion.
 // If the polecat's worktree is deleted before gt done finishes, we use env vars as fallback.
 // All errors are warnings, not failures - gt done must complete even if bead ops fail.
+func isFormulaCompletionBead(id string, issue *beads.Issue) bool {
+	return strings.Contains(id, "-wfs-") || issue != nil && beads.HasLabel(issue, formulaDispatchLabel)
+}
+
 func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
@@ -2316,21 +2320,28 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 		}
 	}
 
-	// Workflow step beads (*-wfs-*) are ephemeral formula steps managed by the workflow
-	// engine. For these, DEFERRED means "step complete, no code commits" not "work
-	// paused for resumption". Close them on DEFERRED so the convoy can advance.
-	isWorkflowStep := strings.Contains(hookedBeadID, "-wfs-")
+	// Workflow step beads (*-wfs-*) and standalone formula dispatch beads are
+	// formula-engine work. For these, DEFERRED means "formula complete, no code
+	// commits" rather than "work paused for resumption". Close them on DEFERRED.
+	isFormulaCompletion := isFormulaCompletionBead(hookedBeadID, nil)
+	if exitType == ExitDeferred && !isFormulaCompletion && hookedBeadID != "" {
+		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
+		hookedBead, err := hookBd.Show(hookedBeadID)
+		if err != nil {
+			return fmt.Errorf("classifying deferred work %s before completion: %w", hookedBeadID, err)
+		}
+		isFormulaCompletion = isFormulaCompletionBead(hookedBeadID, hookedBead)
+	}
 
-	if hookedBeadID != "" && (exitType != ExitDeferred || isWorkflowStep) {
+	if hookedBeadID != "" && (exitType != ExitDeferred || isFormulaCompletion) {
 		// BUG FIX (gt-pftz): Close hooked bead unless already terminal (closed/tombstone).
 		// Previously checked hookedBead.Status == StatusHooked, but polecats update
 		// their work bead to in_progress during work. The exact-match check caused
 		// gt done to skip closing the bead, leaving it as unassigned open work after
 		// the hook was cleared — triggering infinite dispatch loops.
 		//
-		// DEFERRED exits preserve the bead: work is paused, not done. The bead
-		// stays open/in_progress so it can be resumed on the next session.
-		// Exception: workflow step beads (*-wfs-*) are always closed — see above.
+		// DEFERRED exits preserve ordinary work for resumption. Formula workflow
+		// steps and durable standalone-formula dispatch beads are closed — see above.
 		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
 		if hookBd == nil {
 			hookBd = bd

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -911,6 +911,26 @@ func TestShouldNudgeRefinery(t *testing.T) {
 	}
 }
 
+func TestIsFormulaCompletionBead(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		issue *beads.Issue
+		want  bool
+	}{
+		{name: "workflow step", id: "gt-wisp-wfs-abc", want: true},
+		{name: "durable formula dispatch", id: "gt-abc", issue: &beads.Issue{Labels: []string{formulaDispatchLabel}}, want: true},
+		{name: "ordinary deferred work", id: "gt-abc", issue: &beads.Issue{Labels: []string{"gt:task"}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFormulaCompletionBead(tt.id, tt.issue); got != tt.want {
+				t.Fatalf("isFormulaCompletionBead(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldUpdateAgentStateOnDone(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cmd/formula_dispatch_durability_integration_test.go
+++ b/internal/cmd/formula_dispatch_durability_integration_test.go
@@ -1,0 +1,156 @@
+//go:build e2e
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+// TestStandaloneFormulaHookSurvivesCommittedReplica is the GH#4527 feedback
+// loop. Run it inside a resource-capped Docker container; it needs bd, Dolt,
+// and the repository's e2e toolchain.
+func TestStandaloneFormulaHookSurvivesCommittedReplica(t *testing.T) {
+	tmpDir := t.TempDir()
+	hqPath := filepath.Join(tmpDir, "town")
+	env, doltPort := isolatedE2EDoltEnv(t, tmpDir)
+	configureGitIdentity(t, env)
+	configureDoltIdentityForEnv(t, env)
+	testutil.ReapOwnedDoltOnCleanup(t, hqPath)
+
+	gtBinary := buildGT(t)
+	runFormulaDurabilityCmd(t, "", env, gtBinary, "install", hqPath, "--name", "formula-durability", "--git", "--dolt-port", doltPort)
+	t.Cleanup(func() {
+		cmdEnv := append([]string(nil), env...)
+		_ = runFormulaDurabilityCleanupCmd(hqPath, cmdEnv, gtBinary, "dolt", "stop")
+	})
+
+	deaconDir := filepath.Join(hqPath, "deacon")
+	slingEnv := append(append([]string(nil), env...), "GT_ROLE=deacon", "GT_TEST_NO_NUDGE=1")
+	runFormulaDurabilityCmd(t, deaconDir, slingEnv, gtBinary, "sling", "mol-dog-reaper", "--no-boot")
+
+	writerHook := readFormulaHookStatus(t, deaconDir, env, gtBinary, "deacon")
+	if writerHook.BeadID == "" || writerHook.Status != "hooked" {
+		t.Fatalf("writer hook = %+v, want hooked formula work", writerHook)
+	}
+
+	// Push only committed Dolt state to a local remote, then serve a clone as a
+	// second database. This models another machine reading refs/dolt/data rather
+	// than sharing the writer's uncommitted working set.
+	runFormulaDurabilityCmd(t, hqPath, env, gtBinary, "dolt", "stop")
+	remoteDir := filepath.Join(tmpDir, "remote")
+	if err := os.Mkdir(remoteDir, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runFormulaDurabilityCmd(t, remoteDir, env, "dolt", "init")
+
+	hqDatabaseDir := filepath.Join(hqPath, ".dolt-data", "hq")
+	runFormulaDurabilityCmd(t, hqDatabaseDir, env, "dolt", "remote", "add", "durability-test", "file://"+remoteDir)
+	runFormulaDurabilityCmd(t, hqDatabaseDir, env, "dolt", "push", "durability-test", "main")
+
+	runFormulaDurabilityCmd(t, tmpDir, env, "dolt", "clone", "file://"+remoteDir, "reader")
+	readerDatabaseDir := filepath.Join(hqPath, ".dolt-data", "reader")
+	if err := os.Rename(filepath.Join(tmpDir, "reader"), readerDatabaseDir); err != nil {
+		t.Fatalf("move reader database: %v", err)
+	}
+
+	readerTown := filepath.Join(tmpDir, "reader-town")
+	runFormulaDurabilityCmd(t, tmpDir, env, "cp", "-a", hqPath, readerTown)
+	if err := os.RemoveAll(filepath.Join(readerTown, ".dolt-data")); err != nil {
+		t.Fatalf("remove copied Dolt data: %v", err)
+	}
+	setReplicaDatabase(t, filepath.Join(readerTown, ".beads", "metadata.json"), "reader")
+
+	runFormulaDurabilityCmd(t, hqPath, env, gtBinary, "dolt", "start")
+	replicaHook := readFormulaHookStatus(t, filepath.Join(readerTown, "deacon"), env, gtBinary, "deacon")
+	if replicaHook.BeadID != writerHook.BeadID || replicaHook.Status != "hooked" {
+		t.Fatalf("replica hook = %+v, want hooked bead %s from writer", replicaHook, writerHook.BeadID)
+	}
+}
+
+type formulaHookStatus struct {
+	BeadID string `json:"bead_id"`
+	Status string `json:"status"`
+}
+
+func readFormulaHookStatus(t *testing.T, dir string, env []string, gtBinary, agent string) formulaHookStatus {
+	t.Helper()
+	out := runFormulaDurabilityOutputCmd(t, dir, env, gtBinary, "hook", "show", agent, "--json")
+	var status formulaHookStatus
+	if err := json.Unmarshal([]byte(out), &status); err != nil {
+		t.Fatalf("parse hook status: %v\n%s", err, out)
+	}
+	return status
+}
+
+func configureDoltIdentityForEnv(t *testing.T, env []string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"config", "--global", "--add", "user.name", "Test User"},
+		{"config", "--global", "--add", "user.email", "test@test.com"},
+	} {
+		runFormulaDurabilityCmd(t, "", env, "dolt", args...)
+	}
+}
+
+func setReplicaDatabase(t *testing.T, metadataPath, database string) {
+	t.Helper()
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	metadata["dolt_database"] = database
+	data, err = json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(metadataPath, data, 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func runFormulaDurabilityCmd(t *testing.T, dir string, env []string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+	return string(out)
+}
+
+func runFormulaDurabilityOutputCmd(t *testing.T, dir string, env []string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("%s %v failed: %v\n%s", name, args, err, exitErr.Stderr)
+		}
+		t.Fatalf("%s %v failed: %v", name, args, err)
+	}
+	return string(out)
+}
+
+func runFormulaDurabilityCleanupCmd(dir string, env []string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd.Run()
+}

--- a/internal/cmd/formula_dispatch_durability_test.go
+++ b/internal/cmd/formula_dispatch_durability_test.go
@@ -1,0 +1,470 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestShouldReuseExistingFormulaIgnoresLegacyWisps(t *testing.T) {
+	wisp := &beads.Issue{
+		ID:          "gt-wisp-existing",
+		Ephemeral:   true,
+		Labels:      []string{"gt:task"},
+		Description: "attached_formula: mol-anything",
+	}
+	if shouldReuseExistingFormula(wisp, nil, false) {
+		t.Fatal("legacy wisp must not be reused as durable formula dispatch")
+	}
+
+	unlabeled := &beads.Issue{ID: "gt-wisp-unlabeled", Description: "attached_formula: mol-anything"}
+	if shouldReuseExistingFormula(unlabeled, nil, false) {
+		t.Fatal("unlabeled hooked formula must not be reused after the durability fix")
+	}
+
+	durable := &beads.Issue{
+		ID:          "gt-dispatch",
+		Labels:      []string{formulaDispatchLabel},
+		Description: "attached_formula: mol-anything",
+	}
+	if !shouldReuseExistingFormula(durable, nil, false) {
+		t.Fatal("durable formula dispatch should still be reused")
+	}
+}
+
+func TestRunSlingFormulaMigratesLegacyWispToDurableDispatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	_, logPath, attachedLogPath := setupFormulaSlingTown(t, `#!/bin/sh
+set -e
+echo "$PWD|$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook|update)
+    exit 0
+    ;;
+  mol)
+    echo "unexpected new wisp after legacy hook" >&2
+    exit 1
+    ;;
+esac
+exit 0
+`)
+
+	prevFind := findHookedFormulaSingletonFn
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		findHookedFormulaSingletonFn = prevFind
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+
+	slingDryRun = false
+	slingNoBoot = true
+	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
+		return &beads.Issue{
+			ID:          "gt-wisp-existing",
+			Ephemeral:   true,
+			Description: "attached_formula: mol-anything",
+		}, nil
+	}
+
+	var hookedID string
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		hookedID = beadID
+		return nil
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+
+	if hookedID != "gt-dispatch-xyz" {
+		t.Fatalf("hooked %q, want durable dispatch gt-dispatch-xyz", hookedID)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	attachment := string(attachmentBytes)
+	if !strings.Contains(attachment, "attached_molecule: gt-wisp-existing") {
+		t.Fatalf("migrated dispatch must keep the legacy wisp as its molecule:\n%s", attachment)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	log := string(logBytes)
+	if strings.Contains(log, "mol wisp") || strings.Contains(log, "cook ") {
+		t.Fatalf("legacy wisp migration created a new formula instead of promoting the existing wisp:\n%s", log)
+	}
+	if !strings.Contains(log, "update gt-wisp-existing --status=open --assignee=") {
+		t.Fatalf("legacy wisp remained hooked after migration:\n%s", log)
+	}
+}
+
+func TestRunSlingFormulaHooksDurableDispatchNotWisp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	_, _, attachedLogPath := setupFormulaSlingTown(t, `#!/bin/sh
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    echo '{"new_epic_id":"gt-wisp-xyz"}'
+    ;;
+esac
+exit 0
+`)
+
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+	slingDryRun = false
+	slingNoBoot = true
+
+	var hookedID string
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		hookedID = beadID
+		return nil
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+	if hookedID != "gt-dispatch-xyz" {
+		t.Fatalf("hooked %q, want durable dispatch gt-dispatch-xyz", hookedID)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	if !strings.Contains(string(attachmentBytes), "attached_molecule: gt-wisp-xyz") {
+		t.Fatalf("durable dispatch missing molecule pointer:\n%s", attachmentBytes)
+	}
+}
+
+func TestRunSlingFormulaCleansDispatchAndMoleculeOnHookFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot := t.TempDir()
+	setupFormulaSlingWorkspace(t, townRoot)
+	closesLog := filepath.Join(townRoot, "closes.log")
+	writeFormulaSlingBDStub(t, townRoot, fmt.Sprintf(`#!/bin/sh
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    echo '{"new_epic_id":"gt-wisp-xyz"}'
+    ;;
+  show)
+    case "$1" in
+      gt-dispatch-xyz)
+        echo '[{"id":"gt-dispatch-xyz","status":"open","description":"attached_molecule: gt-wisp-xyz"}]'
+        ;;
+      gt-wisp-xyz)
+        echo '[{"id":"gt-wisp-xyz","status":"open","ephemeral":true}]'
+        ;;
+      *)
+        echo '[]'
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+esac
+exit 0
+`, closesLog))
+
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", "")
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+	slingDryRun = false
+	slingNoBoot = true
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		return errors.New("hook failed")
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err == nil {
+		t.Fatal("expected hook failure")
+	}
+
+	closesBytes, err := os.ReadFile(closesLog)
+	if err != nil {
+		t.Fatalf("expected cleanup closes, got %v", err)
+	}
+	closes := string(closesBytes)
+	if !strings.Contains(closes, "gt-dispatch-xyz") {
+		t.Fatalf("failed sling did not close durable dispatch:\n%s", closes)
+	}
+	if !strings.Contains(closes, "gt-wisp-xyz") {
+		t.Fatalf("failed sling did not close formula molecule:\n%s", closes)
+	}
+}
+
+func TestUpdateAgentStateOnDoneDeferredClosesFormulaDispatchAndMolecule(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot, closesLog := setupFormulaDoneTown(t, `#!/bin/sh
+while [ "$1" = "--allow-stale" ]; do shift; done
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    case "$1" in
+      gt-gastown-polecat-nux)
+        echo '[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","status":"open","agent_state":"working"}]'
+        ;;
+      gt-dispatch-1)
+        echo '[{"id":"gt-dispatch-1","title":"mol-dog-reaper","status":"hooked","labels":["gt:task","gt:formula-dispatch"],"description":"attached_molecule: gt-wisp-xyz"}]'
+        ;;
+      gt-wisp-xyz)
+        echo '[{"id":"gt-wisp-xyz","title":"mol-dog-reaper","status":"open","ephemeral":true}]'
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+  agent|update|slot)
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	if err := updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitDeferred, "gt-dispatch-1"); err != nil {
+		t.Fatalf("updateAgentStateOnDone deferred formula: %v", err)
+	}
+
+	closesBytes, err := os.ReadFile(closesLog)
+	if err != nil {
+		t.Fatalf("expected closes, got %v", err)
+	}
+	closes := string(closesBytes)
+	if !strings.Contains(closes, "gt-dispatch-1") {
+		t.Fatalf("DEFERRED formula completion did not close dispatch bead:\n%s", closes)
+	}
+	if !strings.Contains(closes, "gt-wisp-xyz") {
+		t.Fatalf("DEFERRED formula completion did not close attached molecule:\n%s", closes)
+	}
+}
+
+func TestUpdateAgentStateOnDoneDeferredShowFailureDoesNotFail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot, closesLog := setupFormulaDoneTown(t, `#!/bin/sh
+while [ "$1" = "--allow-stale" ]; do shift; done
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    case "$1" in
+      gt-gastown-polecat-nux)
+        echo '[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","status":"open","agent_state":"working"}]'
+        ;;
+      gt-ordinary)
+        echo "transient read error" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+  agent|update|slot)
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	if err := updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitDeferred, "gt-ordinary"); err != nil {
+		t.Fatalf("ordinary DEFERRED completion must stay warning-only on Show failure, got %v", err)
+	}
+	if _, err := os.ReadFile(closesLog); !os.IsNotExist(err) {
+		t.Fatalf("ordinary deferred work was closed after a classification read error")
+	}
+}
+
+func setupFormulaSlingTown(t *testing.T, bdScript string) (townRoot, logPath, attachedLogPath string) {
+	t.Helper()
+	townRoot = t.TempDir()
+	setupFormulaSlingWorkspace(t, townRoot)
+	logPath = filepath.Join(townRoot, "bd.log")
+	attachedLogPath = filepath.Join(townRoot, "attached-molecule.log")
+	writeFormulaSlingBDStub(t, townRoot, bdScript)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return townRoot, logPath, attachedLogPath
+}
+
+func setupFormulaSlingWorkspace(t *testing.T, townRoot string) {
+	t.Helper()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor", "rig"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "bin"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+}
+
+func writeFormulaSlingBDStub(t *testing.T, townRoot, script string) {
+	t.Helper()
+	binDir := filepath.Join(townRoot, "bin")
+	_ = writeBDStub(t, binDir, script, "@echo off\nexit /b 0\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func setupFormulaDoneTown(t *testing.T, bdScript string) (townRoot, closesLog string) {
+	t.Helper()
+	townRoot = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "locks"), 0755); err != nil {
+		t.Fatalf("mkdir .beads/locks: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown"), 0755); err != nil {
+		t.Fatalf("mkdir gastown: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown"}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	closesLog = filepath.Join(townRoot, "closes.log")
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	_ = writeBDStub(t, binDir, fmt.Sprintf(bdScript, closesLog), "@echo off\nexit /b 0\n")
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_ROLE", "polecat")
+	t.Setenv("GT_RIG", "gastown")
+	t.Setenv("GT_POLECAT", "nux")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "gastown")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return townRoot, closesLog
+}

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -480,7 +480,7 @@ func TestStandaloneFormulaRigTargetAcquiresSingleAdmission(t *testing.T) {
 		}, nil
 	}
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"test-formula", "gastown"}); err != nil {
@@ -515,7 +515,7 @@ func TestStandaloneFormulaExistingPolecatNoopDoesNotRequireCapacity(t *testing.T
 		return "gastown/polecats/toast", "%1", filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"), nil
 	}
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"test-formula", "gastown/polecats/toast"}); err != nil {

--- a/internal/cmd/sling_dog_cleanup_test.go
+++ b/internal/cmd/sling_dog_cleanup_test.go
@@ -183,9 +183,10 @@ func TestDogWorksOnHookRequiresFreshAttachment(t *testing.T) {
 
 func TestShouldReuseExistingFormulaSkipsStaleHookAfterFreshDogAssignment(t *testing.T) {
 	startedAt := time.Date(2026, 6, 16, 20, 30, 15, 900_000_000, time.UTC)
-	existing := &beads.Issue{ID: "gt-wisp-stale"}
+	existing := &beads.Issue{ID: "gt-dispatch-stale", Labels: []string{formulaDispatchLabel}}
 	freshDogHook := &beads.Issue{
-		ID:          "gt-wisp-fresh",
+		ID:          "gt-dispatch-fresh",
+		Labels:      []string{formulaDispatchLabel},
 		Description: "attached_formula: mol-dog-reaper\nattached_at: " + startedAt.Format(time.RFC3339Nano),
 	}
 	reusedDog := &DogDispatchInfo{

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -62,18 +62,45 @@ func cleanupStaleDogFormulaWisp(wispRootID, formulaWorkDir string) error {
 	return closeFormulaWisp(wispRootID, formulaWorkDir, "burned: stale dog formula hook replaced")
 }
 
-func closeFormulaWisp(wispRootID, formulaWorkDir, reason string) error {
-	if wispRootID == "" {
+func closeFormulaMoleculeByID(bd *beads.Beads, moleculeID, reason string) error {
+	if moleculeID == "" {
+		return nil
+	}
+	var cleanupErr error
+	if _, err := forceCloseDescendants(bd, moleculeID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close descendants: %w", err))
+	}
+	if err := bd.ForceCloseWithReason(reason, moleculeID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close formula molecule: %w", err))
+	}
+	return cleanupErr
+}
+
+func closeFormulaWisp(workBeadID, formulaWorkDir, reason string) error {
+	if workBeadID == "" {
 		return nil
 	}
 	bd := beads.New(formulaWorkDir)
-	if _, err := forceCloseDescendants(bd, wispRootID); err != nil {
-		return fmt.Errorf("force-close descendants: %w", err)
+	workBead, err := bd.Show(workBeadID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("resolve formula cleanup target %s: %w", workBeadID, err)
 	}
-	if err := bd.ForceCloseWithReason(reason, wispRootID); err != nil {
-		return fmt.Errorf("force-close formula wisp: %w", err)
+
+	moleculeID := workBeadID
+	if fields := beads.ParseAttachmentFields(workBead); fields != nil && fields.AttachedMolecule != "" {
+		moleculeID = fields.AttachedMolecule
 	}
-	return nil
+
+	cleanupErr := closeFormulaMoleculeByID(bd, moleculeID, reason)
+	if moleculeID != workBeadID {
+		if err := bd.ForceCloseWithReason(reason, workBeadID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close formula dispatch bead: %w", err))
+		}
+	}
+	return cleanupErr
 }
 
 var cleanupFailedDogFormulaWispFn = cleanupFailedDogFormulaWisp
@@ -124,13 +151,7 @@ func findHookedFormulaSingleton(workDir, targetAgent, formulaName string) (*bead
 	}
 
 	b := beads.New(workDir)
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:    beads.StatusHooked,
-		Assignee:  targetAgent,
-		Priority:  -1,
-		Ephemeral: true,
-		Limit:     0,
-	})
+	hookedBeads, err := listAssignedActiveWorkAcrossStatuses(b, targetAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -165,15 +186,19 @@ func findHookedFormulaForDogPool(workDir, formulaName string, reusableDog func(*
 	}
 
 	b := beads.New(workDir)
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:    beads.StatusHooked,
-		Priority:  -1,
-		Ephemeral: true,
-		Limit:     0,
-	})
-	if err != nil {
-		return nil, "", err
+	var hookedBeads []*beads.Issue
+	for _, status := range activeWorkStatuses() {
+		active, err := listBeadsAcrossTables(b, beads.ListOptions{
+			Status:   status,
+			Priority: -1,
+			Limit:    0,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		hookedBeads = append(hookedBeads, active...)
 	}
+	hookedBeads = mergeBeadLists(hookedBeads, nil)
 
 	bead, dogName := reusableHookedDogFormula(hookedBeads, formulaName, reusableDog)
 	return bead, dogName, nil
@@ -283,8 +308,26 @@ func verifyFormulaExists(formulaName, workDir, townRoot string) error {
 	return fmt.Errorf("formula '%s' not found (check 'bd formula list')", formulaName)
 }
 
+const formulaDispatchLabel = "gt:formula-dispatch"
+
+func createFormulaDispatchBead(formulaName, formulaWorkDir string) (*beads.Issue, error) {
+	issue, err := beads.New(formulaWorkDir).Create(beads.CreateOptions{
+		Title:    formulaName,
+		Labels:   []string{"gt:task", formulaDispatchLabel},
+		Priority: 2,
+		Actor:    detectActor(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating durable formula dispatch bead: %w", err)
+	}
+	if issue == nil || issue.ID == "" {
+		return nil, fmt.Errorf("creating durable formula dispatch bead: bd returned no issue ID")
+	}
+	return issue, nil
+}
+
 // runSlingFormula handles standalone formula slinging.
-// Flow: cook → wisp → attach to hook → nudge
+// Flow: cook → wisp → durable dispatch bead → attach dispatch bead to hook → nudge
 func runSlingFormula(ctx context.Context, args []string) (err error) {
 	formulaName := args[0]
 
@@ -360,6 +403,8 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 
 	var wispRootID string
+	var dispatchBeadID string
+	formulaWorkComplete := false
 
 	if slingDryRun {
 		existing, err := findHookedFormulaSingletonFn(formulaWorkDir, targetAgent, formulaName)
@@ -396,13 +441,33 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 	defer assigneeUnlock()
 	defer func() {
-		if delayedDogInfo == nil || delayedDogComplete {
+		cleanupID := dispatchBeadID
+		if cleanupID == "" {
+			cleanupID = wispRootID
+		}
+		if delayedDogInfo != nil && !delayedDogComplete {
+			if err != nil || cleanupID != "" {
+				err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)
+			}
+			if dispatchBeadID != "" && wispRootID != "" {
+				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: dog formula sling failed"); cleanupErr != nil {
+					err = errors.Join(err, cleanupErr)
+				}
+			}
 			return
 		}
-		if err == nil && wispRootID == "" {
-			return
+		if err != nil && !formulaWorkComplete && cleanupID != "" {
+			if cleanupErr := closeFormulaWisp(cleanupID, formulaWorkDir, "burned: formula sling failed"); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+			}
+			// Metadata persistence may have failed before attached_molecule was
+			// stored. Close the known wisp ID independently so it cannot leak.
+			if dispatchBeadID != "" && wispRootID != "" {
+				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: formula sling failed"); cleanupErr != nil {
+					err = errors.Join(err, cleanupErr)
+				}
+			}
 		}
-		err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)
 	}()
 	mode := ""
 	if slingRalph {
@@ -499,42 +564,51 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 
 	fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
 
-	// Step 3: Hook the wisp bead with retry and verification.
-	// See: https://github.com/steveyegge/gastown/issues/148.
-	hookDir := beads.ResolveHookDir(townRoot, wispRootID, "")
-	if err := hookBeadWithRetryFn(wispRootID, targetAgent, hookDir); err != nil {
+	// Work dispatch must live in the durable issues table. Wisps intentionally
+	// remain outside Dolt history, so hooking the wisp directly strands the
+	// assignment outside refs/dolt/data and makes remote agents see an empty hook.
+	dispatchBead, err := createFormulaDispatchBead(formulaName, formulaWorkDir)
+	if err != nil {
 		return err
 	}
-	fmt.Printf("%s Attached to hook (status=hooked)\n", style.Bold.Render("✓"))
+	dispatchBeadID = dispatchBead.ID
+	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBeadID)
 
-	// Log sling event to activity feed (formula slinging)
 	actor := detectActor()
-	payload := events.SlingPayload(wispRootID, targetAgent)
-	payload["formula"] = formulaName
-	_ = events.LogFeed(events.TypeSling, actor, payload)
-
-	// Update agent bead's hook_bead field (ZFC: agents track their current work)
-	// Note: formula slinging uses town root as workDir (no polecat-specific path)
-	updateAgentHookBead(targetAgent, wispRootID, "", townBeadsDir)
-
-	// Store all attachment fields in a single read-modify-write cycle.
-	// NOTE: For standalone formula sling, the wisp IS the work - do NOT store
-	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
-	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
-	// creates a wisp that's bonded to a separate base bead.
 	fieldUpdates := beadFieldUpdates{
-		Dispatcher:      actor,
-		Args:            slingArgs,
-		Vars:            append([]string(nil), slingVars...),
-		AttachedFormula: formulaName,
-		Mode:            &mode,
-		FormulaVars:     strings.Join(slingVars, "\n"),
+		Dispatcher:       actor,
+		Args:             slingArgs,
+		Vars:             append([]string(nil), slingVars...),
+		AttachedMolecule: wispRootID,
+		AttachedFormula:  formulaName,
+		Mode:             &mode,
+		FormulaVars:      strings.Join(slingVars, "\n"),
 	}
-	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
-		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
-	} else if slingArgs != "" {
+	// attached_molecule is required to execute and later close the ephemeral
+	// formula. Persist it before reporting that the durable work was hooked.
+	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, fieldUpdates); err != nil {
+		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
+	}
+
+	// Step 3: Hook the durable dispatch bead with retry and verification.
+	// See: https://github.com/steveyegge/gastown/issues/148.
+	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
+	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+		return err
+	}
+	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
+	if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
 	}
+
+	// Log sling event to activity feed (formula slinging).
+	payload := events.SlingPayload(dispatchBeadID, targetAgent)
+	payload["formula"] = formulaName
+	payload["molecule"] = wispRootID
+	_ = events.LogFeed(events.TypeSling, actor, payload)
+
+	// Agent hook slots are legacy; durable bead status+assignee is authoritative.
+	updateAgentHookBead(targetAgent, dispatchBeadID, "", townBeadsDir)
 	if mode != "" {
 		updateAgentMode(targetAgent, mode, "", townBeadsDir)
 	}
@@ -555,12 +629,14 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	if resolved.NewPolecatInfo != nil {
 		pane, err := resolved.NewPolecatInfo.StartSession()
 		if err != nil {
-			// Rollback: unhook wisp, delete Dolt branch, clean up polecat worktree/agent bead
-			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, wispRootID, "", "")
+			// Rollback: unhook durable work, burn its molecule, and clean up the polecat.
+			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, dispatchBeadID, "", "")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
 		targetPane = pane
 	}
+
+	formulaWorkComplete = true
 
 	// Step 4: Nudge to start (graceful if no tmux)
 	// Skip for self-sling - agent is currently processing the sling command and will see

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -258,8 +258,26 @@ func newerAttachment(noCurrent bool, candidate time.Time, candidateOK bool, curr
 	return candidateOK && candidate.After(current)
 }
 
+func isDurableFormulaDispatch(issue *beads.Issue) bool {
+	return issue != nil && !issue.Ephemeral && beads.HasLabel(issue, formulaDispatchLabel)
+}
+
+func isLegacyFormulaWisp(issue *beads.Issue) bool {
+	return issue != nil && !isDurableFormulaDispatch(issue)
+}
+
+func formulaMoleculeID(issue *beads.Issue) string {
+	if issue == nil {
+		return ""
+	}
+	if fields := beads.ParseAttachmentFields(issue); fields != nil && fields.AttachedMolecule != "" {
+		return fields.AttachedMolecule
+	}
+	return issue.ID
+}
+
 func shouldReuseExistingFormula(existing *beads.Issue, delayedDogInfo *DogDispatchInfo, force bool) bool {
-	if existing == nil || force {
+	if existing == nil || force || !isDurableFormulaDispatch(existing) {
 		return false
 	}
 	if delayedDogInfo == nil {
@@ -269,6 +287,84 @@ func shouldReuseExistingFormula(existing *beads.Issue, delayedDogInfo *DogDispat
 		return false
 	}
 	return delayedDogInfo.worksOnHook(existing)
+}
+
+func rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason string) error {
+	var cleanupErr error
+	if dispatchBeadID != "" {
+		if err := closeFormulaWisp(dispatchBeadID, formulaWorkDir, reason); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	if wispRootID != "" && wispRootID != dispatchBeadID {
+		if err := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, reason); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
+}
+
+func unhookFormulaBead(beadID, formulaWorkDir, townRoot string) error {
+	if beadID == "" {
+		return nil
+	}
+	hookDir := beads.ResolveHookDir(townRoot, beadID, formulaWorkDir)
+	if err := BdCmd("update", beadID, "--status=open", "--assignee=").
+		Dir(hookDir).
+		WithAutoCommit().
+		Run(); err != nil {
+		return fmt.Errorf("unhooking legacy formula wisp %s: %w", beadID, err)
+	}
+	return nil
+}
+
+func formulaDispatchFieldUpdates(formulaName, moleculeID, mode string) beadFieldUpdates {
+	return beadFieldUpdates{
+		Dispatcher:       detectActor(),
+		Args:             slingArgs,
+		Vars:             append([]string(nil), slingVars...),
+		AttachedMolecule: moleculeID,
+		AttachedFormula:  formulaName,
+		Mode:             &mode,
+		FormulaVars:      strings.Join(slingVars, "\n"),
+	}
+}
+
+func persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBeadID, targetAgent, formulaName, moleculeID, mode string) error {
+	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, formulaDispatchFieldUpdates(formulaName, moleculeID, mode)); err != nil {
+		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
+	}
+	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
+	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+		return err
+	}
+	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
+	if slingArgs != "" {
+		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
+	}
+	payload := events.SlingPayload(dispatchBeadID, targetAgent)
+	payload["formula"] = formulaName
+	payload["molecule"] = moleculeID
+	_ = events.LogFeed(events.TypeSling, detectActor(), payload)
+	return nil
+}
+
+func migrateLegacyFormulaDispatch(existing *beads.Issue, formulaName, formulaWorkDir, townRoot, targetAgent, mode string) (string, string, error) {
+	moleculeID := formulaMoleculeID(existing)
+	dispatchBead, err := createFormulaDispatchBead(formulaName, formulaWorkDir)
+	if err != nil {
+		return "", moleculeID, err
+	}
+	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBead.ID)
+	if err := persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBead.ID, targetAgent, formulaName, moleculeID, mode); err != nil {
+		return dispatchBead.ID, moleculeID, err
+	}
+	if err := unhookFormulaBead(existing.ID, formulaWorkDir, townRoot); err != nil {
+		return dispatchBead.ID, moleculeID, err
+	}
+	fmt.Printf("%s Migrated legacy formula wisp %s onto durable dispatch %s\n",
+		style.Bold.Render("✓"), existing.ID, dispatchBead.ID)
+	return dispatchBead.ID, moleculeID, nil
 }
 
 // verifyFormulaExists checks that the formula exists using bd formula show.
@@ -411,7 +507,7 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("checking existing hooked formulas for %s: %w", targetAgent, err)
 		}
-		if existing != nil && !slingForce {
+		if existing != nil && !slingForce && isDurableFormulaDispatch(existing) {
 			fmt.Printf("Would reuse existing formula %s on %s via %s\n", formulaName, targetAgent, existing.ID)
 			return nil
 		}
@@ -445,28 +541,17 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		if cleanupID == "" {
 			cleanupID = wispRootID
 		}
+		reason := "burned: formula sling failed"
 		if delayedDogInfo != nil && !delayedDogComplete {
+			reason = "burned: dog formula sling failed"
 			if err != nil || cleanupID != "" {
 				err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)
 			}
-			if dispatchBeadID != "" && wispRootID != "" {
-				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: dog formula sling failed"); cleanupErr != nil {
-					err = errors.Join(err, cleanupErr)
-				}
-			}
+			err = errors.Join(err, rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason))
 			return
 		}
 		if err != nil && !formulaWorkComplete && cleanupID != "" {
-			if cleanupErr := closeFormulaWisp(cleanupID, formulaWorkDir, "burned: formula sling failed"); cleanupErr != nil {
-				err = errors.Join(err, cleanupErr)
-			}
-			// Metadata persistence may have failed before attached_molecule was
-			// stored. Close the known wisp ID independently so it cannot leak.
-			if dispatchBeadID != "" && wispRootID != "" {
-				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: formula sling failed"); cleanupErr != nil {
-					err = errors.Join(err, cleanupErr)
-				}
-			}
+			err = errors.Join(err, rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason))
 		}
 	}()
 	mode := ""
@@ -504,13 +589,20 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		}
 		return nil
 	}
-	if delayedDogInfo != nil && !delayedDogInfo.ownsWork {
+	if delayedDogInfo != nil && !delayedDogInfo.ownsWork && !delayedDogInfo.worksOnHook(existing) {
 		return fmt.Errorf("dog formula reuse became stale before hook verification; retry dispatch")
 	}
 	if existing != nil && !slingForce && delayedDogInfo != nil && delayedDogInfo.ownsWork {
 		if err := cleanupStaleDogFormulaWispFn(existing.ID, formulaWorkDir); err != nil {
 			return fmt.Errorf("cleaning stale dog formula wisp %s: %w", existing.ID, err)
 		}
+	} else if isLegacyFormulaWisp(existing) && !slingForce {
+		dispatchBeadID, wispRootID, err = migrateLegacyFormulaDispatch(existing, formulaName, formulaWorkDir, townRoot, targetAgent, mode)
+		if err != nil {
+			rollbackSpawned(dispatchBeadID)
+			return err
+		}
+		return finishFormulaSling(resolved, delayedDogInfo, &delayedDogComplete, &formulaWorkComplete, townBeadsDir, formulaName, dispatchBeadID, targetAgent, &targetPane, isSelfSling, mode)
 	}
 	if admission == nil && strings.Contains(targetAgent, "/polecats/") {
 		parts := strings.Split(targetAgent, "/")
@@ -574,79 +666,43 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	dispatchBeadID = dispatchBead.ID
 	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBeadID)
 
-	actor := detectActor()
-	fieldUpdates := beadFieldUpdates{
-		Dispatcher:       actor,
-		Args:             slingArgs,
-		Vars:             append([]string(nil), slingVars...),
-		AttachedMolecule: wispRootID,
-		AttachedFormula:  formulaName,
-		Mode:             &mode,
-		FormulaVars:      strings.Join(slingVars, "\n"),
-	}
-	// attached_molecule is required to execute and later close the ephemeral
-	// formula. Persist it before reporting that the durable work was hooked.
-	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, fieldUpdates); err != nil {
-		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
-	}
-
-	// Step 3: Hook the durable dispatch bead with retry and verification.
-	// See: https://github.com/steveyegge/gastown/issues/148.
-	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
-	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+	if err := persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBeadID, targetAgent, formulaName, wispRootID, mode); err != nil {
 		return err
 	}
-	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
-	if slingArgs != "" {
-		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
-	}
+	return finishFormulaSling(resolved, delayedDogInfo, &delayedDogComplete, &formulaWorkComplete, townBeadsDir, formulaName, dispatchBeadID, targetAgent, &targetPane, isSelfSling, mode)
+}
 
-	// Log sling event to activity feed (formula slinging).
-	payload := events.SlingPayload(dispatchBeadID, targetAgent)
-	payload["formula"] = formulaName
-	payload["molecule"] = wispRootID
-	_ = events.LogFeed(events.TypeSling, actor, payload)
-
-	// Agent hook slots are legacy; durable bead status+assignee is authoritative.
+func finishFormulaSling(resolved *ResolvedTarget, delayedDogInfo *DogDispatchInfo, delayedDogComplete, formulaWorkComplete *bool, townBeadsDir, formulaName, dispatchBeadID, targetAgent string, targetPane *string, isSelfSling bool, mode string) error {
 	updateAgentHookBead(targetAgent, dispatchBeadID, "", townBeadsDir)
 	if mode != "" {
 		updateAgentMode(targetAgent, mode, "", townBeadsDir)
 	}
 
-	// Start delayed dog session now that hook is set
-	// This ensures dog sees the hook when gt prime runs on session start
 	if delayedDogInfo != nil {
 		pane, err := delayedDogInfo.StartDelayedSession()
 		if err != nil {
 			return fmt.Errorf("starting delayed dog session: %w", err)
 		}
-		delayedDogComplete = true
-		targetPane = pane
+		*delayedDogComplete = true
+		*targetPane = pane
 	}
 
-	// Start spawned polecat session now that hook is set.
-	// This ensures polecat sees the wisp when gt prime runs on session start.
 	if resolved.NewPolecatInfo != nil {
 		pane, err := resolved.NewPolecatInfo.StartSession()
 		if err != nil {
-			// Rollback: unhook durable work, burn its molecule, and clean up the polecat.
 			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, dispatchBeadID, "", "")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
-		targetPane = pane
+		*targetPane = pane
 	}
 
-	formulaWorkComplete = true
+	*formulaWorkComplete = true
 
-	// Step 4: Nudge to start (graceful if no tmux)
-	// Skip for self-sling - agent is currently processing the sling command and will see
-	// the hooked work on next turn. Nudging would inject text while agent is busy.
 	if isSelfSling {
 		fmt.Printf("%s Self-sling: work hooked, will process on next turn\n", style.Dim.Render("○"))
 		return nil
 	}
 
-	// Skip nudge during tests to prevent agent self-interruption
 	if os.Getenv("GT_TEST_NO_NUDGE") != "" {
 		return nil
 	}
@@ -662,14 +718,13 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		return nil
 	}
 
-	if targetPane == "" {
+	if targetPane == nil || *targetPane == "" {
 		fmt.Printf("%s No pane to nudge (agent will discover work via gt prime)\n", style.Dim.Render("○"))
 		return nil
 	}
 
 	t := tmux.NewTmux()
-	if err := t.NudgePane(targetPane, prompt); err != nil {
-		// Graceful fallback for no-tmux mode
+	if err := t.NudgePane(*targetPane, prompt); err != nil {
 		fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)
 		fmt.Printf("  Agent will discover work via gt prime / bd show\n")
 	} else {

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -36,7 +36,7 @@ func TestRunSlingFormulaCleansDelayedDogFailure(t *testing.T) {
 	for _, want := range []string{
 		") (err error)",
 		"defer func()",
-		"cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)",
+		"cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("runSlingFormula missing %q", want)

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -147,10 +147,14 @@ func TestRunSlingFormulaNonOwnedDogReuseCannotCreateFreshWisp(t *testing.T) {
 }
 
 func TestRunSlingFormulaDogNudgeBeforeEmptyPaneReturn(t *testing.T) {
-	body := runSlingFormulaSourceForTest(t)
+	data, err := os.ReadFile("sling_formula.go")
+	if err != nil {
+		t.Fatalf("read sling_formula.go: %v", err)
+	}
+	body := string(data)
 
 	dogNudgeIdx := strings.LastIndex(body, "nudgeFormulaDog(delayedDogInfo, prompt)")
-	emptyPaneIdx := strings.Index(body, "if targetPane == \"\" {")
+	emptyPaneIdx := strings.Index(body, "if targetPane == nil || *targetPane == \"\" {")
 	if dogNudgeIdx == -1 {
 		t.Fatal("dog-specific nudge call not found")
 	}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2139,6 +2139,9 @@ case "$cmd" in
   formula)
     echo '{"name":"mol-anything"}'
     ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
   cook)
     exit 0
     ;;
@@ -2161,6 +2164,10 @@ set "cmd=%1"
 set "sub=%2"
 if "%cmd%"=="formula" (
   echo {"name":"mol-anything"}
+  exit /b 0
+)
+if "%cmd%"=="create" (
+  echo {"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}
   exit /b 0
 )
 if "%cmd%"=="cook" exit /b 0
@@ -2222,6 +2229,16 @@ exit /b 0
 
 	if !strings.Contains(attachment, "attached_formula: mol-anything") {
 		t.Fatalf("formula attachment missing from persisted description:\n%s", attachment)
+	}
+	if !strings.Contains(attachment, "attached_molecule: gt-wisp-xyz") {
+		t.Fatalf("durable dispatch bead does not point to formula wisp:\n%s", attachment)
+	}
+	bdLog, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	if !strings.Contains(string(bdLog), "update gt-dispatch-xyz --status=hooked --assignee=mayor/") {
+		t.Fatalf("standalone formula hooked the wisp instead of durable dispatch bead:\n%s", bdLog)
 	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2233,13 +2233,6 @@ exit /b 0
 	if !strings.Contains(attachment, "attached_molecule: gt-wisp-xyz") {
 		t.Fatalf("durable dispatch bead does not point to formula wisp:\n%s", attachment)
 	}
-	bdLog, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read bd log: %v", err)
-	}
-	if !strings.Contains(string(bdLog), "update gt-dispatch-xyz --status=hooked --assignee=mayor/") {
-		t.Fatalf("standalone formula hooked the wisp instead of durable dispatch bead:\n%s", bdLog)
-	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
 	}
@@ -2320,7 +2313,7 @@ exit /b 0
 	slingNoBoot = true
 	slingForce = false
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
@@ -2397,7 +2390,7 @@ exit /b 0
 	slingForce = false
 	slingRalph = false
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing", Description: "attached_formula: mol-anything\nmode: ralph"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}, Description: "attached_formula: mol-anything\nmode: ralph"}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {


### PR DESCRIPTION
## Summary

Fixes #4527 by moving standalone formula **dispatch state** onto a durable issue while keeping formula execution wisps ephemeral.

- create a durable `gt:formula-dispatch` bead for standalone formula sling
- store `attached_molecule`/formula metadata on that durable bead before hooking it
- hook the durable bead by status + assignee, so `refs/dolt/data` replicas can discover work
- keep singleton detection across both `hooked` and `in_progress` work
- close both dispatch and molecule on normal completion and rollback
- fail closed if DEFERRED completion cannot classify the hooked bead

## Root cause

Standalone formula sling hooked the wisp itself. Wisps intentionally live outside Dolt history, so the writer's working set showed a successful hook while a replica reading committed `refs/dolt/data` saw an empty hook.

## Verification

All commands ran in Docker with `--cpus=2 --memory=3g --pids-limit=512` and beads 1.1.0.

Before fix, deterministic feedback loop:

```text
writer_view={"agent":"deacon/","bead_id":"hq-wisp-aeu","title":"mol-dog-reaper","status":"hooked"}
replica_view={"agent":"deacon/","status":"empty"}
exit 1
```

After fix, original loop:

```text
writer_view={"agent":"deacon/","bead_id":"hq-uay","title":"mol-dog-reaper","status":"hooked"}
replica_view={"agent":"deacon/","bead_id":"hq-uay","title":"mol-dog-reaper","status":"hooked"}
```

Tests:

```text
go test ./internal/cmd -count=1
ok github.com/steveyegge/gastown/internal/cmd

go test -tags=e2e -count=1 \
  -run '^(TestStandaloneFormulaHookSurvivesCommittedReplica|TestInstallCreatesCorrectStructure)$' \
  ./internal/cmd
ok github.com/steveyegge/gastown/internal/cmd
```
