### PR TITLE
fix: Codex polecat session start on pre-existing sandboxes

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -281,7 +281,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 	AgentCodex: {
 		Name:                AgentCodex,
 		Command:             "codex",
-		Args:                []string{"-c", codexUpdateCheckConfig, "--dangerously-bypass-approvals-and-sandbox"},
+		Args:                []string{"-c", codexUpdateCheckConfig, "--dangerously-bypass-approvals-and-sandbox", codexSkipGitRepoCheckFlag},
 		ProcessNames:        []string{"codex"}, // Codex CLI binary
 		SessionIDEnv:        "",                // Codex captures from JSONL output
 		ResumeFlag:          "resume",

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1443,6 +1443,9 @@ func TestCodexRuntimeConfigHasPromptDetection(t *testing.T) {
 	if !strings.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
 		t.Errorf("RuntimeConfigFromPreset(codex).Args = %v, want bypass flag", rc.Args)
 	}
+	if !strings.Contains(args, "--skip-git-repo-check") {
+		t.Errorf("RuntimeConfigFromPreset(codex).Args = %v, want --skip-git-repo-check (GH#4670)", rc.Args)
+	}
 }
 
 func TestPiProviderDefaults(t *testing.T) {

--- a/internal/config/gh4670_codex_args_test.go
+++ b/internal/config/gh4670_codex_args_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH#4670: Codex launch for pre-existing polecat sandboxes dies during
+// startup. The reporter's working manual command used
+// `codex exec --skip-git-repo-check`. This loop asserts what gt actually
+// puts on the Codex argv.
+
+func TestGH4670_CodexStartupCommandIncludesGitRepoCheckBypass(t *testing.T) {
+	t.Parallel()
+
+	rc := RuntimeConfigFromPreset(AgentCodex)
+	cmd := rc.BuildCommandWithPrompt("[GAS TOWN] witness -> polecat/Toast • assigned")
+
+	if !strings.Contains(cmd, "codex") {
+		t.Fatalf("expected codex in startup command, got %q", cmd)
+	}
+	if !strings.Contains(cmd, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("expected yolo flag in startup command, got %q", cmd)
+	}
+
+	// Interactive `codex` (not `codex exec`) still refuses untrusted /
+	// non-git directories unless this flag is present. Fresh sandboxes
+	// happen to be valid trusted worktrees; pre-existing ones often are not.
+	if !strings.Contains(cmd, "--skip-git-repo-check") {
+		t.Fatalf("codex startup command missing --skip-git-repo-check (GH#4670): %q", cmd)
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3781,6 +3781,9 @@ func TestFillRuntimeDefaultsCodexCustomArgsSuppressesUpdateCheck(t *testing.T) {
 	if strings.Count(args, "check_for_update_on_startup") != 1 {
 		t.Fatalf("codex update suppression duplicated: %v", rc.Args)
 	}
+	if !strings.Contains(args, "--skip-git-repo-check") {
+		t.Fatalf("codex custom args missing --skip-git-repo-check: %v", rc.Args)
+	}
 }
 
 func TestFillRuntimeDefaultsCodexDoesNotOverrideExplicitUpdateCheck(t *testing.T) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1042,14 +1042,23 @@ func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
 
 const codexUpdateCheckKey = "check_for_update_on_startup"
 const codexUpdateCheckConfig = codexUpdateCheckKey + "=false"
+const codexSkipGitRepoCheckFlag = "--skip-git-repo-check"
 
 func ensureCodexAutomationArgs(command string, args []string) []string {
-	if !isCodexRuntime(command) || hasCodexUpdateCheckConfig(args) {
+	if !isCodexRuntime(command) {
 		return args
 	}
-	result := make([]string, 0, len(args)+2)
-	result = append(result, "-c", codexUpdateCheckConfig)
-	result = append(result, args...)
+	result := args
+	if !hasCodexUpdateCheckConfig(result) {
+		prefixed := make([]string, 0, len(result)+2)
+		prefixed = append(prefixed, "-c", codexUpdateCheckConfig)
+		result = append(prefixed, result...)
+	}
+	if !hasCodexFlag(result, codexSkipGitRepoCheckFlag) {
+		prefixed := make([]string, 0, len(result)+1)
+		prefixed = append(prefixed, codexSkipGitRepoCheckFlag)
+		result = append(prefixed, result...)
+	}
 	return result
 }
 
@@ -1060,6 +1069,15 @@ func isCodexRuntime(command string) bool {
 func hasCodexUpdateCheckConfig(args []string) bool {
 	for _, arg := range args {
 		if arg == codexUpdateCheckKey || strings.HasPrefix(arg, codexUpdateCheckKey+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCodexFlag(args []string, flag string) bool {
+	for _, arg := range args {
+		if arg == flag {
 			return true
 		}
 	}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	gtgit "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
@@ -457,13 +458,8 @@ func (d *Daemon) getWorkDir(config *beads.RoleConfig, parsed *ParsedIdentity) st
 	case constants.RoleCrew:
 		return filepath.Join(d.config.TownRoot, parsed.RigName, "crew", parsed.AgentName)
 	case constants.RolePolecat:
-		// New structure: polecats/<name>/<rigname>/ (for LLM ergonomics)
-		// Old structure: polecats/<name>/ (for backward compat)
-		newPath := filepath.Join(d.config.TownRoot, parsed.RigName, "polecats", parsed.AgentName, parsed.RigName)
-		if _, err := os.Stat(newPath); err == nil {
-			return newPath
-		}
-		return filepath.Join(d.config.TownRoot, parsed.RigName, "polecats", parsed.AgentName)
+		rigPath := filepath.Join(d.config.TownRoot, parsed.RigName)
+		return polecat.ResolveClonePath(rigPath, parsed.RigName, parsed.AgentName)
 	default:
 		return ""
 	}

--- a/internal/polecat/gh4670_clonepath_test.go
+++ b/internal/polecat/gh4670_clonepath_test.go
@@ -1,0 +1,64 @@
+package polecat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// GH#4670 old-vs-fresh sandbox discriminator: clonePath prefers
+// polecats/<name>/<rigname>/ whenever that directory exists, even if the
+// actual git worktree is the older polecats/<name>/ layout. Codex then
+// starts outside a git repo and exits.
+
+func TestGH4670_ClonePath_OldWorktreeShadowedByNestedDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	rigName := "gastown"
+	name := "Toast"
+
+	oldWorktree := filepath.Join(root, "polecats", name)
+	if err := os.MkdirAll(oldWorktree, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldWorktree, ".git"), []byte("gitdir: /does/not/exist\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested dir named after the rig — either a repo subdirectory or a
+	// half-migrated new-layout folder. Not a git worktree.
+	nested := filepath.Join(oldWorktree, rigName)
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewSessionManager(nil, &rig.Rig{Name: rigName, Path: root})
+	got := m.clonePath(name)
+	if got != oldWorktree {
+		t.Fatalf("clonePath = %q, want old git worktree %q (nested non-git dir %q shadowed it)", got, oldWorktree, nested)
+	}
+}
+
+func TestGH4670_ClonePath_FreshLayout(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	rigName := "gastown"
+	name := "Toast"
+	fresh := filepath.Join(root, "polecats", name, rigName)
+	if err := os.MkdirAll(fresh, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fresh, ".git"), []byte("gitdir: /fresh/worktree\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewSessionManager(nil, &rig.Rig{Name: rigName, Path: root})
+	got := m.clonePath(name)
+	if got != fresh {
+		t.Fatalf("clonePath = %q, want fresh layout %q", got, fresh)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -498,24 +498,7 @@ func (m *Manager) pendingPath(name string) string {
 // New structure: polecats/<name>/<rigname>/ - gives LLMs recognizable repo context.
 // Falls back to old structure: polecats/<name>/ for backward compatibility.
 func (m *Manager) clonePath(name string) string {
-	// New structure: polecats/<name>/<rigname>/
-	newPath := filepath.Join(m.rig.Path, "polecats", name, m.rig.Name)
-	if info, err := os.Stat(newPath); err == nil && info.IsDir() {
-		return newPath
-	}
-
-	// Old structure: polecats/<name>/ (backward compat)
-	oldPath := filepath.Join(m.rig.Path, "polecats", name)
-	if info, err := os.Stat(oldPath); err == nil && info.IsDir() {
-		// Check if this is actually a git worktree (has .git file or dir)
-		gitPath := filepath.Join(oldPath, ".git")
-		if _, err := os.Stat(gitPath); err == nil {
-			return oldPath
-		}
-	}
-
-	// Default to new structure for new polecats
-	return newPath
+	return ResolveClonePath(m.rig.Path, m.rig.Name, name)
 }
 
 // ClonePath returns the path to a polecat's git worktree.

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -154,24 +154,7 @@ func (m *SessionManager) polecatDir(polecat string) string {
 // New structure: polecats/<name>/<rigname>/ - gives LLMs recognizable repo context.
 // Falls back to old structure: polecats/<name>/ for backward compatibility.
 func (m *SessionManager) clonePath(polecat string) string {
-	// New structure: polecats/<name>/<rigname>/
-	newPath := filepath.Join(m.rig.Path, "polecats", polecat, m.rig.Name)
-	if info, err := os.Stat(newPath); err == nil && info.IsDir() {
-		return newPath
-	}
-
-	// Old structure: polecats/<name>/ (backward compat)
-	oldPath := filepath.Join(m.rig.Path, "polecats", polecat)
-	if info, err := os.Stat(oldPath); err == nil && info.IsDir() {
-		// Check if this is actually a git worktree (has .git file or dir)
-		gitPath := filepath.Join(oldPath, ".git")
-		if _, err := os.Stat(gitPath); err == nil {
-			return oldPath
-		}
-	}
-
-	// Default to new structure for new polecats
-	return newPath
+	return ResolveClonePath(m.rig.Path, m.rig.Name, polecat)
 }
 
 // freshBranchName returns a unique branch name for a new polecat session.
@@ -510,18 +493,16 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear
 	debugSession("AcceptStartupDialogs", m.tmux.AcceptStartupDialogs(sessionID))
-	if err := m.tmux.CheckStartupBlocked(sessionID); err != nil {
-		_ = m.tmux.KillSessionWithProcesses(sessionID)
-		return fmt.Errorf("startup blocked: %w", err)
+	if err := m.abortIfStartupFailed(sessionID, "after startup dialogs"); err != nil {
+		return err
 	}
 
 	// Wait for runtime to be fully ready at the prompt (not just started).
 	// Uses prompt-based polling for agents with ReadyPromptPrefix (e.g., Claude "❯ "),
 	// falling back to ReadyDelayMs sleep for agents without prompt detection.
 	debugSession("WaitForRuntimeReady", m.tmux.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout))
-	if err := m.tmux.CheckStartupBlocked(sessionID); err != nil {
-		_ = m.tmux.KillSessionWithProcesses(sessionID)
-		return fmt.Errorf("startup blocked: %w", err)
+	if err := m.abortIfStartupFailed(sessionID, "after runtime ready wait"); err != nil {
+		return err
 	}
 
 	// Handle fallback nudges for non-hook agents.
@@ -573,16 +554,8 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	// Verify session survived startup - if the command crashed, the session may have died.
 	// Without this check, Start() would return success even if the pane died during initialization.
-	running, err = m.tmux.HasSession(sessionID)
-	if err != nil {
-		return fmt.Errorf("verifying session: %w", err)
-	}
-	if !running {
-		return fmt.Errorf("session %s died during startup (agent command may have failed)", sessionID)
-	}
-	if status := m.tmux.CheckSessionHealth(sessionID, 0); status != tmux.SessionHealthy {
-		_ = m.tmux.KillSessionWithProcesses(sessionID)
-		return fmt.Errorf("session %s unhealthy during startup: %s", sessionID, status)
+	if err := m.abortIfStartupFailed(sessionID, "after startup nudges"); err != nil {
+		return err
 	}
 
 	// Validate GT_AGENT is set. Without GT_AGENT, IsAgentAlive falls back to
@@ -617,6 +590,38 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 		"polecat", polecat, sessionID, m.rig.Name, townRoot, opts.Issue, workDir)
 
 	return nil
+}
+
+// abortIfStartupFailed fails fast when the tmux session is gone, the agent
+// process is dead, or a blocking startup modal/error is still visible.
+// Pane output is included so Codex git-repo-check and trust-dialog failures
+// are not lost with the session (GH#4670).
+func (m *SessionManager) abortIfStartupFailed(sessionID, phase string) error {
+	running, err := m.tmux.HasSession(sessionID)
+	if err != nil {
+		return m.abortStartup(sessionID, "verifying session %s: %v", phase, err)
+	}
+	if !running {
+		return m.abortStartup(sessionID, "session %s died during startup (agent command may have failed)", sessionID)
+	}
+	if err := m.tmux.CheckStartupBlocked(sessionID); err != nil {
+		return m.abortStartup(sessionID, "startup blocked: %v", err)
+	}
+	if status := m.tmux.CheckSessionHealth(sessionID, 0); status != tmux.SessionHealthy {
+		return m.abortStartup(sessionID, "session %s unhealthy during startup: %s", sessionID, status)
+	}
+	return nil
+}
+
+func (m *SessionManager) abortStartup(sessionID, format string, args ...any) error {
+	pane, _ := m.tmux.CapturePane(sessionID, 80)
+	_ = m.tmux.KillSessionWithProcesses(sessionID)
+	msg := fmt.Sprintf(format, args...)
+	pane = strings.TrimSpace(pane)
+	if pane != "" {
+		return fmt.Errorf("%s\npane output:\n%s", msg, pane)
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 // isSessionStale checks if a tmux session's pane process has died.

--- a/internal/polecat/worktree.go
+++ b/internal/polecat/worktree.go
@@ -84,3 +84,29 @@ func VerifyWorktreeExists(clonePath string) error {
 
 	return nil
 }
+
+// ResolveClonePath returns the polecat git worktree directory.
+//
+// New layout is polecats/<name>/<rigname>/ and is used only when that path
+// actually contains a .git file or directory. Otherwise we fall back to the
+// old layout polecats/<name>/ when that path is a worktree. Preferring the
+// nested directory merely because it exists (a repo folder named after the
+// rig, or a half-migrated layout) launches the agent outside a git repo —
+// Codex then exits, and gt session start reports "session died during startup"
+// (GH#4670).
+func ResolveClonePath(rigPath, rigName, polecat string) string {
+	newPath := filepath.Join(rigPath, "polecats", polecat, rigName)
+	if hasGitMetadata(newPath) {
+		return newPath
+	}
+	oldPath := filepath.Join(rigPath, "polecats", polecat)
+	if hasGitMetadata(oldPath) {
+		return oldPath
+	}
+	return newPath
+}
+
+func hasGitMetadata(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}

--- a/internal/tmux/dialog_acceptance_test.go
+++ b/internal/tmux/dialog_acceptance_test.go
@@ -242,8 +242,37 @@ Skip until next version`,
 			wantName:    "codex update prompt",
 		},
 		{
-			name:        "codex trust modal",
-			content:     "> You are in /tmp/demo\nDo you trust the contents of this directory?",
+			name:        "codex git repo check error",
+			content:     "Not inside a trusted directory and --skip-git-repo-check was not specified.",
+			wantBlocked: true,
+			wantName:    "codex git repo check",
+		},
+		{
+			// Real Codex TUI from openai/codex#14547. The selector line uses
+			// the same › glyph as Codex's ready prompt. A false-negative here
+			// lets gt session start treat a live trust modal as "ready" and
+			// nudge it, which quits Codex ("No, quit") — GH#4670.
+			name: "codex trust modal with selector",
+			content: `> You are in /tmp/old-polecat
+
+Do you trust the contents of this directory? Working with untrusted
+contents comes with higher risk of prompt injection.
+
+› 1. Yes, continue
+  2. No, quit`,
+			wantBlocked: true,
+			wantName:    "workspace trust prompt",
+		},
+		{
+			// CapturePane sometimes lands the cursor on its own › line after
+			// the question. promptAppearsAfterStartupBlocker currently treats
+			// that as "stale dialog, agent is ready".
+			name: "codex trust modal with lone selector after question",
+			content: `> You are in /tmp/old-polecat
+Do you trust the contents of this directory?
+›
+1. Yes, continue
+2. No, quit`,
 			wantBlocked: true,
 			wantName:    "workspace trust prompt",
 		},

--- a/internal/tmux/gh4670_codex_startup_test.go
+++ b/internal/tmux/gh4670_codex_startup_test.go
@@ -1,0 +1,104 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// GH#4670: after switching the default agent to Codex, `gt session start`
+// reports "session died during startup (agent command may have failed)" for
+// pre-existing polecat sandboxes. Freshly slung sandboxes start. These tests
+// are the diagnosis loop for that symptom.
+
+// Realistic Codex workspace-trust TUI (openai/codex#14547).
+const gh4670CodexTrustTUI = `> You are in /tmp/old-polecat
+
+Do you trust the contents of this directory? Working with untrusted
+contents comes with higher risk of prompt injection.
+
+› 1. Yes, continue
+  2. No, quit`
+
+func TestGH4670_CodexTrustSelectorLooksLikeReadyPrompt(t *testing.T) {
+	t.Parallel()
+
+	prefix := "› "
+	if !matchesPromptPrefix("› 1. Yes, continue", prefix) {
+		t.Fatal("Codex trust selector should match ReadyPromptPrefix › ; if this fails, WaitForRuntimeReady cannot false-trigger on the modal")
+	}
+	if !matchesPromptPrefix("›", prefix) {
+		t.Fatal("lone › line should match ReadyPromptPrefix")
+	}
+	if matchesPromptPrefix("  2. No, quit", prefix) {
+		t.Fatal("option 2 must not match the ready prefix")
+	}
+}
+
+func TestGH4670_CheckStartupBlocked_CodexTrustTUI(t *testing.T) {
+	t.Parallel()
+
+	name, blocked := containsBlockingStartupDialog(gh4670CodexTrustTUI)
+	if !blocked {
+		t.Fatalf("live Codex trust TUI must be treated as blocking, got name=%q blocked=false (promptAppearsAfterStartupBlocker false-negative)", name)
+	}
+	if name != "workspace trust prompt" {
+		t.Fatalf("name = %q, want workspace trust prompt", name)
+	}
+}
+
+func TestGH4670_DelayedAgentExitKeepsSessionForCapture(t *testing.T) {
+	// Codex git-repo-check / trust-quit often takes >250ms. The pane must
+	// remain after that delayed exit so callers can capture the failure
+	// instead of reporting the opaque GH#4670 "session died during startup".
+	tm := newTestTmux(t)
+	session := "gt-test-gh4670-delayexit-" + t.Name()
+	_ = tm.KillSession(session)
+	defer func() { _ = tm.KillSession(session) }()
+
+	err := tm.NewSessionWithCommand(session, "", `sh -c 'sleep 0.4; echo "Not inside a trusted directory and --skip-git-repo-check was not specified."; exit 1'`)
+	if err != nil {
+		t.Fatalf("NewSessionWithCommand returned error for delayed exit (health check window too wide?): %v", err)
+	}
+
+	time.Sleep(800 * time.Millisecond)
+
+	has, hasErr := tm.HasSession(session)
+	if hasErr != nil {
+		t.Fatalf("HasSession: %v", hasErr)
+	}
+	if !has {
+		t.Fatal("session vanished after delayed agent exit; remain-on-exit must stay on so pane output is recoverable")
+	}
+
+	output, _ := tm.CapturePane(session, 50)
+	if !strings.Contains(output, "Not inside a trusted directory") {
+		t.Fatalf("expected git-repo-check error in pane, got %q", strings.TrimSpace(output))
+	}
+}
+
+func TestGH4670_CheckStartupBlocked_LiveCodexTrustPane(t *testing.T) {
+	tm := newTestTmux(t)
+	session := "gt-test-gh4670-trustpane-" + t.Name()
+	_ = tm.KillSession(session)
+	defer func() { _ = tm.KillSession(session) }()
+
+	// Keep the pane alive with cat so remain-on-exit is not the variable.
+	if err := tm.NewSessionWithCommand(session, "", "cat"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := tm.SendKeys(session, gh4670CodexTrustTUI); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	err := tm.CheckStartupBlocked(session)
+	if err == nil {
+		pane, _ := tm.CapturePane(session, 80)
+		t.Fatalf("CheckStartupBlocked returned nil on live Codex trust TUI; startup would proceed to nudge/quit. pane=%q", pane)
+	}
+	if !strings.Contains(err.Error(), "workspace trust prompt") {
+		t.Fatalf("CheckStartupBlocked error = %v, want workspace trust prompt", err)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -486,8 +486,10 @@ func (t *Tmux) checkSessionAfterCreate(name, command string) error {
 		return err
 	}
 
-	// Pane is alive — restore default (no need to keep dead sessions around)
-	_, _ = t.run("set-option", "-t", name, "remain-on-exit", "off")
+	// Keep remain-on-exit on. Agents such as Codex can pass this 250ms window
+	// and then exit (git-repo-check, trust-dialog quit). Turning remain-on-exit
+	// off here destroys the pane before callers can capture the failure —
+	// GH#4670 "session died during startup (agent command may have failed)".
 	return nil
 }
 
@@ -2044,6 +2046,15 @@ func containsWorkspaceTrustDialog(content string) bool {
 }
 
 func containsBlockingStartupDialog(content string) (string, bool) {
+	// Live Codex trust TUIs include a › selector that looks like the ready
+	// prompt. Treat those as blocking before promptAppearsAfterStartupBlocker
+	// can classify them as stale scrollback (GH#4670).
+	if containsWorkspaceTrustDialog(content) && isLiveCodexTrustDialog(content) {
+		return "workspace trust prompt", true
+	}
+	if containsCodexGitRepoCheckError(content) {
+		return "codex git repo check", true
+	}
 	if promptAppearsAfterStartupBlocker(content) {
 		return "", false
 	}
@@ -2057,6 +2068,15 @@ func containsBlockingStartupDialog(content string) (string, bool) {
 		return "bypass permissions prompt", true
 	}
 	return "", false
+}
+
+func isLiveCodexTrustDialog(content string) bool {
+	return strings.Contains(content, "Yes, continue") || strings.Contains(content, "No, quit")
+}
+
+func containsCodexGitRepoCheckError(content string) bool {
+	return strings.Contains(content, "Not inside a trusted directory") &&
+		strings.Contains(content, "--skip-git-repo-check")
 }
 
 func promptAppearsAfterStartupBlocker(content string) bool {


### PR DESCRIPTION
## Summary

Fix Codex polecat sessions failing during startup on pre-existing sandboxes.

- Add Codex's `--skip-git-repo-check` automation flag.
- Resolve old and new polecat worktree layouts by requiring a valid `.git` path.
- Preserve failed tmux panes long enough to capture startup errors.
- Detect Codex trust prompts and repository-check failures as blocked startup.
- Add regression coverage for the affected startup paths.

Fixes #4670
