### PR TITLE
fix: keep merge-blocks deps blocked until merge is confirmed (#1893)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -481,6 +481,24 @@ func isBlockingDependencyType(depType string) bool {
 	return blockingDependencyTypes[strings.ToLower(strings.TrimSpace(depType))]
 }
 
+// MergeConfirmed reports whether a close reason means the blocker's code is
+// already on the integration branch. merge-blocks dependencies stay blocking
+// until this is true, so a plain gt-done close cannot dispatch downstream
+// work against an unmerged MR (#1893).
+func MergeConfirmed(closeReason string) bool {
+	reason := strings.TrimSpace(closeReason)
+	switch {
+	case strings.HasPrefix(reason, "Merged in "):
+		return true
+	case strings.Contains(reason, "Direct merge"):
+		return true
+	case strings.Contains(reason, "no code changes"):
+		return true
+	default:
+		return false
+	}
+}
+
 func isResolvedDependency(dep IssueDep) bool {
 	status := strings.ToLower(strings.TrimSpace(dep.Status))
 	switch status {
@@ -488,7 +506,7 @@ func isResolvedDependency(dep IssueDep) bool {
 		return true
 	case "closed":
 		if strings.EqualFold(strings.TrimSpace(dep.DependencyType), "merge-blocks") {
-			return strings.HasPrefix(dep.CloseReason, "Merged in ")
+			return MergeConfirmed(dep.CloseReason)
 		}
 		return true
 	default:

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -270,6 +270,29 @@ func TestIssueDepUnmarshalPreservesNonblockingRelationTypes(t *testing.T) {
 	}
 }
 
+func TestMergeConfirmed(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   bool
+	}{
+		{"", false},
+		{"done", false},
+		{"MR rejected", false},
+		{"Merged in mr-xyz", true},
+		{"Merged in gt-wisp", true},
+		{"Direct merge to main (convoy strategy)", true},
+		{"Direct merge to main (convoy strategy, late detection)", true},
+		{"Completed with no code changes (already fixed or already merged)", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			if got := MergeConfirmed(tt.reason); got != tt.want {
+				t.Fatalf("MergeConfirmed(%q) = %v, want %v", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIssueDepUnmarshalMergeBlocksRequireMergedCloseReason(t *testing.T) {
 	issue := unmarshalIssueForTest(t, `{
 		"id":"gt-target",

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -120,6 +120,32 @@ func TestUnresolvedBlockingDependencyIDs(t *testing.T) {
 			want: []string{"gt-closed-only"},
 		},
 		{
+			name: "merge-blocks gt done close reason stays blocked",
+			deps: []IssueDep{
+				{ID: "gt-done", Status: "closed", DependencyType: "merge-blocks", CloseReason: "done"},
+			},
+			want: []string{"gt-done"},
+		},
+		{
+			name: "merge-blocks rejected MR stays blocked",
+			deps: []IssueDep{
+				{ID: "gt-rejected", Status: "closed", DependencyType: "merge-blocks", CloseReason: "MR rejected"},
+			},
+			want: []string{"gt-rejected"},
+		},
+		{
+			name: "merge-blocks direct merge is satisfied",
+			deps: []IssueDep{
+				{ID: "gt-direct", Status: "closed", DependencyType: "merge-blocks", CloseReason: "Direct merge to main (convoy strategy)"},
+			},
+		},
+		{
+			name: "merge-blocks no code changes is satisfied",
+			deps: []IssueDep{
+				{ID: "gt-noop", Status: "closed", DependencyType: "merge-blocks", CloseReason: "Completed with no code changes (already fixed or already merged)"},
+			},
+		},
+		{
 			name: "nonblocking dependency types do not block",
 			deps: []IssueDep{
 				{ID: "gt-empty", Status: "open"},

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -489,7 +489,7 @@ func (b *Beads) storeReady() ([]*Issue, error) {
 		return nil, fmt.Errorf("store ready: %w", err)
 	}
 
-	return sdkIssuesToIssues(sdkIssues), nil
+	return b.filterReadyIssues(ctx, sdkIssuesToIssues(sdkIssues))
 }
 
 // storeReadyWithFilter implements Ready with a WorkFilter using the in-process store.
@@ -502,7 +502,28 @@ func (b *Beads) storeReadyWithFilter(filter beadsdk.WorkFilter) ([]*Issue, error
 		return nil, fmt.Errorf("store ready: %w", err)
 	}
 
-	return sdkIssuesToIssues(sdkIssues), nil
+	return b.filterReadyIssues(ctx, sdkIssuesToIssues(sdkIssues))
+}
+
+// filterReadyIssues drops issues whose merge-blocks dependencies are not yet
+// merge-confirmed. Beads GetReadyWork does not honor merge-blocks (#1893).
+func (b *Beads) filterReadyIssues(ctx context.Context, issues []*Issue) ([]*Issue, error) {
+	if len(issues) == 0 {
+		return issues, nil
+	}
+
+	ready := make([]*Issue, 0, len(issues))
+	for _, issue := range issues {
+		hydrated, err := b.storeHydrateIssueDetails(ctx, issue)
+		if err != nil {
+			return nil, err
+		}
+		if HasUnresolvedBlockers(hydrated) {
+			continue
+		}
+		ready = append(ready, hydrated)
+	}
+	return ready, nil
 }
 
 // storeBlocked implements Blocked using the in-process store.

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -597,6 +597,51 @@ func TestStoreReady(t *testing.T) {
 	}
 }
 
+func TestStoreReady_MergeBlocksNotReadyUntilMerged(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+
+	store.issues["gt-upstream"] = &beadsdk.Issue{
+		ID:     "gt-upstream",
+		Title:  "closed at gt done",
+		Status: beadsdk.StatusClosed,
+	}
+	store.issues["gt-downstream"] = &beadsdk.Issue{
+		ID:     "gt-downstream",
+		Title:  "merge-blocked downstream",
+		Status: beadsdk.StatusOpen,
+		Dependencies: []*beadsdk.Dependency{
+			{IssueID: "gt-downstream", DependsOnID: "gt-upstream", Type: beadsdk.DependencyType("merge-blocks")},
+		},
+	}
+
+	issues, err := b.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	for _, issue := range issues {
+		if issue.ID == "gt-downstream" {
+			t.Fatalf("Ready() included merge-blocked %s while upstream is closed without merge confirmation", issue.ID)
+		}
+	}
+
+	store.issues["gt-upstream"].CloseReason = "Merged in mr-xyz"
+	issues, err = b.Ready()
+	if err != nil {
+		t.Fatalf("Ready after merge: %v", err)
+	}
+	found := false
+	for _, issue := range issues {
+		if issue.ID == "gt-downstream" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Ready() omitted downstream after merge confirmation")
+	}
+}
+
 func TestStoreUpdate(t *testing.T) {
 	store := newMockStorage()
 	b := newTestBeads(store)

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2615,18 +2615,20 @@ type issueDetails struct {
 }
 
 func (d issueDetails) IsBlocked() bool {
-	if d.BlockedByCount > 0 || len(d.BlockedBy) > 0 {
-		return true
+	issue := &beads.Issue{
+		BlockedBy:      d.BlockedBy,
+		BlockedByCount: d.BlockedByCount,
+		Dependencies:   make([]beads.IssueDep, len(d.Dependencies)),
 	}
-
-	// bd show can omit blocked_by_count; fall back to live dependency edges.
-	for _, dep := range d.Dependencies {
-		if dep.DependencyType == "blocks" && dep.Status != "closed" && dep.Status != "tombstone" {
-			return true
+	for i, dep := range d.Dependencies {
+		issue.Dependencies[i] = beads.IssueDep{
+			ID:             dep.ID,
+			Status:         dep.Status,
+			DependencyType: dep.DependencyType,
+			CloseReason:    dep.CloseReason,
 		}
 	}
-
-	return false
+	return beads.HasUnresolvedBlockers(issue)
 }
 
 // getIssueDetailsBatch fetches details through the central routed beads lookup.
@@ -2702,6 +2704,7 @@ func issueToDetails(issue *beads.Issue) *issueDetails {
 			ID:             dep.ID,
 			Status:         dep.Status,
 			DependencyType: dep.DependencyType,
+			CloseReason:    dep.CloseReason,
 		})
 	}
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2598,6 +2598,7 @@ type issueDependency struct {
 	ID             string `json:"id"`
 	Status         string `json:"status"`
 	DependencyType string `json:"dependency_type"`
+	CloseReason    string `json:"close_reason,omitempty"`
 }
 
 // issueDetails holds basic issue info.

--- a/internal/cmd/convoy_stranded_test.go
+++ b/internal/cmd/convoy_stranded_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestIsReadyIssue_BlockingAndStatus(t *testing.T) {
@@ -148,6 +150,88 @@ func TestIssueDetailsIsBlocked(t *testing.T) {
 			},
 			want: false,
 		},
+		// #1893: merge-blocks stays blocked until merge is confirmed, not merely closed.
+		{
+			name: "open merge-blocks dependency marks blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "open"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "closed merge-blocks without merge confirmation still blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "closed merge-blocks with gt done close reason still blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed", CloseReason: "done"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "rejected merge-blocks stays blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed", CloseReason: "MR rejected"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "merged merge-blocks does not mark blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed", CloseReason: "Merged in mr-xyz"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "direct-merge merge-blocks does not mark blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed", CloseReason: "Direct merge to main (convoy strategy)"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no-code-changes merge-blocks does not mark blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "closed", CloseReason: "Completed with no code changes (already fixed or already merged)"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "tombstone merge-blocks does not mark blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "merge-blocks", Status: "tombstone"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "closed blocks dependency still unblocks (existing semantics)",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "blocks", Status: "closed"},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -157,6 +241,41 @@ func TestIssueDetailsIsBlocked(t *testing.T) {
 				t.Fatalf("IsBlocked() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIssueToDetails_PreservesMergeBlocksCloseReason(t *testing.T) {
+	issue := &beads.Issue{
+		ID:     "gt-downstream",
+		Title:  "Downstream",
+		Status: "open",
+		Type:   "task",
+		Dependencies: []beads.IssueDep{
+			{
+				ID:             "gt-upstream",
+				Status:         "closed",
+				DependencyType: "merge-blocks",
+				CloseReason:    "Merged in mr-xyz",
+			},
+		},
+	}
+
+	details := issueToDetails(issue)
+	if details == nil {
+		t.Fatal("issueToDetails returned nil")
+	}
+	if len(details.Dependencies) != 1 {
+		t.Fatalf("Dependencies len = %d, want 1", len(details.Dependencies))
+	}
+	dep := details.Dependencies[0]
+	if dep.DependencyType != "merge-blocks" {
+		t.Fatalf("DependencyType = %q, want merge-blocks", dep.DependencyType)
+	}
+	if dep.CloseReason != "Merged in mr-xyz" {
+		t.Fatalf("CloseReason = %q, want %q", dep.CloseReason, "Merged in mr-xyz")
+	}
+	if details.IsBlocked() {
+		t.Fatal("issueToDetails should preserve merge confirmation so IsBlocked is false")
 	}
 }
 

--- a/internal/convoy/operations.go
+++ b/internal/convoy/operations.go
@@ -190,9 +190,8 @@ var blockingDepTypes = map[string]bool{
 // dependency targets an issue that is not closed/tombstone.
 //
 // For merge-blocks dependencies, "closed" alone is not sufficient — the
-// blocker must have a CloseReason starting with "Merged in " to confirm
-// that the code was actually integrated. This prevents dispatching work
-// against un-merged code (see #1893).
+// blocker must have a merge-confirmed CloseReason (see beads.MergeConfirmed)
+// so downstream work is not dispatched against un-merged code (#1893).
 //
 // When a StoreResolver is provided, cross-database dependencies are resolved
 // by querying the appropriate rig store for fresh status. Without a resolver,
@@ -234,7 +233,7 @@ func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string, 
 		}
 		if status == "closed" {
 			// For merge-blocks: "closed" alone is not enough — need merge confirmation
-			if depType == "merge-blocks" && !strings.HasPrefix(d.CloseReason, "Merged in ") {
+			if depType == "merge-blocks" && !beads.MergeConfirmed(d.CloseReason) {
 				return true // closed but not merged = still blocked
 			}
 			continue // closed = unblocked for non-merge-blocks
@@ -265,7 +264,7 @@ func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string, 
 				return true // confirmed not closed
 			}
 			// For merge-blocks: check close reason from fresh data
-			if staleCandidateTypes[i] == "merge-blocks" && !strings.HasPrefix(fresh.CloseReason, "Merged in ") {
+			if staleCandidateTypes[i] == "merge-blocks" && !beads.MergeConfirmed(fresh.CloseReason) {
 				return true
 			}
 		}

--- a/internal/convoy/operations_test.go
+++ b/internal/convoy/operations_test.go
@@ -582,6 +582,283 @@ func TestIsIssueBlocked_MergeBlocksUnblockedOnTombstone(t *testing.T) {
 	}
 }
 
+func TestIsIssueBlocked_MergeBlocksDirectMergeUnblocks(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	blocker := &beadsdk.Issue{
+		ID:          "test-mblkr-direct",
+		Title:       "Direct Merged Blocker",
+		Status:      beadsdk.StatusClosed,
+		CloseReason: "Direct merge to main (convoy strategy)",
+		Priority:    2,
+		IssueType:   beadsdk.TypeTask,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	blocked := &beadsdk.Issue{
+		ID:        "test-mblkd-direct",
+		Title:     "Merge-Blocked By Direct Merge",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := store.CreateIssue(ctx, blocker, "test"); err != nil {
+		t.Fatalf("CreateIssue blocker: %v", err)
+	}
+	if err := store.CreateIssue(ctx, blocked, "test"); err != nil {
+		t.Fatalf("CreateIssue blocked: %v", err)
+	}
+	if err := store.AddDependency(ctx, &beadsdk.Dependency{
+		IssueID:     blocked.ID,
+		DependsOnID: blocker.ID,
+		Type:        beadsdk.DependencyType("merge-blocks"),
+		CreatedAt:   now,
+		CreatedBy:   "test",
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	if isIssueBlocked(ctx, store, blocked.ID, nil) {
+		_, metaErr := store.GetDependenciesWithMetadata(ctx, blocked.ID)
+		if metaErr != nil {
+			t.Skipf("GetDependenciesWithMetadata not supported in embedded mode: %v", metaErr)
+		}
+		t.Error("isIssueBlocked should return false when merge-blocks blocker was direct-merged")
+	}
+}
+
+func TestIsIssueBlocked_MergeBlocksNoCodeChangesUnblocks(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	blocker := &beadsdk.Issue{
+		ID:          "test-mblkr-noop",
+		Title:       "No Code Changes Blocker",
+		Status:      beadsdk.StatusClosed,
+		CloseReason: "Completed with no code changes (already fixed or already merged)",
+		Priority:    2,
+		IssueType:   beadsdk.TypeTask,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	blocked := &beadsdk.Issue{
+		ID:        "test-mblkd-noop",
+		Title:     "Merge-Blocked By Noop",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := store.CreateIssue(ctx, blocker, "test"); err != nil {
+		t.Fatalf("CreateIssue blocker: %v", err)
+	}
+	if err := store.CreateIssue(ctx, blocked, "test"); err != nil {
+		t.Fatalf("CreateIssue blocked: %v", err)
+	}
+	if err := store.AddDependency(ctx, &beadsdk.Dependency{
+		IssueID:     blocked.ID,
+		DependsOnID: blocker.ID,
+		Type:        beadsdk.DependencyType("merge-blocks"),
+		CreatedAt:   now,
+		CreatedBy:   "test",
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	if isIssueBlocked(ctx, store, blocked.ID, nil) {
+		_, metaErr := store.GetDependenciesWithMetadata(ctx, blocked.ID)
+		if metaErr != nil {
+			t.Skipf("GetDependenciesWithMetadata not supported in embedded mode: %v", metaErr)
+		}
+		t.Error("isIssueBlocked should return false when merge-blocks blocker completed with no code changes")
+	}
+}
+
+func readyIDs(issues []*beadsdk.Issue) map[string]bool {
+	ids := make(map[string]bool, len(issues))
+	for _, issue := range issues {
+		if issue != nil {
+			ids[issue.ID] = true
+		}
+	}
+	return ids
+}
+
+// TestGetReadyWork_MergeBlocksNotReadyUntilMerged is the #1893 scheduler
+// seam: bd ready / GetReadyWork must not treat gt-done closure as merge.
+func TestGetReadyWork_MergeBlocksNotReadyUntilMerged(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	blocker := &beadsdk.Issue{
+		ID:        "test-ready-a",
+		Title:     "Upstream closed at gt done",
+		Status:    beadsdk.StatusClosed,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	blocked := &beadsdk.Issue{
+		ID:        "test-ready-b",
+		Title:     "Downstream merge-blocked",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := store.CreateIssue(ctx, blocker, "test"); err != nil {
+		t.Fatalf("CreateIssue blocker: %v", err)
+	}
+	if err := store.CreateIssue(ctx, blocked, "test"); err != nil {
+		t.Fatalf("CreateIssue blocked: %v", err)
+	}
+	if err := store.AddDependency(ctx, &beadsdk.Dependency{
+		IssueID:     blocked.ID,
+		DependsOnID: blocker.ID,
+		Type:        beadsdk.DependencyType("merge-blocks"),
+		CreatedAt:   now,
+		CreatedBy:   "test",
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	ready, err := store.GetReadyWork(ctx, beadsdk.WorkFilter{Status: beadsdk.StatusOpen})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	ids := readyIDs(ready)
+	if ids[blocked.ID] {
+		t.Fatalf("GetReadyWork included %s while merge-blocks blocker is closed without merge confirmation; ready=%v", blocked.ID, ids)
+	}
+
+	if err := store.UpdateIssue(ctx, blocker.ID, map[string]interface{}{
+		"close_reason": "Merged in mr-xyz",
+	}, "test"); err != nil {
+		t.Fatalf("UpdateIssue close_reason: %v", err)
+	}
+
+	ready, err = store.GetReadyWork(ctx, beadsdk.WorkFilter{Status: beadsdk.StatusOpen})
+	if err != nil {
+		t.Fatalf("GetReadyWork after merge: %v", err)
+	}
+	ids = readyIDs(ready)
+	if !ids[blocked.ID] {
+		t.Fatalf("GetReadyWork omitted %s after merge confirmation; ready=%v", blocked.ID, ids)
+	}
+}
+
+func TestFeedNextReadyIssue_SkipsMergeBlocksUntilMerged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	convoy := &beadsdk.Issue{
+		ID:        "test-convoy-mb",
+		Title:     "Convoy Merge-Blocks Feed",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	blocker := &beadsdk.Issue{
+		ID:        "test-feed-a",
+		Title:     "Upstream closed at gt done",
+		Status:    beadsdk.StatusClosed,
+		Priority:  1,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	blocked := &beadsdk.Issue{
+		ID:        "test-feed-b",
+		Title:     "Downstream merge-blocked",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	for _, iss := range []*beadsdk.Issue{convoy, blocker, blocked} {
+		if err := store.CreateIssue(ctx, iss, "test"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", iss.ID, err)
+		}
+	}
+	if err := store.AddDependency(ctx, &beadsdk.Dependency{
+		IssueID:     convoy.ID,
+		DependsOnID: blocked.ID,
+		Type:        beadsdk.DependencyType("tracks"),
+		CreatedAt:   now,
+		CreatedBy:   "test",
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency tracks: %v", err)
+	}
+	if err := store.AddDependency(ctx, &beadsdk.Dependency{
+		IssueID:     blocked.ID,
+		DependsOnID: blocker.ID,
+		Type:        beadsdk.DependencyType("merge-blocks"),
+		CreatedAt:   now,
+		CreatedBy:   "test",
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency merge-blocks: %v", err)
+	}
+
+	townRoot := setupTownRoot(t)
+	gtPath, logPath := makeGTStub(t, 0)
+	logger, logMsgs := makeLogger()
+
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
+
+	if _, err := os.ReadFile(logPath); err == nil {
+		t.Fatalf("gt stub should not sling %s while merge-blocks blocker is unmerged; logs=%v", blocked.ID, *logMsgs)
+	}
+
+	if err := store.UpdateIssue(ctx, blocker.ID, map[string]interface{}{
+		"close_reason": "Merged in mr-xyz",
+	}, "test"); err != nil {
+		t.Fatalf("UpdateIssue close_reason: %v", err)
+	}
+
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		_, metaErr := store.GetDependenciesWithMetadata(ctx, blocked.ID)
+		if metaErr != nil {
+			t.Skipf("GetDependenciesWithMetadata not supported in embedded mode: %v", metaErr)
+		}
+		t.Fatalf("gt stub was not called after merge confirmation; logs=%v", *logMsgs)
+	}
+	if !strings.Contains(string(logData), "sling test-feed-b testrig --no-boot") {
+		t.Errorf("expected dispatch of %s after merge, got %q; logs=%v", blocked.ID, string(logData), *logMsgs)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // rigForIssue tests
 // ---------------------------------------------------------------------------

--- a/internal/convoy/operations_test.go
+++ b/internal/convoy/operations_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestExtractIssueID(t *testing.T) {
@@ -686,19 +687,9 @@ func TestIsIssueBlocked_MergeBlocksNoCodeChangesUnblocks(t *testing.T) {
 	}
 }
 
-func readyIDs(issues []*beadsdk.Issue) map[string]bool {
-	ids := make(map[string]bool, len(issues))
-	for _, issue := range issues {
-		if issue != nil {
-			ids[issue.ID] = true
-		}
-	}
-	return ids
-}
-
-// TestGetReadyWork_MergeBlocksNotReadyUntilMerged is the #1893 scheduler
-// seam: bd ready / GetReadyWork must not treat gt-done closure as merge.
-func TestGetReadyWork_MergeBlocksNotReadyUntilMerged(t *testing.T) {
+// TestReady_MergeBlocksNotReadyUntilMerged is the #1893 scheduler seam:
+// gt ready / Beads.Ready must not treat gt-done closure as merge.
+func TestReady_MergeBlocksNotReadyUntilMerged(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -740,13 +731,15 @@ func TestGetReadyWork_MergeBlocksNotReadyUntilMerged(t *testing.T) {
 		t.Fatalf("AddDependency: %v", err)
 	}
 
-	ready, err := store.GetReadyWork(ctx, beadsdk.WorkFilter{Status: beadsdk.StatusOpen})
+	b := beads.NewWithStore(t.TempDir(), store)
+	issues, err := b.Ready()
 	if err != nil {
-		t.Fatalf("GetReadyWork: %v", err)
+		t.Fatalf("Ready: %v", err)
 	}
-	ids := readyIDs(ready)
-	if ids[blocked.ID] {
-		t.Fatalf("GetReadyWork included %s while merge-blocks blocker is closed without merge confirmation; ready=%v", blocked.ID, ids)
+	for _, issue := range issues {
+		if issue.ID == blocked.ID {
+			t.Fatalf("Ready() included %s while merge-blocks blocker is closed without merge confirmation", blocked.ID)
+		}
 	}
 
 	if err := store.UpdateIssue(ctx, blocker.ID, map[string]interface{}{
@@ -755,13 +748,19 @@ func TestGetReadyWork_MergeBlocksNotReadyUntilMerged(t *testing.T) {
 		t.Fatalf("UpdateIssue close_reason: %v", err)
 	}
 
-	ready, err = store.GetReadyWork(ctx, beadsdk.WorkFilter{Status: beadsdk.StatusOpen})
+	issues, err = b.Ready()
 	if err != nil {
-		t.Fatalf("GetReadyWork after merge: %v", err)
+		t.Fatalf("Ready after merge: %v", err)
 	}
-	ids = readyIDs(ready)
-	if !ids[blocked.ID] {
-		t.Fatalf("GetReadyWork omitted %s after merge confirmation; ready=%v", blocked.ID, ids)
+	found := false
+	for _, issue := range issues {
+		if issue.ID == blocked.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Ready() omitted %s after merge confirmation", blocked.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix the remaining Gastown dispatch paths for #1893 so `merge-blocks` dependencies stay blocked when upstream work is closed by `gt done`, and unblock only after merge confirmation.

- Apply shared merge-confirmation semantics to `Beads.Ready()`, stranded scans, and convoy feed.
- Preserve dependency `close_reason` during stranded scans.
- Keep existing dependency-type behavior unchanged.
- Add regression tests for pending, rejected, merged, direct-merge, no-code-change, and tombstoned blockers.

Fixes #1893
