### PR TITLE
fix: make bare dog dispatch authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,8 +3,12 @@ name: Windows CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,14 @@ and full-suite parallelism — they all pass when isolated:
   `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
 - `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
   shared agent registry). It passes reliably via `go test ./internal/config/`.
+
+### mattpocock/skills
+
+The update script also installs [`mattpocock/skills`](https://github.com/mattpocock/skills) via the
+vercel `skills` CLI (`npx skills@latest add mattpocock/skills --agent cursor --skill '*' -g -y --copy`),
+which lands them under `~/.agents/skills/`. Because the Cursor Cloud agent discovers global skills from
+`~/.cursor/skills-cursor/` (not `~/.cursor/skills`, which is where the `skills` CLI's cursor preset
+points), the update script then mirrors each skill folder into `~/.cursor/skills-cursor/` so they are
+discoverable next session. This is deliberately global (user-level), not project-level, to avoid leaving
+untracked files in the repo working tree. The skills-refresh step is best-effort (`|| true`); a prior
+copy persists in the VM snapshot if the network fetch fails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,3 +183,44 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
+
+---
+
+## Cursor Cloud specific instructions
+
+Gas Town is a Go CLI (`gt`). The environment build already has: Go (base `go1.22.2`, but
+`go.mod` pins `go 1.26.2`, auto-fetched via `GOTOOLCHAIN=auto`), `libicu-dev` (required for the
+`go-icu-regex` CGo dependency), `golangci-lint` v2.11.4, `bd` (beads), and `dolt` v2.0.7. The
+update script runs `go mod download` to refresh module deps after a pull.
+
+### Build / lint / test / run
+
+- Build: `make build` → produces `gt`, `gt-proxy-server`, `gt-proxy-client` at repo root. First
+  build compiles a large dep tree (~1.5 min). `go run ./cmd/gt …` also works.
+- Lint: `golangci-lint run --timeout=5m` (installed at `~/go/bin`).
+  - GOTCHA: `golangci-lint` refuses to run if it was built with an older Go than `go.mod`'s
+    `1.26.2` ("the Go language version go1.25 ... is lower than the targeted Go version 1.26.2").
+    `go install ...@v2.11.4` picks the tool's own toolchain (1.25). It must be built with
+    `GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`.
+    The prebuilt binary in the snapshot is already correct.
+- Test (unit): `go test -short ./...`. Full suite is slow (~15-20 min) because many packages spawn
+  real `git`/`tmux` subprocesses.
+- Integration tests are build-tagged and need Dolt: `go test -tags=integration ./internal/cmd/...`.
+  Some use `internal/testutil` helpers that start Dolt Docker containers and skip gracefully when
+  prerequisites are missing.
+- Run the app: `gt install <path>` creates a town HQ and auto-starts a Dolt SQL server; then
+  `gt status`, `bd create/list/update/close` (beads work ledger), `gt rig add`, etc. `gt` must be on
+  `PATH` for hooks/crew workflows (`cp gt ~/go/bin/` or `make install` → `~/.local/bin`).
+
+### Known environment-induced test failures (NOT code bugs)
+
+Under a full `go test ./...` in the cloud VM, these fail purely due to the VM's global git config
+and full-suite parallelism — they all pass when isolated:
+
+- `internal/git` (`TestConfigurePushURL`, `TestGetPushURL_NoPushURL`, `TestClearPushURL`) and
+  `internal/doctor` (`TestBareRepoExistsCheck_*PushURL*`): the cloud VM injects Cursor-managed
+  `url.https://x-access-token:***@github.com/.insteadOf` rewrites into the global git config, so
+  round-tripped remote URLs don't match. Re-run with a clean config to confirm green, e.g.
+  `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
+- `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
+  shared agent registry). It passes reliably via `go test ./internal/config/`.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,47 @@
+# Coding standards
+
+## Tests
+
+- Strongly prefer integration and end-to-end tests over unit tests when behaviour crosses CLI, process, filesystem, tmux, Git, or Dolt boundaries.
+- Strongly prefer exercising real system behaviour over treating a green test suite as proof that the product works.
+- Mock only third-party services or process boundaries that we cannot control. Do not mock packages or business rules that we own.
+- For command and workflow changes, the default proof is to run the real command against a temporary town or rig and assert exit status, output, and persisted state.
+- Assert results produced by production code. Do not assert values assembled only by test helpers, copied production logic, or mocks configured by the same test.
+- Use `testutil.RequireDoltContainer`, `testutil.StartIsolatedDoltContainer`, or `testutil.RequireTownEnv` when a test needs those resources. Self-contained tests that create their own temporary town do not need an integration guard.
+- Keep concurrency tests deterministic. Synchronize on observable state or explicit test seams instead of sleeps when possible, and run race-sensitive packages with `go test -race ./path/to/package`.
+- Use `make test` as the repository-wide unit-test gate; it includes shell checks before `go test ./...`. Run tagged integration tests for affected command paths and use `make test-e2e-container` for installation or full-workspace behaviour.
+
+## Comments and docs
+
+- Code comments use ASD-STE100 Simplified Technical English: use short direct sentences, one instruction per sentence, and consistent terms.
+- Use established Gas Town domain terms consistently: town, rig, convoy, bead, molecule, wisp, polecat, crew, dog, hook, sling, and refinery. Use "merge request" for Gas Town's refinery queue and "pull request" for GitHub contributions. Do not invent synonyms for existing terms.
+- Do not write comments that only repeat what the code already makes clear. Explain invariants, boundary conditions, compatibility constraints, and non-obvious reasons.
+- Do not put brittle references in comments or docs, such as line numbers, temporary paths, current versions, or "as of today" claims, when those details can change.
+- Update user-facing docs when commands, configuration, output, or operational behaviour changes.
+
+## Common footguns
+
+- Tautological tests that assert a mock was called exactly as the test configured it.
+- Mocks of packages, modules, or services we own.
+- Treating a green suite as proof that a real agent, town, or rig can complete the workflow.
+- Encoding agent judgment in Go: behavioural heuristics and arbitrary decision thresholds belong in agents and formulas. Deterministic protocol rules and safety boundaries can remain in Go.
+- Confusing ephemeral wisps with durable Dolt-backed issues, or assuming every command reads the same Beads database.
+- Swallowing process, tmux, Git, or persistence errors and then reporting success.
+- Using sleeps to hide lifecycle races or relying on goroutine completion order for stable results.
+- Narrating comments, stale README claims, and hard-coded implementation details.
+- Evading complexity or quality gates with denser syntax, hidden branching, or indirection that does not reduce real complexity.
+
+## Go
+
+- Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
+- Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
+- Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.
+- Use existing package boundaries and production seams. Keep Cobra command wiring in `internal/cmd` thin, and put reusable domain behaviour in the relevant `internal` package.
+- Pass `context.Context` through blocking work. Give subprocesses and external operations explicit cancellation or timeouts.
+- Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
+- Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
+- Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
+- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
+- Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -42,6 +42,6 @@
 - Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
 - Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
 - Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
-- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- Run `make build` and `make test` before merging changes that can affect Go behaviour. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour. Markdown-only changes do not require Go builds or tests.
 - For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
 - Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -34,6 +34,8 @@
 ## Go
 
 - Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Production Go code changes should report no violations on the `messgo` rulesets `design`, `codesize`, and `unusedcode`.
+- Production Go code changes should report a covered-MSI of 80% or above from `mutago`.
 - Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
 - Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
 - Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.

--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -97,10 +97,10 @@ A comprehensive catalog of all cleanup-related commands in the gastown/beads eco
 
 | Command | What it does |
 |---------|-------------|
-| `gt dog remove <name>` | Removes worktrees and dog directory |
-| `gt dog remove --all` | Removes all dogs |
-| `gt dog clear <name>` | Resets stuck dog to idle state |
-| `gt dog done [name]` | Marks dog as done, clears work field |
+| `gt dog remove <name>` | Removes worktrees and dog directory. Source-backed bead/formula work must be recovered or completed first. |
+| `gt dog remove --all` | Removes all dogs that are idle or hold only plugin work |
+| `gt dog clear <name>` | Resets stuck plugin work to idle. Source-backed work is refused. |
+| `gt dog done [name]` | Completes work, closes the authoritative source when present, and kills the session only if the dog is still idle |
 
 ## Convoy Cleanup
 

--- a/internal/beads/merge_policy.go
+++ b/internal/beads/merge_policy.go
@@ -1,0 +1,35 @@
+package beads
+
+import "strings"
+
+// ResolveMergeStrategy returns the merge strategy dispatch must honor.
+// An explicit CLI --merge value wins. Otherwise a stored merge_strategy on the
+// issue is reused. Otherwise issue prose that states local-commit-only intent
+// becomes "local". Empty means the default MR path.
+func ResolveMergeStrategy(cliMerge, storedMerge, issueText string) string {
+	if s := strings.TrimSpace(cliMerge); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(storedMerge); s != "" {
+		return s
+	}
+	if IssueTextImpliesLocalMerge(issueText) {
+		return "local"
+	}
+	return ""
+}
+
+// IssueTextImpliesLocalMerge reports whether issue title or description states
+// that the branch must stay local. This is a protocol safety rule for the
+// production phrases in gastownhall/gastown#4512, not agent judgment.
+func IssueTextImpliesLocalMerge(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "local commit only") ||
+		strings.Contains(lower, "do not push") ||
+		strings.Contains(lower, "don't push")
+}
+
+// HasLocalMergeStrategy reports whether attachment fields carry merge_strategy=local.
+func HasLocalMergeStrategy(fields *AttachmentFields) bool {
+	return fields != nil && strings.EqualFold(strings.TrimSpace(fields.MergeStrategy), "local")
+}

--- a/internal/beads/merge_policy.go
+++ b/internal/beads/merge_policy.go
@@ -4,8 +4,8 @@ import "strings"
 
 // ResolveMergeStrategy returns the merge strategy dispatch must honor.
 // An explicit CLI --merge value wins. Otherwise a stored merge_strategy on the
-// issue is reused. Otherwise issue prose that states local-commit-only intent
-// becomes "local". Empty means the default MR path.
+// issue is reused. Otherwise local-commit-only issue text becomes "local".
+// Empty means the default merge-request path.
 func ResolveMergeStrategy(cliMerge, storedMerge, issueText string) string {
 	if s := strings.TrimSpace(cliMerge); s != "" {
 		return s
@@ -21,7 +21,7 @@ func ResolveMergeStrategy(cliMerge, storedMerge, issueText string) string {
 
 // IssueTextImpliesLocalMerge reports whether issue title or description states
 // that the branch must stay local. This is a protocol safety rule for the
-// production phrases in gastownhall/gastown#4512, not agent judgment.
+// production phrases that must not reach a shared remote.
 func IssueTextImpliesLocalMerge(text string) bool {
 	lower := strings.ToLower(text)
 	return strings.Contains(lower, "local commit only") ||
@@ -29,7 +29,12 @@ func IssueTextImpliesLocalMerge(text string) bool {
 		strings.Contains(lower, "don't push")
 }
 
+// IsLocalMergeStrategy reports whether a stored merge strategy value is local.
+func IsLocalMergeStrategy(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "local")
+}
+
 // HasLocalMergeStrategy reports whether attachment fields carry merge_strategy=local.
 func HasLocalMergeStrategy(fields *AttachmentFields) bool {
-	return fields != nil && strings.EqualFold(strings.TrimSpace(fields.MergeStrategy), "local")
+	return fields != nil && IsLocalMergeStrategy(fields.MergeStrategy)
 }

--- a/internal/beads/merge_policy_test.go
+++ b/internal/beads/merge_policy_test.go
@@ -91,4 +91,7 @@ func TestHasLocalMergeStrategy(t *testing.T) {
 	if !HasLocalMergeStrategy(&AttachmentFields{MergeStrategy: " LOCAL "}) {
 		t.Fatal("LOCAL with space should be local")
 	}
+	if !IsLocalMergeStrategy("local") {
+		t.Fatal("IsLocalMergeStrategy(local) = false")
+	}
 }

--- a/internal/beads/merge_policy_test.go
+++ b/internal/beads/merge_policy_test.go
@@ -1,0 +1,94 @@
+package beads
+
+import "testing"
+
+func TestResolveMergeStrategy(t *testing.T) {
+	productionProse := "DO NOT push to GitHub — local commit only"
+
+	tests := []struct {
+		name        string
+		cliMerge    string
+		storedMerge string
+		issueText   string
+		want        string
+	}{
+		{
+			name:     "explicit CLI local wins",
+			cliMerge: "local",
+			want:     "local",
+		},
+		{
+			name:        "CLI wins over stored and prose",
+			cliMerge:    "mr",
+			storedMerge: "local",
+			issueText:   productionProse,
+			want:        "mr",
+		},
+		{
+			name:        "stored local is reused without CLI flag",
+			storedMerge: "local",
+			issueText:   "ordinary work",
+			want:        "local",
+		},
+		{
+			name:        "stored mr is reused without CLI flag",
+			storedMerge: "mr",
+			issueText:   productionProse,
+			want:        "mr",
+		},
+		{
+			name:      "production prose becomes local without CLI or stored field",
+			issueText: productionProse,
+			want:      "local",
+		},
+		{
+			name:      "local commit only phrase",
+			issueText: "Keep this on the machine: local commit only.",
+			want:      "local",
+		},
+		{
+			name:      "do not push phrase",
+			issueText: "Please do not push this branch.",
+			want:      "local",
+		},
+		{
+			name:      "don't push phrase",
+			issueText: "Don't push to origin.",
+			want:      "local",
+		},
+		{
+			name:      "ordinary issue text stays default",
+			issueText: "Fix the login button.",
+			want:      "",
+		},
+		{
+			name:     "whitespace-only CLI is treated as unset",
+			cliMerge: "   ",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveMergeStrategy(tt.cliMerge, tt.storedMerge, tt.issueText)
+			if got != tt.want {
+				t.Fatalf("ResolveMergeStrategy() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasLocalMergeStrategy(t *testing.T) {
+	if HasLocalMergeStrategy(nil) {
+		t.Fatal("nil fields should not be local")
+	}
+	if HasLocalMergeStrategy(&AttachmentFields{MergeStrategy: "mr"}) {
+		t.Fatal("mr should not be local")
+	}
+	if !HasLocalMergeStrategy(&AttachmentFields{MergeStrategy: "local"}) {
+		t.Fatal("local should be local")
+	}
+	if !HasLocalMergeStrategy(&AttachmentFields{MergeStrategy: " LOCAL "}) {
+		t.Fatal("LOCAL with space should be local")
+	}
+}

--- a/internal/cmd/assign.go
+++ b/internal/cmd/assign.go
@@ -160,10 +160,12 @@ func runAssign(_ *cobra.Command, args []string) error {
 		break
 	}
 
-	// Step 3: Update agent hook_bead field (currently a no-op but maintains contract)
+	// Step 3: Update agent hook_bead field so gt hook / gt mol status can find the work.
 	townBeadsDir := filepath.Join(townRoot, ".beads")
 	rigBeadsDir := filepath.Join(townRoot, rigName, ".beads")
-	updateAgentHookBead(agentID, beadID, rigBeadsDir, townBeadsDir)
+	if err := updateAgentHookBead(agentID, beadID, rigBeadsDir, townBeadsDir); err != nil {
+		fmt.Printf("%s Could not update agent hook: %v\n", style.Dim.Render("Warning:"), err)
+	}
 
 	// Step 4: Log event
 	if err := events.LogFeed(events.TypeHook, agentID, events.HookPayload(beadID)); err != nil {

--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -86,7 +86,9 @@ var dogRemoveCmd = &cobra.Command{
 	Long: `Remove one or more dogs from the kennel.
 
 Removes all worktrees and the dog directory.
-Use --force to remove even if dog is in working state.
+Source-backed bead or formula work cannot be removed while assigned.
+Recover or complete that work first; --force only overrides plugin work
+and live-session checks.
 
 Examples:
   gt dog remove alpha
@@ -145,8 +147,10 @@ var dogDoneCmd = &cobra.Command{
 	Long: `Mark a dog as done with its current work and return to idle state.
 
 Dogs should call this when they complete their work assignment.
-This clears the work field and sets state to idle, making the dog
-available for new work.
+Plugin work is cleared from dog state only. Source-backed bead or formula
+work also closes the authoritative hooked source before the dog becomes idle.
+The tmux session is killed only if the dog is still idle after a short delay,
+so a newer assignment is not terminated.
 
 Without a name argument, auto-detects the current dog from the working
 directory (must be run from within a dog's worktree).
@@ -165,6 +169,9 @@ var dogClearCmd = &cobra.Command{
 
 Use this when a dog is stuck in "working" state but its session has died.
 The Deacon uses this during patrol to clear dogs that have timed out.
+
+Plugin work can be cleared from dog state. Source-backed bead or formula
+work cannot; recover or re-sling the source first.
 
 By default, refuses to clear a dog if its tmux session still exists.
 Use --force to clear even if the session is alive.
@@ -714,35 +721,8 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 		if !cleared {
 			return fmt.Errorf("dog %s assignment changed during completion; state preserved", name)
 		}
-	} else {
-		townRoot, err := workspace.FindFromCwd()
-		if err != nil {
-			return fmt.Errorf("finding town for dog completion: %w", err)
-		}
-		source, sourceDir, err := resolveDogAuthoritativeSource(townRoot, d)
-		if err != nil {
-			return err
-		}
-		unlock, err := tryAcquireSlingBeadLock(townRoot, source.ID)
-		if err != nil {
-			return fmt.Errorf("serializing dog completion: %w", err)
-		}
-		defer unlock()
-
-		var completeErr error
-		cleared, err := mgr.ClearWorkIfMatchesAfter(name, d.Work, d.WorkStartedAt, func() bool {
-			completeErr = closeDogAuthoritativeSource(sourceDir, d, source.ID)
-			return completeErr == nil
-		})
-		if completeErr != nil {
-			return completeErr
-		}
-		if err != nil {
-			return fmt.Errorf("clearing completed dog work: %w", err)
-		}
-		if !cleared {
-			return fmt.Errorf("dog %s assignment changed during completion; state preserved", name)
-		}
+	} else if err := completeSourceBackedDogWork(mgr, name, d); err != nil {
+		return err
 	}
 
 	fmt.Printf("✓ Dog %s returned to kennel (idle)\n", name)
@@ -755,26 +735,57 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 	//
 	// We disable remain-on-exit first — otherwise kill-session leaves a
 	// dead pane that the deacon's health-check reports as an orphan.
+	scheduleCompletedDogSessionKill(mgr, name)
+	return nil
+}
+
+func completeSourceBackedDogWork(mgr *dog.Manager, name string, d *dog.Dog) error {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return fmt.Errorf("finding town for dog completion: %w", err)
+	}
+	source, sourceDir, err := resolveDogAuthoritativeSource(townRoot, d)
+	if err != nil {
+		return err
+	}
+	unlock, err := tryAcquireSlingBeadLock(townRoot, source.ID)
+	if err != nil {
+		return fmt.Errorf("serializing dog completion: %w", err)
+	}
+	defer unlock()
+
+	var completeErr error
+	cleared, err := mgr.ClearWorkIfMatchesAfter(name, d.Work, d.WorkStartedAt, func() bool {
+		completeErr = closeDogAuthoritativeSource(sourceDir, d, source.ID)
+		return completeErr == nil
+	})
+	if completeErr != nil {
+		return completeErr
+	}
+	if err != nil {
+		return fmt.Errorf("clearing completed dog work: %w", err)
+	}
+	if !cleared {
+		return fmt.Errorf("dog %s assignment changed during completion; state preserved", name)
+	}
+	return nil
+}
+
+func scheduleCompletedDogSessionKill(mgr *dog.Manager, name string) {
 	sessionID := fmt.Sprintf("hq-dog-%s", name)
 	t := tmux.NewTmux()
 	_ = t.SetRemainOnExit(sessionID, false)
-	fmt.Printf("  Session %s will terminate in 3s\n", sessionID)
+	fmt.Printf("  Session %s will terminate in 3s if still idle\n", sessionID)
 
-	// Kill the tmux session after a short delay using a goroutine.
-	// Previous approach used bash -c "sleep 3 && tmux kill-session" which
-	// fails silently on Windows. The goroutine is cross-platform and uses
-	// the tmux package which handles the socket name automatically.
 	go func() {
 		time.Sleep(3 * time.Second)
-		if err := t.KillSession(sessionID); err != nil {
+		if err := dog.KillCompletedDogSession(mgr, name, sessionID, t.KillSession); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to kill session %s: %v\n", sessionID, err)
 		}
 	}()
 
 	// Wait for the goroutine to finish (the process will exit after kill).
 	time.Sleep(4 * time.Second)
-
-	return nil
 }
 
 func splitPathComponents(path string) []string {

--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -403,14 +404,24 @@ func runDogRemove(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Check if working
+		// Source-backed ownership must be recovered before removal even with
+		// --force; deleting the dog would strand its authoritative hook.
+		if d.State == dog.StateWorking && !dog.CanClearStateOnly(d.Work, d.WorkKind) {
+			removeErrors = append(removeErrors, fmt.Sprintf("%s: has source-backed work %s; recover or complete it before removal", name, d.Work))
+			continue
+		}
 		if d.State == dog.StateWorking && !dogForce {
 			removeErrors = append(removeErrors, fmt.Sprintf("%s: is working (use --force to remove anyway)", name))
 			continue
 		}
 
-		if err := mgr.Remove(name); err != nil {
+		removedMatch, err := mgr.RemoveIfSnapshotMatchesAfter(name, d.Work, d.WorkStartedAt, d.LastActive, nil)
+		if err != nil {
 			removeErrors = append(removeErrors, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		if !removedMatch {
+			removeErrors = append(removeErrors, fmt.Sprintf("%s: assignment changed during removal; retry", name))
 			continue
 		}
 
@@ -627,9 +638,19 @@ func runDogClear(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Clear work and return to idle
-	if err := mgr.ClearWork(name); err != nil {
+	// Source-backed work cannot be cleared independently: doing so would return
+	// the dog to the pool while its bead remains assigned to it.
+	if !dog.CanClearStateOnly(d.Work, d.WorkKind) {
+		return fmt.Errorf("dog %s has source-backed work %s; recover or re-sling the source before clearing the dog", name, d.Work)
+	}
+
+	// Clear only the state-only assignment observed above.
+	cleared, err := mgr.ClearWorkIfMatches(name, d.Work, d.WorkStartedAt)
+	if err != nil {
 		return fmt.Errorf("clearing work for dog %s: %w", name, err)
+	}
+	if !cleared {
+		return fmt.Errorf("dog %s assignment changed during clear; state preserved", name)
 	}
 
 	fmt.Printf("✓ Cleared dog %s (now idle)\n", name)
@@ -685,8 +706,43 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := mgr.ClearWork(name); err != nil {
-		return fmt.Errorf("clearing work for dog %s: %w", name, err)
+	if dog.CanClearStateOnly(d.Work, d.WorkKind) {
+		cleared, err := mgr.ClearWorkIfMatches(name, d.Work, d.WorkStartedAt)
+		if err != nil {
+			return fmt.Errorf("clearing work for dog %s: %w", name, err)
+		}
+		if !cleared {
+			return fmt.Errorf("dog %s assignment changed during completion; state preserved", name)
+		}
+	} else {
+		townRoot, err := workspace.FindFromCwd()
+		if err != nil {
+			return fmt.Errorf("finding town for dog completion: %w", err)
+		}
+		source, sourceDir, err := resolveDogAuthoritativeSource(townRoot, d)
+		if err != nil {
+			return err
+		}
+		unlock, err := tryAcquireSlingBeadLock(townRoot, source.ID)
+		if err != nil {
+			return fmt.Errorf("serializing dog completion: %w", err)
+		}
+		defer unlock()
+
+		var completeErr error
+		cleared, err := mgr.ClearWorkIfMatchesAfter(name, d.Work, d.WorkStartedAt, func() bool {
+			completeErr = closeDogAuthoritativeSource(sourceDir, d, source.ID)
+			return completeErr == nil
+		})
+		if completeErr != nil {
+			return completeErr
+		}
+		if err != nil {
+			return fmt.Errorf("clearing completed dog work: %w", err)
+		}
+		if !cleared {
+			return fmt.Errorf("dog %s assignment changed during completion; state preserved", name)
+		}
 	}
 
 	fmt.Printf("✓ Dog %s returned to kennel (idle)\n", name)
@@ -1148,8 +1204,13 @@ func runDogDispatch(cmd *cobra.Command, args []string) error {
 
 	// Assign work FIRST (before sending mail) to prevent race condition
 	// If this fails, we haven't sent any mail yet
-	if err := mgr.AssignWork(targetDog.Name, workDesc); err != nil {
+	assignedState, err := mgr.AssignWorkIfIdleWithKind(targetDog.Name, workDesc, dog.WorkKindPlugin)
+	if err != nil {
 		return fmt.Errorf("assigning work to dog: %w", err)
+	}
+	clearPluginAssignment := func() error {
+		_, err := mgr.ClearWorkIfMatches(targetDog.Name, workDesc, assignedState.WorkStartedAt)
+		return err
 	}
 
 	// Create and send mail message with plugin instructions
@@ -1168,8 +1229,8 @@ func runDogDispatch(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := router.Send(msg); err != nil {
-		// Rollback: clear work assignment since mail failed
-		if clearErr := mgr.ClearWork(targetDog.Name); clearErr != nil {
+		// Roll back only the assignment this dispatch created.
+		if clearErr := clearPluginAssignment(); clearErr != nil {
 			// Log rollback failure but return original error
 			if !dogDispatchJSON {
 				fmt.Printf("  Warning: rollback failed: %v\n", clearErr)
@@ -1192,7 +1253,7 @@ func runDogDispatch(cmd *cobra.Command, args []string) error {
 		// cannot read its mail, leaving it stuck in StateWorking (zombie).
 		// Clearing work returns it to idle so it can be re-dispatched.
 		// See: github.com/steveyegge/gastown/issues/2748
-		if clearErr := mgr.ClearWork(targetDog.Name); clearErr != nil {
+		if clearErr := clearPluginAssignment(); clearErr != nil {
 			warn := fmt.Sprintf("session start failed AND rollback failed for dog %s — dog stuck in StateWorking, run: gt dog health-check --auto-clear: %v", targetDog.Name, clearErr)
 			result.Warnings = append(result.Warnings, warn)
 			if !dogDispatchJSON {
@@ -1222,7 +1283,7 @@ func runDogDispatch(cmd *cobra.Command, args []string) error {
 			style.PrintWarning("%s", warn)
 		}
 		_ = dogEscalateBestEffort(warn)
-	} else if d.Work != "" {
+	} else if d.Work == workDesc && d.WorkKind == dog.WorkKindPlugin && d.WorkStartedAt.Equal(assignedState.WorkStartedAt) {
 		result.WorkConfirmed = true
 	} else {
 		warn := fmt.Sprintf("dog dispatch: work assignment cleared for %s between dispatch and verify — re-dispatch required", targetDog.Name)
@@ -1252,6 +1313,66 @@ func runDogDispatch(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Dog: %s\n", targetDog.Name)
 	fmt.Printf("  Work: %s\n", workDesc)
 
+	return nil
+}
+
+func resolveDogAuthoritativeSource(townRoot string, d *dog.Dog) (*beads.Issue, string, error) {
+	agentID := fmt.Sprintf("deacon/dogs/%s", d.Name)
+	rigsConfig, err := config.LoadRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"))
+	if err != nil {
+		return nil, "", fmt.Errorf("loading rigs for dog completion: %w", err)
+	}
+	roots := []string{filepath.Join(townRoot, ".beads")}
+	for rigName := range rigsConfig.Rigs {
+		rigDir := beads.GetRigDirForName(townRoot, rigName)
+		if rigDir == "" {
+			rigDir = filepath.Join(townRoot, rigName, "mayor", "rig")
+		}
+		roots = append(roots, rigDir)
+	}
+	for _, root := range roots {
+		work, err := listAssignedActiveWorkAcrossStatuses(beads.New(root), agentID)
+		if err != nil {
+			return nil, "", fmt.Errorf("querying dog source in %s: %w", root, err)
+		}
+		for _, issue := range work {
+			fields := beads.ParseAttachmentFields(issue)
+			formulaMatches := fields != nil && fields.AttachedFormula == d.Work && dogWorksOnHook(d, d.Work, issue)
+			if issue.ID == d.Work || formulaMatches {
+				return issue, root, nil
+			}
+		}
+	}
+	return nil, "", fmt.Errorf("authoritative source for dog %s is missing or no longer assigned", d.Name)
+}
+
+func closeDogAuthoritativeSource(sourceDir string, d *dog.Dog, issueID string) error {
+	agentID := fmt.Sprintf("deacon/dogs/%s", d.Name)
+	bd := beads.New(sourceDir)
+	issue, err := bd.Show(issueID)
+	if err != nil {
+		return fmt.Errorf("reading authoritative source %s: %w", issueID, err)
+	}
+	if issue == nil || issue.Assignee != agentID ||
+		(issue.Status != beads.StatusHooked && issue.Status != string(beads.StatusInProgress)) {
+		return fmt.Errorf("authoritative source %s changed before dog completion", issueID)
+	}
+	fields := beads.ParseAttachmentFields(issue)
+	if fields != nil && fields.AttachedMolecule != "" {
+		if _, err := forceCloseDescendants(bd, fields.AttachedMolecule); err != nil {
+			return fmt.Errorf("closing molecule steps for %s: %w", fields.AttachedMolecule, err)
+		}
+		if err := bd.ForceCloseWithReason("dog done", fields.AttachedMolecule); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			return fmt.Errorf("closing attached molecule %s: %w", fields.AttachedMolecule, err)
+		}
+	} else if d.WorkKind == dog.WorkKindFormula {
+		if _, err := forceCloseDescendants(bd, issue.ID); err != nil {
+			return fmt.Errorf("closing formula steps for %s: %w", issue.ID, err)
+		}
+	}
+	if err := bd.ForceCloseWithReason("dog done", issue.ID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		return fmt.Errorf("closing authoritative source %s: %w", issue.ID, err)
+	}
 	return nil
 }
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2249,6 +2249,73 @@ func isFormulaCompletionBead(id string, issue *beads.Issue) bool {
 	return strings.Contains(id, "-wfs-") || issue != nil && beads.HasLabel(issue, formulaDispatchLabel)
 }
 
+func shouldCloseHookedWorkOnDone(exitType, hookedBeadID, beadsPath string, bd *beads.Beads) bool {
+	if hookedBeadID == "" {
+		return false
+	}
+	if exitType != ExitDeferred {
+		return true
+	}
+	if isFormulaCompletionBead(hookedBeadID, nil) {
+		return true
+	}
+	hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
+	if hookBd == nil {
+		hookBd = bd
+	}
+	hookedBead, err := hookBd.Show(hookedBeadID)
+	if err != nil {
+		style.PrintWarning("could not classify deferred work %s before completion: %v", hookedBeadID, err)
+		return false
+	}
+	return isFormulaCompletionBead(hookedBeadID, hookedBead)
+}
+
+func closeHookedWorkOnDone(hookBd *beads.Beads, hookedBeadID, townRoot, rig string) error {
+	hookedBead, err := hookBd.Show(hookedBeadID)
+	if err != nil || beads.IssueStatus(hookedBead.Status).IsTerminal() {
+		return nil
+	}
+
+	if beads.HasLabel(hookedBead, "gt:rig") {
+		fmt.Fprintf(os.Stderr, "Note: hooked bead %s is a rig identity bead (gt:rig) — skipping close\n", hookedBeadID)
+		return nil
+	}
+
+	if skipReason, fatal := doneSourceCloseSkipReason(hookBd, hookedBeadID, hookedBead); skipReason != "" {
+		style.PrintWarning("%s", skipReason)
+		fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
+		notifyDoneCloseSkipped(townRoot, rig, detectSender(), hookedBeadID, skipReason)
+		if fatal {
+			return fmt.Errorf("cannot complete hooked work: %s", skipReason)
+		}
+		return nil
+	}
+
+	attachment := beads.ParseAttachmentFields(hookedBead)
+	if attachment != nil && attachment.AttachedMolecule != "" {
+		if n := closeDescendants(hookBd, attachment.AttachedMolecule); n > 0 {
+			fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
+		}
+		if closeErr := hookBd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
+			if !errors.Is(closeErr, beads.ErrNotFound) {
+				fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
+				return nil
+			}
+		}
+	}
+
+	if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
+		style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
+		fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
+		return nil
+	}
+	if err := hookBd.Close(hookedBeadID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
+	}
+	return nil
+}
+
 func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
@@ -2323,91 +2390,16 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Workflow step beads (*-wfs-*) and standalone formula dispatch beads are
 	// formula-engine work. For these, DEFERRED means "formula complete, no code
 	// commits" rather than "work paused for resumption". Close them on DEFERRED.
-	isFormulaCompletion := isFormulaCompletionBead(hookedBeadID, nil)
-	if exitType == ExitDeferred && !isFormulaCompletion && hookedBeadID != "" {
-		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
-		hookedBead, err := hookBd.Show(hookedBeadID)
-		if err != nil {
-			return fmt.Errorf("classifying deferred work %s before completion: %w", hookedBeadID, err)
-		}
-		isFormulaCompletion = isFormulaCompletionBead(hookedBeadID, hookedBead)
-	}
-
-	if hookedBeadID != "" && (exitType != ExitDeferred || isFormulaCompletion) {
-		// BUG FIX (gt-pftz): Close hooked bead unless already terminal (closed/tombstone).
-		// Previously checked hookedBead.Status == StatusHooked, but polecats update
-		// their work bead to in_progress during work. The exact-match check caused
-		// gt done to skip closing the bead, leaving it as unassigned open work after
-		// the hook was cleared — triggering infinite dispatch loops.
-		//
-		// DEFERRED exits preserve ordinary work for resumption. Formula workflow
-		// steps and durable standalone-formula dispatch beads are closed — see above.
+	if shouldCloseHookedWorkOnDone(exitType, hookedBeadID, beadsPath, bd) {
 		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
 		if hookBd == nil {
 			hookBd = bd
 		}
-		if hookedBead, err := hookBd.Show(hookedBeadID); err == nil && !beads.IssueStatus(hookedBead.Status).IsTerminal() {
-			// Guard: never close a rig identity bead. Polecats dispatched with the
-			// rig bead as their hook (via mol-polecat-work) must not close permanent
-			// infrastructure. Skip close and fall through to idle state update.
-			if beads.HasLabel(hookedBead, "gt:rig") {
-				fmt.Fprintf(os.Stderr, "Note: hooked bead %s is a rig identity bead (gt:rig) — skipping close\n", hookedBeadID)
-				goto doneStateUpdate
-			}
-
-			if skipReason, fatal := doneSourceCloseSkipReason(hookBd, hookedBeadID, hookedBead); skipReason != "" {
-				style.PrintWarning("%s", skipReason)
-				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
-				if fatal {
-					return fmt.Errorf("cannot complete hooked work: %s", skipReason)
-				}
-				goto doneStateUpdate
-			}
-
-			// BUG FIX: Close attached molecule (wisp) BEFORE closing hooked bead.
-			// When using formula-on-bead (gt sling formula --on bead), the base bead
-			// has attached_molecule pointing to the wisp. Without this fix, gt done
-			// only closed the hooked bead, leaving the wisp orphaned.
-			// Order matters: wisp closes -> unblocks base bead -> base bead closes.
-			attachment := beads.ParseAttachmentFields(hookedBead)
-			if attachment != nil && attachment.AttachedMolecule != "" {
-				// Close molecule step descendants before closing the wisp root.
-				// bd close doesn't cascade — without this, open/in_progress steps
-				// from the molecule stay stuck forever after gt done completes.
-				// Order: step children -> wisp root -> base bead.
-				if n := closeDescendants(hookBd, attachment.AttachedMolecule); n > 0 {
-					fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
-				}
-
-				// Close the wisp root with --force and audit reason.
-				// ForceCloseWithReason handles any status (hooked, open, in_progress)
-				// and records the reason + session for attribution.
-				// Same pattern as gt mol burn/squash (#1879).
-				if closeErr := hookBd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
-					if !errors.Is(closeErr, beads.ErrNotFound) {
-						fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
-						// Don't try to close hookedBeadID - it may still be blocked.
-						// But DO clear hooks and update agent state (goto doneStateUpdate)
-						// so the polecat isn't stuck in 'working' state (za-o9e).
-						goto doneStateUpdate
-					}
-					// Not found = already burned/deleted by another path, continue
-				}
-			}
-
-			// Acceptance criteria gate: skip close if criteria are unchecked.
-			if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
-				style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
-				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-			} else if err := hookBd.Close(hookedBeadID); err != nil {
-				// Non-fatal: warn but continue
-				fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
-			}
+		if err := closeHookedWorkOnDone(hookBd, hookedBeadID, townRoot, ctx.Rig); err != nil {
+			return err
 		}
 	}
 
-doneStateUpdate:
 	// Clear hook_bead on the agent bead (gt-qbh). The hq-l6mm5 refactor made
 	// SetHookBead/ClearHookBead no-ops, but the witness still reads the
 	// hook_bead field from the agent bead snapshot. If the hooked bead is a

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2245,6 +2245,10 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // BUG FIX (hq-3xaxy): This function must be resilient to working directory deletion.
 // If the polecat's worktree is deleted before gt done finishes, we use env vars as fallback.
 // All errors are warnings, not failures - gt done must complete even if bead ops fail.
+func isFormulaCompletionBead(id string, issue *beads.Issue) bool {
+	return strings.Contains(id, "-wfs-") || issue != nil && beads.HasLabel(issue, formulaDispatchLabel)
+}
+
 func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
@@ -2316,21 +2320,28 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 		}
 	}
 
-	// Workflow step beads (*-wfs-*) are ephemeral formula steps managed by the workflow
-	// engine. For these, DEFERRED means "step complete, no code commits" not "work
-	// paused for resumption". Close them on DEFERRED so the convoy can advance.
-	isWorkflowStep := strings.Contains(hookedBeadID, "-wfs-")
+	// Workflow step beads (*-wfs-*) and standalone formula dispatch beads are
+	// formula-engine work. For these, DEFERRED means "formula complete, no code
+	// commits" rather than "work paused for resumption". Close them on DEFERRED.
+	isFormulaCompletion := isFormulaCompletionBead(hookedBeadID, nil)
+	if exitType == ExitDeferred && !isFormulaCompletion && hookedBeadID != "" {
+		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
+		hookedBead, err := hookBd.Show(hookedBeadID)
+		if err != nil {
+			return fmt.Errorf("classifying deferred work %s before completion: %w", hookedBeadID, err)
+		}
+		isFormulaCompletion = isFormulaCompletionBead(hookedBeadID, hookedBead)
+	}
 
-	if hookedBeadID != "" && (exitType != ExitDeferred || isWorkflowStep) {
+	if hookedBeadID != "" && (exitType != ExitDeferred || isFormulaCompletion) {
 		// BUG FIX (gt-pftz): Close hooked bead unless already terminal (closed/tombstone).
 		// Previously checked hookedBead.Status == StatusHooked, but polecats update
 		// their work bead to in_progress during work. The exact-match check caused
 		// gt done to skip closing the bead, leaving it as unassigned open work after
 		// the hook was cleared — triggering infinite dispatch loops.
 		//
-		// DEFERRED exits preserve the bead: work is paused, not done. The bead
-		// stays open/in_progress so it can be resumed on the next session.
-		// Exception: workflow step beads (*-wfs-*) are always closed — see above.
+		// DEFERRED exits preserve ordinary work for resumption. Formula workflow
+		// steps and durable standalone-formula dispatch beads are closed — see above.
 		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
 		if hookBd == nil {
 			hookBd = bd

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -432,6 +432,13 @@ func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Iss
 	return doneSourceCloseSkipReasonForHead(bd, issueID, issue, currentHead)
 }
 
+func doneSkipPushForLocalStrategy(convoyInfo *ConvoyInfo, sourceIssue *beads.Issue) bool {
+	if convoyInfo != nil && strings.EqualFold(strings.TrimSpace(convoyInfo.MergeStrategy), "local") {
+		return true
+	}
+	return beads.HasLocalMergeStrategy(beads.ParseAttachmentFields(sourceIssue))
+}
+
 func doneDirectMergeSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue, targetBranch string) string {
 	if strings.TrimSpace(issueID) == "" {
 		return "source issue is required for direct merge"
@@ -1193,8 +1200,10 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			convoyInfo = getConvoyInfoForIssue(issueID)
 		}
 
-		// Handle "local" strategy: skip push and MR entirely
-		if convoyInfo != nil && convoyInfo.MergeStrategy == "local" {
+		// Handle "local" strategy: skip push and MR entirely.
+		// Check the current convoy and the issue itself so a re-dispatch without
+		// --merge local cannot push a branch that must stay local.
+		if doneSkipPushForLocalStrategy(convoyInfo, sourceIssueForNoMerge) {
 			fmt.Printf("%s Local merge strategy: skipping push and merge queue\n", style.Bold.Render("→"))
 			fmt.Printf("  Branch: %s\n", branch)
 			if issueID != "" {
@@ -1287,14 +1296,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Fprintf(os.Stderr, "  MR beads written here will be invisible to the Refinery — run 'gt polecat repair' to fix\n")
 		}
 		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
-		if attachmentFields := beads.ParseAttachmentFields(sourceIssueForNoMerge); attachmentFields != nil && strings.EqualFold(strings.TrimSpace(attachmentFields.MergeStrategy), "local") {
-			fmt.Printf("%s Local merge strategy: skipping push and merge queue\n", style.Bold.Render("→"))
-			fmt.Printf("  Branch: %s\n", branch)
-			fmt.Printf("  Issue: %s\n", issueID)
-			fmt.Println()
-			fmt.Printf("%s\n", style.Dim.Render("Work stays on local feature branch."))
-			goto notifyWitness
-		}
 
 		// Fallback: check if issue belongs to a direct-merge convoy that the
 		// primary check missed — e.g., issues dispatched before the attachment-field

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -433,10 +433,16 @@ func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Iss
 }
 
 func doneSkipPushForLocalStrategy(convoyInfo *ConvoyInfo, sourceIssue *beads.Issue) bool {
-	if convoyInfo != nil && strings.EqualFold(strings.TrimSpace(convoyInfo.MergeStrategy), "local") {
+	if convoyInfo != nil && beads.IsLocalMergeStrategy(convoyInfo.MergeStrategy) {
 		return true
 	}
-	return beads.HasLocalMergeStrategy(beads.ParseAttachmentFields(sourceIssue))
+	if sourceIssue == nil {
+		return false
+	}
+	if beads.HasLocalMergeStrategy(beads.ParseAttachmentFields(sourceIssue)) {
+		return true
+	}
+	return beads.IssueTextImpliesLocalMerge(sourceIssue.Title + "\n" + sourceIssue.Description)
 }
 
 func doneDirectMergeSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue, targetBranch string) string {

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -911,6 +911,26 @@ func TestShouldNudgeRefinery(t *testing.T) {
 	}
 }
 
+func TestIsFormulaCompletionBead(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		issue *beads.Issue
+		want  bool
+	}{
+		{name: "workflow step", id: "gt-wisp-wfs-abc", want: true},
+		{name: "durable formula dispatch", id: "gt-abc", issue: &beads.Issue{Labels: []string{formulaDispatchLabel}}, want: true},
+		{name: "ordinary deferred work", id: "gt-abc", issue: &beads.Issue{Labels: []string{"gt:task"}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFormulaCompletionBead(tt.id, tt.issue); got != tt.want {
+				t.Fatalf("isFormulaCompletionBead(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldUpdateAgentStateOnDone(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cmd/formula_dispatch_durability_integration_test.go
+++ b/internal/cmd/formula_dispatch_durability_integration_test.go
@@ -1,0 +1,156 @@
+//go:build e2e
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+// TestStandaloneFormulaHookSurvivesCommittedReplica is the GH#4527 feedback
+// loop. Run it inside a resource-capped Docker container; it needs bd, Dolt,
+// and the repository's e2e toolchain.
+func TestStandaloneFormulaHookSurvivesCommittedReplica(t *testing.T) {
+	tmpDir := t.TempDir()
+	hqPath := filepath.Join(tmpDir, "town")
+	env, doltPort := isolatedE2EDoltEnv(t, tmpDir)
+	configureGitIdentity(t, env)
+	configureDoltIdentityForEnv(t, env)
+	testutil.ReapOwnedDoltOnCleanup(t, hqPath)
+
+	gtBinary := buildGT(t)
+	runFormulaDurabilityCmd(t, "", env, gtBinary, "install", hqPath, "--name", "formula-durability", "--git", "--dolt-port", doltPort)
+	t.Cleanup(func() {
+		cmdEnv := append([]string(nil), env...)
+		_ = runFormulaDurabilityCleanupCmd(hqPath, cmdEnv, gtBinary, "dolt", "stop")
+	})
+
+	deaconDir := filepath.Join(hqPath, "deacon")
+	slingEnv := append(append([]string(nil), env...), "GT_ROLE=deacon", "GT_TEST_NO_NUDGE=1")
+	runFormulaDurabilityCmd(t, deaconDir, slingEnv, gtBinary, "sling", "mol-dog-reaper", "--no-boot")
+
+	writerHook := readFormulaHookStatus(t, deaconDir, env, gtBinary, "deacon")
+	if writerHook.BeadID == "" || writerHook.Status != "hooked" {
+		t.Fatalf("writer hook = %+v, want hooked formula work", writerHook)
+	}
+
+	// Push only committed Dolt state to a local remote, then serve a clone as a
+	// second database. This models another machine reading refs/dolt/data rather
+	// than sharing the writer's uncommitted working set.
+	runFormulaDurabilityCmd(t, hqPath, env, gtBinary, "dolt", "stop")
+	remoteDir := filepath.Join(tmpDir, "remote")
+	if err := os.Mkdir(remoteDir, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runFormulaDurabilityCmd(t, remoteDir, env, "dolt", "init")
+
+	hqDatabaseDir := filepath.Join(hqPath, ".dolt-data", "hq")
+	runFormulaDurabilityCmd(t, hqDatabaseDir, env, "dolt", "remote", "add", "durability-test", "file://"+remoteDir)
+	runFormulaDurabilityCmd(t, hqDatabaseDir, env, "dolt", "push", "durability-test", "main")
+
+	runFormulaDurabilityCmd(t, tmpDir, env, "dolt", "clone", "file://"+remoteDir, "reader")
+	readerDatabaseDir := filepath.Join(hqPath, ".dolt-data", "reader")
+	if err := os.Rename(filepath.Join(tmpDir, "reader"), readerDatabaseDir); err != nil {
+		t.Fatalf("move reader database: %v", err)
+	}
+
+	readerTown := filepath.Join(tmpDir, "reader-town")
+	runFormulaDurabilityCmd(t, tmpDir, env, "cp", "-a", hqPath, readerTown)
+	if err := os.RemoveAll(filepath.Join(readerTown, ".dolt-data")); err != nil {
+		t.Fatalf("remove copied Dolt data: %v", err)
+	}
+	setReplicaDatabase(t, filepath.Join(readerTown, ".beads", "metadata.json"), "reader")
+
+	runFormulaDurabilityCmd(t, hqPath, env, gtBinary, "dolt", "start")
+	replicaHook := readFormulaHookStatus(t, filepath.Join(readerTown, "deacon"), env, gtBinary, "deacon")
+	if replicaHook.BeadID != writerHook.BeadID || replicaHook.Status != "hooked" {
+		t.Fatalf("replica hook = %+v, want hooked bead %s from writer", replicaHook, writerHook.BeadID)
+	}
+}
+
+type formulaHookStatus struct {
+	BeadID string `json:"bead_id"`
+	Status string `json:"status"`
+}
+
+func readFormulaHookStatus(t *testing.T, dir string, env []string, gtBinary, agent string) formulaHookStatus {
+	t.Helper()
+	out := runFormulaDurabilityOutputCmd(t, dir, env, gtBinary, "hook", "show", agent, "--json")
+	var status formulaHookStatus
+	if err := json.Unmarshal([]byte(out), &status); err != nil {
+		t.Fatalf("parse hook status: %v\n%s", err, out)
+	}
+	return status
+}
+
+func configureDoltIdentityForEnv(t *testing.T, env []string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"config", "--global", "--add", "user.name", "Test User"},
+		{"config", "--global", "--add", "user.email", "test@test.com"},
+	} {
+		runFormulaDurabilityCmd(t, "", env, "dolt", args...)
+	}
+}
+
+func setReplicaDatabase(t *testing.T, metadataPath, database string) {
+	t.Helper()
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("parse metadata: %v", err)
+	}
+	metadata["dolt_database"] = database
+	data, err = json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(metadataPath, data, 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func runFormulaDurabilityCmd(t *testing.T, dir string, env []string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+	return string(out)
+}
+
+func runFormulaDurabilityOutputCmd(t *testing.T, dir string, env []string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("%s %v failed: %v\n%s", name, args, err, exitErr.Stderr)
+		}
+		t.Fatalf("%s %v failed: %v", name, args, err)
+	}
+	return string(out)
+}
+
+func runFormulaDurabilityCleanupCmd(dir string, env []string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd.Run()
+}

--- a/internal/cmd/formula_dispatch_durability_test.go
+++ b/internal/cmd/formula_dispatch_durability_test.go
@@ -1,0 +1,470 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestShouldReuseExistingFormulaIgnoresLegacyWisps(t *testing.T) {
+	wisp := &beads.Issue{
+		ID:          "gt-wisp-existing",
+		Ephemeral:   true,
+		Labels:      []string{"gt:task"},
+		Description: "attached_formula: mol-anything",
+	}
+	if shouldReuseExistingFormula(wisp, nil, false) {
+		t.Fatal("legacy wisp must not be reused as durable formula dispatch")
+	}
+
+	unlabeled := &beads.Issue{ID: "gt-wisp-unlabeled", Description: "attached_formula: mol-anything"}
+	if shouldReuseExistingFormula(unlabeled, nil, false) {
+		t.Fatal("unlabeled hooked formula must not be reused after the durability fix")
+	}
+
+	durable := &beads.Issue{
+		ID:          "gt-dispatch",
+		Labels:      []string{formulaDispatchLabel},
+		Description: "attached_formula: mol-anything",
+	}
+	if !shouldReuseExistingFormula(durable, nil, false) {
+		t.Fatal("durable formula dispatch should still be reused")
+	}
+}
+
+func TestRunSlingFormulaMigratesLegacyWispToDurableDispatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	_, logPath, attachedLogPath := setupFormulaSlingTown(t, `#!/bin/sh
+set -e
+echo "$PWD|$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook|update)
+    exit 0
+    ;;
+  mol)
+    echo "unexpected new wisp after legacy hook" >&2
+    exit 1
+    ;;
+esac
+exit 0
+`)
+
+	prevFind := findHookedFormulaSingletonFn
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		findHookedFormulaSingletonFn = prevFind
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+
+	slingDryRun = false
+	slingNoBoot = true
+	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
+		return &beads.Issue{
+			ID:          "gt-wisp-existing",
+			Ephemeral:   true,
+			Description: "attached_formula: mol-anything",
+		}, nil
+	}
+
+	var hookedID string
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		hookedID = beadID
+		return nil
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+
+	if hookedID != "gt-dispatch-xyz" {
+		t.Fatalf("hooked %q, want durable dispatch gt-dispatch-xyz", hookedID)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	attachment := string(attachmentBytes)
+	if !strings.Contains(attachment, "attached_molecule: gt-wisp-existing") {
+		t.Fatalf("migrated dispatch must keep the legacy wisp as its molecule:\n%s", attachment)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	log := string(logBytes)
+	if strings.Contains(log, "mol wisp") || strings.Contains(log, "cook ") {
+		t.Fatalf("legacy wisp migration created a new formula instead of promoting the existing wisp:\n%s", log)
+	}
+	if !strings.Contains(log, "update gt-wisp-existing --status=open --assignee=") {
+		t.Fatalf("legacy wisp remained hooked after migration:\n%s", log)
+	}
+}
+
+func TestRunSlingFormulaHooksDurableDispatchNotWisp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	_, _, attachedLogPath := setupFormulaSlingTown(t, `#!/bin/sh
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    echo '{"new_epic_id":"gt-wisp-xyz"}'
+    ;;
+esac
+exit 0
+`)
+
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+	slingDryRun = false
+	slingNoBoot = true
+
+	var hookedID string
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		hookedID = beadID
+		return nil
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+	if hookedID != "gt-dispatch-xyz" {
+		t.Fatalf("hooked %q, want durable dispatch gt-dispatch-xyz", hookedID)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	if !strings.Contains(string(attachmentBytes), "attached_molecule: gt-wisp-xyz") {
+		t.Fatalf("durable dispatch missing molecule pointer:\n%s", attachmentBytes)
+	}
+}
+
+func TestRunSlingFormulaCleansDispatchAndMoleculeOnHookFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot := t.TempDir()
+	setupFormulaSlingWorkspace(t, townRoot)
+	closesLog := filepath.Join(townRoot, "closes.log")
+	writeFormulaSlingBDStub(t, townRoot, fmt.Sprintf(`#!/bin/sh
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    echo '{"new_epic_id":"gt-wisp-xyz"}'
+    ;;
+  show)
+    case "$1" in
+      gt-dispatch-xyz)
+        echo '[{"id":"gt-dispatch-xyz","status":"open","description":"attached_molecule: gt-wisp-xyz"}]'
+        ;;
+      gt-wisp-xyz)
+        echo '[{"id":"gt-wisp-xyz","status":"open","ephemeral":true}]'
+        ;;
+      *)
+        echo '[]'
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+esac
+exit 0
+`, closesLog))
+
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", "")
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	prevHook := hookBeadWithRetryFn
+	prevDryRun, prevNoBoot := slingDryRun, slingNoBoot
+	t.Cleanup(func() {
+		hookBeadWithRetryFn = prevHook
+		slingDryRun, slingNoBoot = prevDryRun, prevNoBoot
+	})
+	slingDryRun = false
+	slingNoBoot = true
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		return errors.New("hook failed")
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err == nil {
+		t.Fatal("expected hook failure")
+	}
+
+	closesBytes, err := os.ReadFile(closesLog)
+	if err != nil {
+		t.Fatalf("expected cleanup closes, got %v", err)
+	}
+	closes := string(closesBytes)
+	if !strings.Contains(closes, "gt-dispatch-xyz") {
+		t.Fatalf("failed sling did not close durable dispatch:\n%s", closes)
+	}
+	if !strings.Contains(closes, "gt-wisp-xyz") {
+		t.Fatalf("failed sling did not close formula molecule:\n%s", closes)
+	}
+}
+
+func TestUpdateAgentStateOnDoneDeferredClosesFormulaDispatchAndMolecule(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot, closesLog := setupFormulaDoneTown(t, `#!/bin/sh
+while [ "$1" = "--allow-stale" ]; do shift; done
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    case "$1" in
+      gt-gastown-polecat-nux)
+        echo '[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","status":"open","agent_state":"working"}]'
+        ;;
+      gt-dispatch-1)
+        echo '[{"id":"gt-dispatch-1","title":"mol-dog-reaper","status":"hooked","labels":["gt:task","gt:formula-dispatch"],"description":"attached_molecule: gt-wisp-xyz"}]'
+        ;;
+      gt-wisp-xyz)
+        echo '[{"id":"gt-wisp-xyz","title":"mol-dog-reaper","status":"open","ephemeral":true}]'
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+  agent|update|slot)
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	if err := updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitDeferred, "gt-dispatch-1"); err != nil {
+		t.Fatalf("updateAgentStateOnDone deferred formula: %v", err)
+	}
+
+	closesBytes, err := os.ReadFile(closesLog)
+	if err != nil {
+		t.Fatalf("expected closes, got %v", err)
+	}
+	closes := string(closesBytes)
+	if !strings.Contains(closes, "gt-dispatch-1") {
+		t.Fatalf("DEFERRED formula completion did not close dispatch bead:\n%s", closes)
+	}
+	if !strings.Contains(closes, "gt-wisp-xyz") {
+		t.Fatalf("DEFERRED formula completion did not close attached molecule:\n%s", closes)
+	}
+}
+
+func TestUpdateAgentStateOnDoneDeferredShowFailureDoesNotFail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	townRoot, closesLog := setupFormulaDoneTown(t, `#!/bin/sh
+while [ "$1" = "--allow-stale" ]; do shift; done
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    case "$1" in
+      gt-gastown-polecat-nux)
+        echo '[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","status":"open","agent_state":"working"}]'
+        ;;
+      gt-ordinary)
+        echo "transient read error" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  list)
+    echo '[]'
+    ;;
+  close)
+    for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
+      echo "$arg" >> "%s"
+    done
+    ;;
+  agent|update|slot)
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	if err := updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitDeferred, "gt-ordinary"); err != nil {
+		t.Fatalf("ordinary DEFERRED completion must stay warning-only on Show failure, got %v", err)
+	}
+	if _, err := os.ReadFile(closesLog); !os.IsNotExist(err) {
+		t.Fatalf("ordinary deferred work was closed after a classification read error")
+	}
+}
+
+func setupFormulaSlingTown(t *testing.T, bdScript string) (townRoot, logPath, attachedLogPath string) {
+	t.Helper()
+	townRoot = t.TempDir()
+	setupFormulaSlingWorkspace(t, townRoot)
+	logPath = filepath.Join(townRoot, "bd.log")
+	attachedLogPath = filepath.Join(townRoot, "attached-molecule.log")
+	writeFormulaSlingBDStub(t, townRoot, bdScript)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return townRoot, logPath, attachedLogPath
+}
+
+func setupFormulaSlingWorkspace(t *testing.T, townRoot string) {
+	t.Helper()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor", "rig"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "bin"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+}
+
+func writeFormulaSlingBDStub(t *testing.T, townRoot, script string) {
+	t.Helper()
+	binDir := filepath.Join(townRoot, "bin")
+	_ = writeBDStub(t, binDir, script, "@echo off\nexit /b 0\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func setupFormulaDoneTown(t *testing.T, bdScript string) (townRoot, closesLog string) {
+	t.Helper()
+	townRoot = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "locks"), 0755); err != nil {
+		t.Fatalf("mkdir .beads/locks: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown"), 0755); err != nil {
+		t.Fatalf("mkdir gastown: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown"}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	closesLog = filepath.Join(townRoot, "closes.log")
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	_ = writeBDStub(t, binDir, fmt.Sprintf(bdScript, closesLog), "@echo off\nexit /b 0\n")
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_ROLE", "polecat")
+	t.Setenv("GT_RIG", "gastown")
+	t.Setenv("GT_POLECAT", "nux")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "gastown")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	return townRoot, closesLog
+}

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -416,7 +416,9 @@ func runHook(_ *cobra.Command, args []string) error {
 
 	// Update agent bead's hook_bead field (matches gt sling behavior)
 	// This ensures gt hook / gt mol status can find hooked work via the agent bead
-	updateAgentHookBead(agentID, beadID, workDir, townBeadsDir)
+	if err := updateAgentHookBead(agentID, beadID, workDir, townBeadsDir); err != nil {
+		fmt.Printf("%s Could not update agent hook: %v\n", style.Dim.Render("Warning:"), err)
+	}
 
 	if targetAgent != "" {
 		fmt.Printf("  Use 'gt hook show %s' to verify\n", targetAgent)

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -96,6 +96,11 @@ func buildAgentBeadID(identity string, role Role, townRoot string) string {
 			return beads.CrewBeadIDWithPrefix(getPrefix(parts[0]), parts[0], parts[2])
 		}
 		return ""
+	case RoleDog:
+		if len(parts) == 3 && parts[0] == "deacon" && parts[1] == "dogs" {
+			return beads.DogBeadIDTown(parts[2])
+		}
+		return ""
 	case RoleBoot:
 		// Boot is a deacon dog — uses town-level dog bead ID
 		return beads.DogBeadIDTown("boot")

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -394,8 +394,8 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Called in a retry loop for polecats to handle Dolt propagation lag.
 	lookupHookedWork := func() *beads.Issue {
 		// Resolve agent bead ID for display purposes only.
-		// Agent bead's hook_bead field is no longer maintained (updateAgentHookBead is
-		// a no-op since hq-l6mm5), so reading it returns stale data. See GH#2371.
+		// Dog dispatch still writes hook_bead onto the agent description so
+		// assignment verification can require hook/source agreement.
 		agentBeadID := buildAgentBeadID(target, roleCtx.Role, townRoot)
 		if agentBeadID != "" {
 			agentBeadPath := beads.ResolveHookDir(townRoot, agentBeadID, workDir)

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -288,8 +288,10 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 		// this watcher. It exits on: delivery, session death, or timeout.
 		// Must be synchronous (not a goroutine) because gt nudge is a CLI
 		// command — the process exits after return, killing any goroutines.
-		watchAndDeliver(t, townRoot, sessionName)
-		return nil
+		// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
+		// must propagate so the CLI does not print ✓ Nudged after the
+		// watcher has already logged a failed delivery. (GH#4666)
+		return watchAndDeliver(t, townRoot, sessionName)
 
 	default: // NudgeModeImmediate
 		opts := tmux.NudgeOpts{TownRoot: townRoot}
@@ -312,15 +314,17 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 // send-keys input, so we cannot rely on it.
 //
 // This runs synchronously — gt nudge blocks until the watcher exits.
-// Errors are logged to stderr rather than returned since delivery failure
-// after successful queue write is non-fatal (queue persists for next drain).
+// Timeout and "someone else drained the queue" are non-errors: the nudge
+// remains queued. A hard delivery error after drain is returned so callers
+// do not report success; drained nudges are requeued first. (GH#4666)
 //
 // Exit conditions:
 //   - Agent becomes idle: drain queue and deliver formatted content, exit.
 //   - Queue is empty (someone else drained it): exit.
 //   - Session disappears: exit (nothing to deliver to).
 //   - Timeout: exit (queue stays for next input or watcher cycle).
-func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
+//   - Delivery fails: requeue drained nudges and return the error.
+func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 	fmt.Fprintf(os.Stderr, "Watching %s for idle (up to %s)...\n", sessionName, idleWatcherTimeout)
 	deadline := time.Now().Add(idleWatcherTimeout)
 	for time.Now().Before(deadline) {
@@ -328,12 +332,12 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
 
 		// If queue is already empty, someone else drained it.
 		if nudge.QueueLen(townRoot, sessionName) == 0 {
-			return
+			return nil
 		}
 
 		// Check if session still exists — no point watching a dead session.
 		if exists, _ := t.HasSession(sessionName); !exists {
-			return
+			return nil
 		}
 
 		// Use WaitForIdle with a short timeout instead of single-snapshot
@@ -346,17 +350,19 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
 			// empty slice and skip delivery to avoid duplicates.
 			drained, _ := nudge.Drain(townRoot, sessionName)
 			if len(drained) == 0 {
-				return
+				return nil
 			}
 			formatted := nudge.FormatForInjection(drained)
 			if err := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot}); err != nil {
 				fmt.Fprintf(os.Stderr, "idle-watcher: delivery for %s failed: %v\n", sessionName, err)
 				requeueDrainedNudges(townRoot, sessionName, "idle-watcher", drained)
+				return err
 			}
-			return
+			return nil
 		}
 	}
 	// Timeout — nudge stays in queue for next watcher or manual drain.
+	return nil
 }
 
 func requeueDrainedNudges(townRoot, sessionName, source string, drained []nudge.QueuedNudge) {

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -156,18 +156,8 @@ var idleWatcherPollInterval = 1 * time.Second
 // For "queue" mode: writes to the nudge queue for cooperative delivery.
 // For "wait-idle" mode: waits for idle, then delivers or falls back to queue.
 func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
-	// Test hook: when GT_TEST_NUDGE_LOG is set, log the nudge instead of
-	// delivering through real tmux/queue transport. Prevents test-suite
-	// runs from delivering "test" messages to live agents (mayor reported
-	// recurring synthetic nudges traced to nudge_test.go invocations).
-	// Mirrors the pattern in sling_helpers.go's nudgeWitness/nudgeRefinery.
-	if logPath := os.Getenv("GT_TEST_NUDGE_LOG"); logPath != "" {
-		entry := fmt.Sprintf("nudge:%s:%s:%s\n", sessionName, sender, message)
-		if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-			_, _ = f.WriteString(entry)
-			_ = f.Close()
-		}
-		return nil
+	if handled, err := logNudgeIfTest(sessionName, sender, message); handled {
+		return err
 	}
 
 	townRoot, _ := workspace.FindFromCwd()
@@ -179,132 +169,167 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 		mode = NudgeModeQueue
 	}
 
-	// For direct tmux delivery, prefix with sender attribution.
-	// Queue-based delivery stores Sender as a separate field and
-	// FormatForInjection adds the prefix, so we must NOT double-prefix.
-	prefixedMessage := fmt.Sprintf("[from %s] %s", sender, message)
-
 	switch mode {
 	case NudgeModeQueue:
 		if townRoot == "" {
 			return fmt.Errorf("--mode=queue requires a Gas Town workspace")
 		}
-		return nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-			Sender:   sender,
-			Message:  message,
-			Priority: nudgePriorityFlag,
-		})
+		return nudge.Enqueue(townRoot, sessionName, queuedNudge(sender, message))
 
 	case NudgeModeWaitIdle:
-		if townRoot == "" {
-			// wait-idle needs workspace for queue fallback — fail explicitly
-			// rather than silently degrading to immediate (destructive) delivery.
-			return fmt.Errorf("--mode=wait-idle requires a Gas Town workspace")
-		}
-		// Check if the target agent supports prompt-based idle detection.
-		// WaitForIdle uses Claude Code's prompt pattern (❯) and status bar (⏵⏵).
-		// Non-Claude agents (Gemini, Codex, etc.) have no ReadyPromptPrefix,
-		// so WaitForIdle produces false positives — it sees no busy indicator
-		// and matches stale prompt characters in the pane buffer. (GH#gt-5ey3)
-		// Degrade to queue mode for agents without prompt-based detection.
-		if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
-			preset := config.GetAgentPresetByName(agentName)
-			if preset != nil && preset.ReadyPromptPrefix == "" {
-				fmt.Fprintf(os.Stderr, "wait-idle: %s agent %q has no prompt detection, using queue mode\n", sessionName, agentName)
-				if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-					Sender:   sender,
-					Message:  message,
-					Priority: nudgePriorityFlag,
-				}); qErr != nil {
-					formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-						Sender:   sender,
-						Message:  message,
-						Priority: nudgePriorityFlag,
-					}})
-					return t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-				}
-				// Ensure a nudge-poller is running so the queue actually drains.
-				// The poller is normally started by gt crew start, but if the
-				// session was started manually (or the poller crashed), queued
-				// nudges sit undelivered forever. StartPoller is idempotent —
-				// it no-ops if a poller is already alive for this session.
-				if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
-					fmt.Fprintf(os.Stderr, "wait-idle: could not start nudge poller for %s: %v\n", sessionName, pollerErr)
-				}
-				return nil
-			}
-		}
-		// Try to wait for idle
-		err := t.WaitForIdle(sessionName, waitIdleTimeout)
-		if err == nil {
-			// Agent is idle — deliver directly. Format as system-reminder
-			// so the agent processes it as a background notification rather
-			// than a user interruption/correction.
-			formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}})
-			deliverErr := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-			if !errors.Is(deliverErr, tmux.ErrSubmitNotVerified) {
-				return deliverErr
-			}
-			fmt.Fprintf(os.Stderr, "wait-idle: %v; queueing for %s\n", deliverErr, sessionName)
-			if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}); qErr != nil {
-				return fmt.Errorf("queue fallback after unverified submit failed: %v (original: %w)", qErr, deliverErr)
-			}
-			return nil
-		}
-		// Terminal errors (session gone, no server) — propagate, don't queue.
-		// Queueing a nudge for a dead session means it will never be delivered.
-		if errors.Is(err, tmux.ErrSessionNotFound) || errors.Is(err, tmux.ErrNoServer) {
-			return fmt.Errorf("wait-idle: %w", err)
-		}
-		// Timeout (agent busy) — queue instead
-		if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-			Sender:   sender,
-			Message:  message,
-			Priority: nudgePriorityFlag,
-		}); qErr != nil {
-			// Queue failed — fall back to immediate as last resort.
-			// Better to interrupt than lose the message entirely.
-			fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
-			// Still use FormatForInjection so the agent sees a consistent
-			// <system-reminder> format regardless of delivery path.
-			formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}})
-			return t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-		}
-		// Run watcher synchronously: polls for idle over a longer window.
-		// The UserPromptSubmit hook drains the queue on agent input, but an
-		// idle agent receives no input — so queued nudges are lost without
-		// this watcher. It exits on: delivery, session death, or timeout.
-		// Must be synchronous (not a goroutine) because gt nudge is a CLI
-		// command — the process exits after return, killing any goroutines.
-		// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
-		// must propagate so the CLI does not print ✓ Nudged after the
-		// watcher has already logged a failed delivery. (GH#4666)
-		return watchAndDeliver(t, townRoot, sessionName)
+		return deliverNudgeWaitIdle(t, townRoot, sessionName, sender, message)
 
 	default: // NudgeModeImmediate
-		opts := tmux.NudgeOpts{TownRoot: townRoot}
-		// Check if the target agent uses Escape as cancel (e.g., Gemini CLI).
-		// For these agents, skip the Escape keystroke to avoid canceling
-		// in-flight generation. (GH#gt-wasn)
-		if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
-			if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
-				opts.SkipEscape = true
-			}
-		}
-		return t.NudgeSessionWithOpts(sessionName, prefixedMessage, opts)
+		return deliverNudgeImmediate(t, townRoot, sessionName, sender, message)
 	}
+}
+
+func logNudgeIfTest(sessionName, sender, message string) (bool, error) {
+	// Test hook: when GT_TEST_NUDGE_LOG is set, log the nudge instead of
+	// delivering through real tmux/queue transport. Prevents test-suite
+	// runs from delivering "test" messages to live agents (mayor reported
+	// recurring synthetic nudges traced to nudge_test.go invocations).
+	// Mirrors the pattern in sling_helpers.go's nudgeWitness/nudgeRefinery.
+	logPath := os.Getenv("GT_TEST_NUDGE_LOG")
+	if logPath == "" {
+		return false, nil
+	}
+	entry := fmt.Sprintf("nudge:%s:%s:%s\n", sessionName, sender, message)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return true, fmt.Errorf("writing test nudge log: %w", err)
+	}
+	_, writeErr := f.WriteString(entry)
+	if closeErr := f.Close(); writeErr != nil {
+		return true, fmt.Errorf("writing test nudge log: %w", writeErr)
+	} else if closeErr != nil {
+		return true, fmt.Errorf("closing test nudge log: %w", closeErr)
+	}
+	return true, nil
+}
+
+func deliverNudgeImmediate(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	// Prefix with sender attribution. Queue-based delivery stores Sender as
+	// a separate field and FormatForInjection adds the prefix, so wait-idle
+	// and queue paths must not double-prefix.
+	prefixedMessage := fmt.Sprintf("[from %s] %s", sender, message)
+	opts := tmux.NudgeOpts{TownRoot: townRoot}
+	// Check if the target agent uses Escape as cancel (e.g., Gemini CLI).
+	// For these agents, skip the Escape keystroke to avoid canceling
+	// in-flight generation. (GH#gt-wasn)
+	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+		if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
+			opts.SkipEscape = true
+		}
+	}
+	return t.NudgeSessionWithOpts(sessionName, prefixedMessage, opts)
+}
+
+func queuedNudge(sender, message string) nudge.QueuedNudge {
+	return nudge.QueuedNudge{
+		Sender:   sender,
+		Message:  message,
+		Priority: nudgePriorityFlag,
+	}
+}
+
+func injectFormatted(t *tmux.Tmux, townRoot, sessionName string, nudges []nudge.QueuedNudge) error {
+	return t.NudgeSessionWithOpts(sessionName, nudge.FormatForInjection(nudges), tmux.NudgeOpts{TownRoot: townRoot})
+}
+
+// deliverNudgeWaitIdle waits for idle, then delivers. On timeout it queues
+// and watches. Queue failure falls back to immediate delivery.
+func deliverNudgeWaitIdle(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	if townRoot == "" {
+		// wait-idle needs workspace for queue fallback — fail explicitly
+		// rather than silently degrading to immediate (destructive) delivery.
+		return fmt.Errorf("--mode=wait-idle requires a Gas Town workspace")
+	}
+	// Check if the target agent supports prompt-based idle detection.
+	// WaitForIdle uses Claude Code's prompt pattern (❯) and status bar (⏵⏵).
+	// Non-Claude agents (Gemini, Codex, etc.) have no ReadyPromptPrefix,
+	// so WaitForIdle produces false positives — it sees no busy indicator
+	// and matches stale prompt characters in the pane buffer. (GH#gt-5ey3)
+	// Degrade to queue mode for agents without prompt-based detection.
+	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+		preset := config.GetAgentPresetByName(agentName)
+		if preset != nil && preset.ReadyPromptPrefix == "" {
+			return queuePromptlessAgent(t, townRoot, sessionName, sender, message, agentName)
+		}
+	}
+	err := t.WaitForIdle(sessionName, waitIdleTimeout)
+	if err == nil {
+		return deliverWaitIdleDirect(t, townRoot, sessionName, sender, message)
+	}
+	// Terminal errors (session gone, no server) — propagate, don't queue.
+	// Queueing a nudge for a dead session means it will never be delivered.
+	if errors.Is(err, tmux.ErrSessionNotFound) || errors.Is(err, tmux.ErrNoServer) {
+		return fmt.Errorf("wait-idle: %w", err)
+	}
+	return queueThenWatch(t, townRoot, sessionName, sender, message)
+}
+
+func queuePromptlessAgent(t *tmux.Tmux, townRoot, sessionName, sender, message, agentName string) error {
+	fmt.Fprintf(os.Stderr, "wait-idle: %s agent %q has no prompt detection, using queue mode\n", sessionName, agentName)
+	item := queuedNudge(sender, message)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		return injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	}
+	// Ensure a nudge-poller is running so the queue actually drains.
+	// The poller is normally started by gt crew start, but if the
+	// session was started manually (or the poller crashed), queued
+	// nudges sit undelivered forever. StartPoller is idempotent —
+	// it no-ops if a poller is already alive for this session.
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
+		fmt.Fprintf(os.Stderr, "wait-idle: could not start nudge poller for %s: %v\n", sessionName, pollerErr)
+	}
+	return nil
+}
+
+func deliverWaitIdleDirect(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	item := queuedNudge(sender, message)
+	deliverErr := injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	if deliverErr == nil {
+		return nil
+	}
+	if errors.Is(deliverErr, tmux.ErrSubmitNotVerified) {
+		fmt.Fprintf(os.Stderr, "wait-idle: %v; queueing for %s\n", deliverErr, sessionName)
+		if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+			return fmt.Errorf("queue fallback after unverified submit failed: %v (original: %w)", qErr, deliverErr)
+		}
+		return nil
+	}
+	// Hard send-keys errors take the same fallback as a wait-idle timeout:
+	// queue first, then immediate if the queue write fails. (GH#4666)
+	fmt.Fprintf(os.Stderr, "wait-idle: delivery for %s failed: %v; queueing\n", sessionName, deliverErr)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
+		if immErr := injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item}); immErr != nil {
+			return fmt.Errorf("wait-idle delivery for session %q: %w (queue failed: %w; immediate fallback: %w)", sessionName, deliverErr, qErr, immErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("wait-idle delivery for session %q: %w", sessionName, deliverErr)
+}
+
+func queueThenWatch(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	item := queuedNudge(sender, message)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		// Queue failed — fall back to immediate as last resort.
+		// Better to interrupt than lose the message entirely.
+		fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
+		return injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	}
+	// Run watcher synchronously: polls for idle over a longer window.
+	// The UserPromptSubmit hook drains the queue on agent input, but an
+	// idle agent receives no input — so queued nudges are lost without
+	// this watcher. It exits on: delivery, session death, or timeout.
+	// Must be synchronous (not a goroutine) because gt nudge is a CLI
+	// command — the process exits after return, killing any goroutines.
+	// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
+	// must propagate so the CLI does not print ✓ Nudged after the
+	// watcher has already logged a failed delivery. (GH#4666)
+	return watchAndDeliver(t, townRoot, sessionName)
 }
 
 // watchAndDeliver polls a session for idle state over idleWatcherTimeout.
@@ -315,15 +340,18 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 //
 // This runs synchronously — gt nudge blocks until the watcher exits.
 // Timeout and "someone else drained the queue" are non-errors: the nudge
-// remains queued. A hard delivery error after drain is returned so callers
-// do not report success; drained nudges are requeued first. (GH#4666)
+// remains queued. A hard delivery error after drain is returned with
+// operation and session context so callers do not report success. Drained
+// nudges are requeued first; if requeue fails, immediate delivery is the
+// last resort. (GH#4666)
 //
 // Exit conditions:
 //   - Agent becomes idle: drain queue and deliver formatted content, exit.
 //   - Queue is empty (someone else drained it): exit.
 //   - Session disappears: exit (nothing to deliver to).
 //   - Timeout: exit (queue stays for next input or watcher cycle).
-//   - Delivery fails: requeue drained nudges and return the error.
+//   - Delivery fails: requeue drained nudges and return a wrapped error.
+//     If requeue also fails, attempt immediate delivery before returning.
 func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 	fmt.Fprintf(os.Stderr, "Watching %s for idle (up to %s)...\n", sessionName, idleWatcherTimeout)
 	deadline := time.Now().Add(idleWatcherTimeout)
@@ -352,11 +380,9 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 			if len(drained) == 0 {
 				return nil
 			}
-			formatted := nudge.FormatForInjection(drained)
-			if err := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot}); err != nil {
+			if err := injectFormatted(t, townRoot, sessionName, drained); err != nil {
 				fmt.Fprintf(os.Stderr, "idle-watcher: delivery for %s failed: %v\n", sessionName, err)
-				requeueDrainedNudges(townRoot, sessionName, "idle-watcher", drained)
-				return err
+				return recoverFailedWatcherDelivery(t, townRoot, sessionName, drained, err)
 			}
 			return nil
 		}
@@ -369,6 +395,18 @@ func requeueDrainedNudges(townRoot, sessionName, source string, drained []nudge.
 	if err := nudge.Requeue(townRoot, sessionName, drained); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: requeue for %s failed: %v\n", source, sessionName, err)
 	}
+}
+
+func recoverFailedWatcherDelivery(t *tmux.Tmux, townRoot, sessionName string, drained []nudge.QueuedNudge, deliverErr error) error {
+	if qErr := nudge.Requeue(townRoot, sessionName, drained); qErr != nil {
+		fmt.Fprintf(os.Stderr, "idle-watcher: requeue for %s failed: %v\n", sessionName, qErr)
+		fmt.Fprintf(os.Stderr, "Warning: requeue failed (%v), delivering immediately\n", qErr)
+		if immErr := injectFormatted(t, townRoot, sessionName, drained); immErr != nil {
+			return fmt.Errorf("idle-watcher delivery for session %q: %w (requeue failed: %w; immediate fallback: %w)", sessionName, deliverErr, qErr, immErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("idle-watcher delivery for session %q: %w", sessionName, deliverErr)
 }
 
 // validNudgeModes is the set of allowed --mode values.

--- a/internal/cmd/nudge_idle_watcher_delivery_test.go
+++ b/internal/cmd/nudge_idle_watcher_delivery_test.go
@@ -1,27 +1,132 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/tmux/tmuxtest"
 )
 
 // TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError replays
 // GH#4666: busy-target wait-idle falls through to the idle-watcher, send-keys
-// then fails with the tmux 3.7b "unknown flag -V" error, and gt still reports
-// success. The loop is red while deliverNudge returns nil after that failure.
+// then fails with the tmux 3.7b "unknown flag -V" error. The contract is that
+// deliverNudge returns that failure with operation and session context, and
+// the drained nudge is requeued.
 func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, time.Millisecond)
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
 	}
+	if !strings.Contains(stderrText, "unknown flag -V") {
+		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
+	}
+
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+	if !strings.Contains(deliverErr.Error(), "idle-watcher") {
+		t.Fatalf("delivery error missing operation context: %v", deliverErr)
+	}
+	if !strings.Contains(deliverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", deliverErr)
+	}
+
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
+	}
+}
+
+// TestDeliverNudge_WaitIdle_DirectSendKeysFailure_QueuesAndReturnsError covers
+// the idle-direct path: WaitForIdle succeeds, send-keys fails, and the hard
+// error must queue then return so the message is not lost and gt does not
+// print success.
+func TestDeliverNudge_WaitIdle_DirectSendKeysFailure_QueuesAndReturnsError(t *testing.T) {
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, 5*time.Second)
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "wait-idle: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected wait-idle delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
+	}
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-direct send-keys failure. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+	if !strings.Contains(deliverErr.Error(), "wait-idle") {
+		t.Fatalf("delivery error missing operation context: %v", deliverErr)
+	}
+	if !strings.Contains(deliverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", deliverErr)
+	}
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the nudge (queue empty)")
+	}
+}
+
+// TestRecoverFailedWatcherDelivery_RequeueFailure_ImmediateFallback covers
+// the issue's last-resort fallback: when watcher delivery fails and requeue
+// also fails, attempt immediate delivery so the drained nudge is not lost.
+func TestRecoverFailedWatcherDelivery_RequeueFailure_ImmediateFallback(t *testing.T) {
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, time.Millisecond)
+	drained := []nudge.QueuedNudge{{
+		Sender:   "test",
+		Message:  "hello from 4666",
+		Priority: nudge.PriorityNormal,
+	}}
+	queueDir := filepath.Join(townRoot, constants.DirRuntime, "nudge_queue", sessionName)
+	if err := os.MkdirAll(queueDir, 0o755); err != nil {
+		t.Fatalf("mkdir queue dir: %v", err)
+	}
+	if err := os.RemoveAll(queueDir); err != nil {
+		t.Fatalf("remove queue dir: %v", err)
+	}
+	if err := os.WriteFile(queueDir, []byte("not-a-directory"), 0o644); err != nil {
+		t.Fatalf("block requeue: %v", err)
+	}
+
+	var recoverErr error
+	stderrText := captureStderr(t, func() {
+		recoverErr = recoverFailedWatcherDelivery(tm, townRoot, sessionName, drained,
+			fmt.Errorf("tmux send-keys: command send-keys: unknown flag -V"))
+	})
+
+	if !strings.Contains(stderrText, "delivering immediately") {
+		t.Fatalf("expected immediate-delivery fallback after requeue failure, stderr=%q err=%v", stderrText, recoverErr)
+	}
+	if recoverErr == nil {
+		t.Fatalf("send-keys still fails on immediate fallback; must not report success. stderr=%q", stderrText)
+	}
+	if !strings.Contains(recoverErr.Error(), "idle-watcher") {
+		t.Fatalf("delivery error missing operation context: %v", recoverErr)
+	}
+	if !strings.Contains(recoverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", recoverErr)
+	}
+	if !strings.Contains(recoverErr.Error(), "requeue failed") {
+		t.Fatalf("delivery error missing requeue failure: %v", recoverErr)
+	}
+}
+
+func setupWaitIdleSendKeysFailure(t *testing.T, waitIdle time.Duration) (townRoot, sessionName string, tm *tmux.Tmux) {
+	t.Helper()
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	origMode := nudgeModeFlag
 	origPriority := nudgePriorityFlag
@@ -40,79 +145,20 @@ func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testin
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_FAIL_SEND_KEYS", "1")
 
-	townRoot := setupTestTownForConfig(t)
+	townRoot = setupTestTownForConfig(t)
 	t.Chdir(townRoot)
 
-	socket := isolatedTmuxSocketName(t)
-	sessionName := "hq-mayor"
-	startIsolatedTmuxSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
+	socket := tmuxtest.SocketName(t, "gt4666-")
+	sessionName = "hq-mayor"
+	tmuxtest.StartSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
 
-	stub := installTmuxStub(t)
-	tm := tmux.NewTmuxWithSocketAndBinary(socket, stub)
+	stub := tmuxtest.InstallStub(t)
+	tm = tmux.NewTmuxWithSocketAndBinary(socket, stub)
 
 	nudgeModeFlag = NudgeModeWaitIdle
 	nudgePriorityFlag = nudge.PriorityNormal
-	// Force the idle-watcher path: the first WaitForIdle cannot complete two
-	// consecutive polls inside 1ms, so wait-idle queues and watchAndDeliver
-	// is the delivery attempt that hits the send-keys failure.
-	waitIdleTimeout = time.Millisecond
+	waitIdleTimeout = waitIdle
 	idleWatcherTimeout = 5 * time.Second
 	idleWatcherPollInterval = 800 * time.Millisecond
-
-	var deliverErr error
-	stderrText := captureStderr(t, func() {
-		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
-	})
-
-	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
-		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
-	}
-	if !strings.Contains(stderrText, "unknown flag -V") {
-		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
-	}
-
-	// User-facing symptom: gt prints ✓ Nudged and exits 0 because this error
-	// is swallowed. The contract is that a hard send-keys failure is not success.
-	if deliverErr == nil {
-		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
-			stderrText, nudge.QueueLen(townRoot, sessionName))
-	}
-
-	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
-		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
-	}
-}
-
-func isolatedTmuxSocketName(t *testing.T) string {
-	t.Helper()
-	return "gt4666-" + strings.ReplaceAll(t.Name(), "/", "-")
-}
-
-func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
-	t.Helper()
-	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("tmux new-session: %v\n%s", err, out)
-	}
-	t.Cleanup(func() {
-		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
-	})
-}
-
-func installTmuxStub(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src := filepath.Join(filepath.Dir(file), "..", "tmux", "testdata", "tmuxstub.sh")
-	data, err := os.ReadFile(src)
-	if err != nil {
-		t.Fatalf("read tmux stub: %v", err)
-	}
-	dst := filepath.Join(t.TempDir(), "tmux")
-	if err := os.WriteFile(dst, data, 0o755); err != nil {
-		t.Fatalf("write tmux stub: %v", err)
-	}
-	return dst
+	return townRoot, sessionName, tm
 }

--- a/internal/cmd/nudge_idle_watcher_delivery_test.go
+++ b/internal/cmd/nudge_idle_watcher_delivery_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError replays
+// GH#4666: busy-target wait-idle falls through to the idle-watcher, send-keys
+// then fails with the tmux 3.7b "unknown flag -V" error, and gt still reports
+// success. The loop is red while deliverNudge returns nil after that failure.
+func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	origMode := nudgeModeFlag
+	origPriority := nudgePriorityFlag
+	origWait := waitIdleTimeout
+	origWatch := idleWatcherTimeout
+	origInterval := idleWatcherPollInterval
+	t.Cleanup(func() {
+		nudgeModeFlag = origMode
+		nudgePriorityFlag = origPriority
+		waitIdleTimeout = origWait
+		idleWatcherTimeout = origWatch
+		idleWatcherPollInterval = origInterval
+	})
+
+	t.Setenv("GT_TEST_NUDGE_LOG", "")
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_FAIL_SEND_KEYS", "1")
+
+	townRoot := setupTestTownForConfig(t)
+	t.Chdir(townRoot)
+
+	socket := isolatedTmuxSocketName(t)
+	sessionName := "hq-mayor"
+	startIsolatedTmuxSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
+
+	stub := installTmuxStub(t)
+	tm := tmux.NewTmuxWithSocketAndBinary(socket, stub)
+
+	nudgeModeFlag = NudgeModeWaitIdle
+	nudgePriorityFlag = nudge.PriorityNormal
+	// Force the idle-watcher path: the first WaitForIdle cannot complete two
+	// consecutive polls inside 1ms, so wait-idle queues and watchAndDeliver
+	// is the delivery attempt that hits the send-keys failure.
+	waitIdleTimeout = time.Millisecond
+	idleWatcherTimeout = 5 * time.Second
+	idleWatcherPollInterval = 800 * time.Millisecond
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
+	}
+	if !strings.Contains(stderrText, "unknown flag -V") {
+		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
+	}
+
+	// User-facing symptom: gt prints ✓ Nudged and exits 0 because this error
+	// is swallowed. The contract is that a hard send-keys failure is not success.
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
+	}
+}
+
+func isolatedTmuxSocketName(t *testing.T) string {
+	t.Helper()
+	return "gt4666-" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+func installTmuxStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "..", "tmux", "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -480,7 +480,7 @@ func TestStandaloneFormulaRigTargetAcquiresSingleAdmission(t *testing.T) {
 		}, nil
 	}
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"test-formula", "gastown"}); err != nil {
@@ -515,7 +515,7 @@ func TestStandaloneFormulaExistingPolecatNoopDoesNotRequireCapacity(t *testing.T
 		return "gastown/polecats/toast", "%1", filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"), nil
 	}
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"test-formula", "gastown/polecats/toast"}); err != nil {

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
 	"github.com/steveyegge/gastown/internal/lock"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/state"
@@ -826,6 +827,20 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	// always has the authoritative .beads/ database. (GH#2503)
 	b := beads.New(rigBeadsRoot(ctx))
 
+	// Dogs are town-level agents, but their source work can belong to any rig.
+	// Search every configured rig before consulting the legacy agent hook. The
+	// source bead's hooked status and assignee are authoritative; a stale agent
+	// hook must not hide a newer assignment in another database. (GH#4516)
+	if ctx.Role == RoleDog {
+		assigned, err := findAssignedDogWork(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		// Dog agent hooks are compatibility metadata, never assignment authority.
+		// Returning here prevents a stale hook from reviving unrelated work.
+		return assigned, nil
+	}
+
 	// Agent bead's hook_bead field. NOTE: updateAgentHookBead was made a no-op
 	// (see sling_helpers.go), so HookBead is typically empty. Kept for backward
 	// compatibility with agent beads that still have hook_bead set.
@@ -839,7 +854,8 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 			hb := beads.New(hookBeadDir)
 			hookBead, showErr := hb.Show(agentBead.HookBead)
 			if showErr == nil && hookBead != nil &&
-				(hookBead.Status == beads.StatusHooked || hookBead.Status == "in_progress") {
+				(hookBead.Status == beads.StatusHooked || hookBead.Status == "in_progress") &&
+				hookBead.Assignee == agentID {
 				return hookBead, nil
 			}
 			// The agent bead names a hook bead but `bd show` cannot find it.
@@ -878,6 +894,93 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 		return nil, nil
 	}
 	return hookedBeads[0], nil
+}
+
+// findAssignedDogWork searches the town and every configured rig for active
+// source beads assigned to a dog. Dogs have worktrees in multiple rigs, so no
+// single local beads database can represent their authoritative hook.
+func findAssignedDogWork(ctx RoleContext, agentID string) (*beads.Issue, error) {
+	if ctx.TownRoot == "" {
+		return nil, nil
+	}
+
+	rigsConfig, err := config.LoadRigsConfig(filepath.Join(ctx.TownRoot, "mayor", "rigs.json"))
+	if err != nil {
+		return nil, fmt.Errorf("loading rigs for dog work lookup: %w", err)
+	}
+
+	mgr := dog.NewManager(ctx.TownRoot, rigsConfig)
+	current, currentErr := mgr.Get(ctx.Polecat)
+	if currentErr != nil && !errors.Is(currentErr, dog.ErrDogNotFound) {
+		return nil, fmt.Errorf("reading dog state: %w", currentErr)
+	}
+	if current != nil && current.State == dog.StateWorking && current.Work != "" &&
+		(current.WorkKind == dog.WorkKindPlugin || (current.WorkKind == "" && strings.HasPrefix(current.Work, "plugin:"))) {
+		// Plugin work is delivered by mail and intentionally has no source hook.
+		return nil, nil
+	}
+	if current != nil && current.State == dog.StateWorking && current.Work != "" && current.WorkKind != dog.WorkKindFormula {
+		// Bare-bead dispatch records the exact source ID in dog state. Resolve it
+		// directly through routes instead of scanning every database.
+		workDir := beads.ResolveHookDir(ctx.TownRoot, current.Work, ctx.WorkDir)
+		if issue, err := beads.New(workDir).Show(current.Work); err == nil && issue != nil &&
+			(issue.Status == beads.StatusHooked || issue.Status == string(beads.StatusInProgress)) &&
+			issue.Assignee == agentID {
+			return issue, nil
+		}
+	}
+
+	roots := []string{filepath.Join(ctx.TownRoot, ".beads")}
+	rigNames := make([]string, 0, len(rigsConfig.Rigs))
+	for rigName := range rigsConfig.Rigs {
+		rigNames = append(rigNames, rigName)
+	}
+	sort.Strings(rigNames)
+	for _, rigName := range rigNames {
+		rigDir := beads.GetRigDirForName(ctx.TownRoot, rigName)
+		if rigDir == "" {
+			// A partially repaired town may not have routes yet, but the standard
+			// rig directory is still a safe, bounded fallback.
+			rigDir = filepath.Join(ctx.TownRoot, rigName, "mayor", "rig")
+		}
+		roots = append(roots, rigDir)
+	}
+
+	var assigned []*beads.Issue
+	var queryErr error
+	for _, root := range roots {
+		work, err := listAssignedActiveWorkAcrossStatuses(beads.New(root), agentID)
+		if err != nil {
+			queryErr = errors.Join(queryErr, fmt.Errorf("querying %s: %w", root, err))
+			continue
+		}
+		if current != nil && current.State == dog.StateWorking && current.Work != "" {
+			for _, issue := range work {
+				fields := beads.ParseAttachmentFields(issue)
+				formulaMatches := fields != nil && fields.AttachedFormula == current.Work &&
+					(current.WorkStartedAt.IsZero() || dogWorksOnHook(current, current.Work, issue))
+				if issue.ID == current.Work || formulaMatches {
+					return issue, nil
+				}
+			}
+		}
+		assigned = append(assigned, work...)
+	}
+	assigned = mergeBeadLists(assigned, nil)
+
+	if current == nil || current.State != dog.StateWorking || current.Work == "" {
+		if len(assigned) > 0 {
+			return nil, fmt.Errorf("dog %s has %d assigned active bead(s) but no matching working state", ctx.Polecat, len(assigned))
+		}
+		if queryErr != nil {
+			return nil, fmt.Errorf("querying dog work: %w", queryErr)
+		}
+		return nil, nil
+	}
+	if queryErr != nil {
+		return nil, fmt.Errorf("querying dog work: %w", queryErr)
+	}
+	return nil, fmt.Errorf("dog %s state names %q but no authoritative assigned hook resolves to it", ctx.Polecat, current.Work)
 }
 
 // rigBeadsRoot returns the route-owned directory to use for beads queries.
@@ -1179,6 +1282,8 @@ func getAgentIdentity(ctx RoleContext) string {
 		return fmt.Sprintf("%s/crew/%s", ctx.Rig, ctx.Polecat)
 	case RolePolecat:
 		return fmt.Sprintf("%s/polecats/%s", ctx.Rig, ctx.Polecat)
+	case RoleDog:
+		return fmt.Sprintf("deacon/dogs/%s", ctx.Polecat)
 	case RoleMayor:
 		return "mayor"
 	case RoleDeacon:

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -914,8 +914,8 @@ func findAssignedDogWork(ctx RoleContext, agentID string) (*beads.Issue, error) 
 	if currentErr != nil && !errors.Is(currentErr, dog.ErrDogNotFound) {
 		return nil, fmt.Errorf("reading dog state: %w", currentErr)
 	}
-	if issue, done, err := resolveDogWorkFromState(ctx, agentID, current); done {
-		return issue, err
+	if issue, done := resolveDogWorkFromState(ctx, agentID, current); done {
+		return issue, nil
 	}
 
 	matched, assigned, queryErr := collectAssignedDogWork(ctx, agentID, current, rigsConfig)
@@ -990,29 +990,30 @@ func matchWorkingDogIssue(current *dog.Dog, work []*beads.Issue) *beads.Issue {
 	return nil
 }
 
-func resolveDogWorkFromState(ctx RoleContext, agentID string, current *dog.Dog) (*beads.Issue, bool, error) {
+func resolveDogWorkFromState(ctx RoleContext, agentID string, current *dog.Dog) (*beads.Issue, bool) {
 	if current == nil || current.State != dog.StateWorking || current.Work == "" {
-		return nil, false, nil
+		return nil, false
 	}
 	if current.WorkKind == dog.WorkKindPlugin || (current.WorkKind == "" && strings.HasPrefix(current.Work, "plugin:")) {
-		return nil, true, nil
+		return nil, true
 	}
 	sourceID := current.WorkSourceID
 	if sourceID == "" && current.WorkKind != dog.WorkKindFormula {
 		sourceID = current.Work
 	}
 	if sourceID == "" {
-		return nil, false, nil
+		return nil, false
 	}
 	workDir := beads.ResolveHookDir(ctx.TownRoot, sourceID, ctx.WorkDir)
 	issue, err := beads.New(workDir).Show(sourceID)
 	if err != nil || issue == nil {
-		return nil, false, nil
+		// Source may live in another beads database; continue the full search.
+		return nil, false
 	}
 	if (issue.Status == beads.StatusHooked || issue.Status == string(beads.StatusInProgress)) && issue.Assignee == agentID {
-		return issue, true, nil
+		return issue, true
 	}
-	return nil, false, nil
+	return nil, false
 }
 
 // rigBeadsRoot returns the route-owned directory to use for beads queries.

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -841,9 +841,9 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 		return assigned, nil
 	}
 
-	// Agent bead's hook_bead field. NOTE: updateAgentHookBead was made a no-op
-	// (see sling_helpers.go), so HookBead is typically empty. Kept for backward
-	// compatibility with agent beads that still have hook_bead set.
+	// Agent bead's hook_bead field. Dog dispatch writes this field so the
+	// agent hook agrees with the hooked source. Other roles still consult it
+	// for backward compatibility.
 	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
 	var staleHookErr error
 	if agentBeadID != "" {
@@ -914,57 +914,13 @@ func findAssignedDogWork(ctx RoleContext, agentID string) (*beads.Issue, error) 
 	if currentErr != nil && !errors.Is(currentErr, dog.ErrDogNotFound) {
 		return nil, fmt.Errorf("reading dog state: %w", currentErr)
 	}
-	if current != nil && current.State == dog.StateWorking && current.Work != "" &&
-		(current.WorkKind == dog.WorkKindPlugin || (current.WorkKind == "" && strings.HasPrefix(current.Work, "plugin:"))) {
-		// Plugin work is delivered by mail and intentionally has no source hook.
-		return nil, nil
-	}
-	if current != nil && current.State == dog.StateWorking && current.Work != "" && current.WorkKind != dog.WorkKindFormula {
-		// Bare-bead dispatch records the exact source ID in dog state. Resolve it
-		// directly through routes instead of scanning every database.
-		workDir := beads.ResolveHookDir(ctx.TownRoot, current.Work, ctx.WorkDir)
-		if issue, err := beads.New(workDir).Show(current.Work); err == nil && issue != nil &&
-			(issue.Status == beads.StatusHooked || issue.Status == string(beads.StatusInProgress)) &&
-			issue.Assignee == agentID {
-			return issue, nil
-		}
+	if issue, done, err := resolveDogWorkFromState(ctx, agentID, current); done {
+		return issue, err
 	}
 
-	roots := []string{filepath.Join(ctx.TownRoot, ".beads")}
-	rigNames := make([]string, 0, len(rigsConfig.Rigs))
-	for rigName := range rigsConfig.Rigs {
-		rigNames = append(rigNames, rigName)
-	}
-	sort.Strings(rigNames)
-	for _, rigName := range rigNames {
-		rigDir := beads.GetRigDirForName(ctx.TownRoot, rigName)
-		if rigDir == "" {
-			// A partially repaired town may not have routes yet, but the standard
-			// rig directory is still a safe, bounded fallback.
-			rigDir = filepath.Join(ctx.TownRoot, rigName, "mayor", "rig")
-		}
-		roots = append(roots, rigDir)
-	}
-
-	var assigned []*beads.Issue
-	var queryErr error
-	for _, root := range roots {
-		work, err := listAssignedActiveWorkAcrossStatuses(beads.New(root), agentID)
-		if err != nil {
-			queryErr = errors.Join(queryErr, fmt.Errorf("querying %s: %w", root, err))
-			continue
-		}
-		if current != nil && current.State == dog.StateWorking && current.Work != "" {
-			for _, issue := range work {
-				fields := beads.ParseAttachmentFields(issue)
-				formulaMatches := fields != nil && fields.AttachedFormula == current.Work &&
-					(current.WorkStartedAt.IsZero() || dogWorksOnHook(current, current.Work, issue))
-				if issue.ID == current.Work || formulaMatches {
-					return issue, nil
-				}
-			}
-		}
-		assigned = append(assigned, work...)
+	matched, assigned, queryErr := collectAssignedDogWork(ctx, agentID, current, rigsConfig)
+	if matched != nil {
+		return matched, nil
 	}
 	assigned = mergeBeadLists(assigned, nil)
 
@@ -981,6 +937,82 @@ func findAssignedDogWork(ctx RoleContext, agentID string) (*beads.Issue, error) 
 		return nil, fmt.Errorf("querying dog work: %w", queryErr)
 	}
 	return nil, fmt.Errorf("dog %s state names %q but no authoritative assigned hook resolves to it", ctx.Polecat, current.Work)
+}
+
+func collectAssignedDogWork(ctx RoleContext, agentID string, current *dog.Dog, rigsConfig *config.RigsConfig) (*beads.Issue, []*beads.Issue, error) {
+	var assigned []*beads.Issue
+	var queryErr error
+	for _, root := range dogWorkLookupRoots(ctx.TownRoot, rigsConfig) {
+		work, err := listAssignedActiveWorkAcrossStatuses(beads.New(root), agentID)
+		if err != nil {
+			queryErr = errors.Join(queryErr, fmt.Errorf("querying %s: %w", root, err))
+			continue
+		}
+		if issue := matchWorkingDogIssue(current, work); issue != nil {
+			return issue, nil, nil
+		}
+		assigned = append(assigned, work...)
+	}
+	return nil, assigned, queryErr
+}
+
+func dogWorkLookupRoots(townRoot string, rigsConfig *config.RigsConfig) []string {
+	roots := []string{filepath.Join(townRoot, ".beads")}
+	rigNames := make([]string, 0, len(rigsConfig.Rigs))
+	for rigName := range rigsConfig.Rigs {
+		rigNames = append(rigNames, rigName)
+	}
+	sort.Strings(rigNames)
+	for _, rigName := range rigNames {
+		rigDir := beads.GetRigDirForName(townRoot, rigName)
+		if rigDir == "" {
+			// A partially repaired town may not have routes yet, but the standard
+			// rig directory is still a safe, bounded fallback.
+			rigDir = filepath.Join(townRoot, rigName, "mayor", "rig")
+		}
+		roots = append(roots, rigDir)
+	}
+	return roots
+}
+
+func matchWorkingDogIssue(current *dog.Dog, work []*beads.Issue) *beads.Issue {
+	if current == nil || current.State != dog.StateWorking || current.Work == "" {
+		return nil
+	}
+	for _, issue := range work {
+		fields := beads.ParseAttachmentFields(issue)
+		formulaMatches := fields != nil && fields.AttachedFormula == current.Work &&
+			(current.WorkStartedAt.IsZero() || dogWorksOnHook(current, current.Work, issue))
+		if issue.ID == current.Work || formulaMatches {
+			return issue
+		}
+	}
+	return nil
+}
+
+func resolveDogWorkFromState(ctx RoleContext, agentID string, current *dog.Dog) (*beads.Issue, bool, error) {
+	if current == nil || current.State != dog.StateWorking || current.Work == "" {
+		return nil, false, nil
+	}
+	if current.WorkKind == dog.WorkKindPlugin || (current.WorkKind == "" && strings.HasPrefix(current.Work, "plugin:")) {
+		return nil, true, nil
+	}
+	sourceID := current.WorkSourceID
+	if sourceID == "" && current.WorkKind != dog.WorkKindFormula {
+		sourceID = current.Work
+	}
+	if sourceID == "" {
+		return nil, false, nil
+	}
+	workDir := beads.ResolveHookDir(ctx.TownRoot, sourceID, ctx.WorkDir)
+	issue, err := beads.New(workDir).Show(sourceID)
+	if err != nil || issue == nil {
+		return nil, false, nil
+	}
+	if (issue.Status == beads.StatusHooked || issue.Status == string(beads.StatusInProgress)) && issue.Assignee == agentID {
+		return issue, true, nil
+	}
+	return nil, false, nil
 }
 
 // rigBeadsRoot returns the route-owned directory to use for beads queries.

--- a/internal/cmd/prime_dog_hook_ownership_test.go
+++ b/internal/cmd/prime_dog_hook_ownership_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// TestFindAgentWorkOnceDogIgnoresLegacyHook covers the other GH-4516 startup
+// outcome: a dog agent bead points at older active work while no source bead
+// matches current dog state. That stale pointer is metadata, not authority.
+func TestGetAgentIdentityDog(t *testing.T) {
+	got := getAgentIdentity(RoleContext{Role: RoleDog, Polecat: "alpha"})
+	if got != "deacon/dogs/alpha" {
+		t.Fatalf("getAgentIdentity(dog alpha) = %q, want deacon/dogs/alpha", got)
+	}
+}
+
+func TestFindAgentWorkOnceDogIgnoresLegacyHook(t *testing.T) {
+	townRoot := t.TempDir()
+	dogDir := filepath.Join(townRoot, "deacon", "dogs", "alpha")
+	for _, dir := range []string{dogDir, filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), &config.RigsConfig{
+		Version: 1,
+		Rigs:    map[string]config.RigEntry{},
+	}); err != nil {
+		t.Fatalf("save rigs config: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	bdScript := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    hq-dog-alpha)
+      echo '[{"id":"hq-dog-alpha","title":"Dog alpha","status":"open","hook_bead":"gt-old"}]'
+      exit 0
+      ;;
+    gt-old)
+      echo '[{"id":"gt-old","title":"Older dog work","status":"hooked","assignee":"deacon/dogs/alpha"}]'
+      exit 0
+      ;;
+    list) echo '[]'; exit 0 ;;
+  esac
+done
+echo '[]'
+`
+	writeBDStub(t, binDir, bdScript, "@echo off\necho []\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := findAgentWorkOnce(RoleContext{
+		Role:     RoleDog,
+		Polecat:  "alpha",
+		TownRoot: townRoot,
+		WorkDir:  dogDir,
+	}, "deacon/dogs/alpha")
+	if err != nil {
+		t.Fatalf("findAgentWorkOnce: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("findAgentWorkOnce returned stale legacy hook %s; want no authoritative dog work", got.ID)
+	}
+}

--- a/internal/cmd/prime_dog_hook_test.go
+++ b/internal/cmd/prime_dog_hook_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+// TestFindAgentWorkOnceDogPrefersAssignedRigBead reproduces GH-4516: a dog
+// can retain an unrelated legacy hook while a newly slung rig bead is hooked
+// and assigned to it. The source bead is authoritative and must win even
+// though dogs are town-level agents and the source lives in a rig database.
+func TestFindAgentWorkOnceDogPrefersAssignedRigBead(t *testing.T) {
+	townRoot := t.TempDir()
+	dogDir := filepath.Join(townRoot, "deacon", "dogs", "alpha")
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	for _, dir := range []string{dogDir, rigDir, filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	rigs := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{
+		"gastown": {
+			GitURL:  "file:///tmp/gastown.git",
+			AddedAt: time.Unix(1, 0).UTC(),
+			BeadsConfig: &config.BeadsConfig{
+				Repo:   "local",
+				Prefix: "gt-",
+			},
+		},
+	}}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), rigs); err != nil {
+		t.Fatalf("save rigs config: %v", err)
+	}
+	startedAt := time.Date(2026, 7, 17, 5, 0, 0, 0, time.UTC)
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "gt-new",
+		WorkKind:      dog.WorkKindBead,
+		WorkStartedAt: startedAt,
+		LastActive:    startedAt,
+		CreatedAt:     startedAt.Add(-time.Hour),
+		UpdatedAt:     startedAt,
+	})
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	bdScript := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    hq-dog-alpha)
+      echo '[{"id":"hq-dog-alpha","title":"Dog alpha","status":"open","hook_bead":"gt-old"}]'
+      exit 0
+      ;;
+    gt-old)
+      echo '[{"id":"gt-old","title":"Unrelated old work","status":"hooked","assignee":"deacon/dogs/alpha","updated_at":"2026-07-17T04:00:00Z"}]'
+      exit 0
+      ;;
+    gt-new)
+      case "$PWD" in
+        */gastown/mayor/rig) ;;
+        *) [ "$DOG_ALLOW_SOURCE_SHOW" = "1" ] || { echo '[]'; exit 0; } ;;
+      esac
+      printf '[{"id":"gt-new","title":"Requested dog work","description":"attached_formula: code-review\\nattached_at: 2026-07-17T05:00:00Z","status":"hooked","assignee":"%s","updated_at":"2026-07-17T05:00:00Z"}]\n' "${DOG_SOURCE_ASSIGNEE:-deacon/dogs/alpha}"
+      exit 0
+      ;;
+  esac
+  if [ "$arg" = "list" ]; then
+    case "$PWD" in
+      */gastown/mayor/rig)
+        printf '%s\n' '[{"id":"gt-new","title":"Requested dog work","description":"attached_formula: code-review\nattached_at: 2026-07-17T05:00:00Z","status":"hooked","assignee":"deacon/dogs/alpha","updated_at":"2026-07-17T05:00:00Z"}]'
+        ;;
+      */.beads)
+        if [ "$DOG_HIDE_OLD" = "1" ]; then
+          echo '[]'
+        else
+          echo '[{"id":"gt-old","title":"Unrelated old work","status":"hooked","assignee":"deacon/dogs/alpha","updated_at":"2026-07-17T04:00:00Z"}]'
+        fi
+        ;;
+      *) echo '[]' ;;
+    esac
+    exit 0
+  fi
+done
+echo '[]'
+`
+	bdScriptWindows := `@echo off
+echo []
+`
+	writeBDStub(t, binDir, bdScript, bdScriptWindows)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	direct, err := listAssignedActiveWork(beads.New(rigDir), "deacon/dogs/alpha")
+	if err != nil {
+		t.Fatalf("direct rig query: %v", err)
+	}
+	if len(direct) != 1 || direct[0].ID != "gt-new" {
+		t.Fatalf("fixture rig query = %+v; want gt-new", direct)
+	}
+	t.Log("direct rig query resolves authoritative assignment gt-new")
+
+	ctx := RoleContext{
+		Role:     RoleDog,
+		Polecat:  "alpha",
+		TownRoot: townRoot,
+		WorkDir:  dogDir,
+	}
+	got, err := findAgentWorkOnce(ctx, "deacon/dogs/alpha")
+	if err != nil {
+		t.Fatalf("findAgentWorkOnce: %v", err)
+	}
+	if got == nil {
+		t.Fatal("findAgentWorkOnce returned no work; want newly assigned rig bead gt-new")
+	}
+	if got.ID != "gt-new" {
+		t.Fatalf("findAgentWorkOnce returned %s (%q); want authoritative assigned bead gt-new", got.ID, got.Title)
+	}
+
+	t.Setenv("DOG_ALLOW_SOURCE_SHOW", "1")
+	dispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		AgentID:       "deacon/dogs/alpha",
+		townRoot:      townRoot,
+		workDesc:      "gt-new",
+		workStartedAt: startedAt,
+		ownsWork:      true,
+		rigsConfig:    rigs,
+	}
+	if err := dispatch.verifyBareBeadAssignment("gt-new"); err != nil {
+		t.Fatalf("verifyBareBeadAssignment: %v", err)
+	}
+
+	t.Setenv("DOG_SOURCE_ASSIGNEE", "gastown/crew/other")
+	if err := dispatch.verifyBareBeadAssignment("gt-new"); err == nil {
+		t.Fatal("verifyBareBeadAssignment accepted a source bead assigned to another agent")
+	}
+
+	// Formula dispatch uses exact formula and assignment-time metadata rather
+	// than inferring work from an unrelated sole hook.
+	t.Setenv("DOG_SOURCE_ASSIGNEE", "deacon/dogs/alpha")
+	t.Setenv("DOG_HIDE_OLD", "1")
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "code-review",
+		WorkKind:      dog.WorkKindFormula,
+		WorkStartedAt: startedAt,
+		LastActive:    startedAt,
+		CreatedAt:     startedAt.Add(-time.Hour),
+		UpdatedAt:     startedAt,
+	})
+	formulaWork, err := findAssignedDogWork(ctx, "deacon/dogs/alpha")
+	if err != nil {
+		t.Fatalf("findAssignedDogWork formula: %v", err)
+	}
+	if formulaWork == nil || formulaWork.ID != "gt-new" {
+		t.Fatalf("formula lookup = %+v, want exact attached formula gt-new", formulaWork)
+	}
+	dispatch.workDesc = "code-review"
+	if err := dispatch.verifyFormulaAssignment("gt-new"); err != nil {
+		t.Fatalf("verifyFormulaAssignment: %v", err)
+	}
+
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "plugin:rebuild-gt",
+		WorkKind:      dog.WorkKindPlugin,
+		WorkStartedAt: startedAt,
+		CreatedAt:     startedAt.Add(-time.Hour),
+		UpdatedAt:     startedAt,
+	})
+	pluginWork, err := findAssignedDogWork(ctx, "deacon/dogs/alpha")
+	if err != nil {
+		t.Fatalf("findAssignedDogWork plugin: %v", err)
+	}
+	if pluginWork != nil {
+		t.Fatalf("plugin mail work unexpectedly resolved a source hook: %+v", pluginWork)
+	}
+}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -882,7 +882,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 				var err error
 				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
 				if err != nil {
-					// Log warning but don't fail - convoy is optional
+					if delayedDogInfo != nil {
+						return fmt.Errorf("creating dog dispatch convoy: %w", err)
+					}
 					fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
 				} else {
 					fmt.Printf("%s Created convoy 🚚 %s\n", style.Bold.Render("→"), convoyID)
@@ -895,6 +897,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					}
 				}
 			} else {
+				convoyID = existingConvoy
 				fmt.Printf("%s Already tracked by convoy %s\n", style.Dim.Render("○"), existingConvoy)
 			}
 		}
@@ -1096,7 +1099,12 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// error when polecat redirect setup fails (GH #gt-mzyk5: agent bead created in rig beads
 	// but updateAgentHookBead looks in polecat's local beads if redirect is missing).
 	if !hookSetAtomically {
-		updateAgentHookBead(targetAgent, beadID, hookWorkDir, townBeadsDir)
+		if err := updateAgentHookBead(targetAgent, beadID, hookWorkDir, townBeadsDir); err != nil {
+			if delayedDogInfo != nil {
+				return fmt.Errorf("updating dog agent hook: %w", err)
+			}
+			fmt.Printf("%s Could not update agent hook: %v\n", style.Dim.Render("Warning:"), err)
+		}
 	}
 
 	// Store all attachment fields in a single read-modify-write cycle.
@@ -1136,64 +1144,40 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		previousDogCleared = true
 	}
 
-	// Verify the consumer-side view before starting the delayed dog session.
-	// Source status, dog state, and startup lookup must all name this bead.
-	if delayedDogInfo != nil {
-		var verifyErr error
-		if attachedMoleculeID != "" {
-			verifyErr = delayedDogInfo.verifyFormulaAssignment(beadID)
-		} else {
-			verifyErr = delayedDogInfo.verifyBareBeadAssignment(beadID)
-		}
-		if verifyErr != nil {
-			return fmt.Errorf("verifying dog dispatch: %w", verifyErr)
-		}
-		pane, err := delayedDogInfo.StartDelayedSession()
-		if err != nil {
-			return fmt.Errorf("starting delayed dog session: %w", err)
-		}
-		targetPane = pane
-		dogDispatchComplete = true
-	}
-
 	// Start polecat session now that attached_molecule is set.
 	// This ensures polecat sees the molecule when gt prime runs on session start.
 	freshlySpawned := newPolecatInfo != nil
 	if freshlySpawned {
 		pane, err := newPolecatInfo.StartSession()
 		if err != nil {
-			// Rollback: session failed, clean up zombie artifacts (worktree, hooked bead).
-			// Without rollback, next sling attempt fails with "bead already hooked" (gt-jn40ft).
 			rollbackSpawnedPolecat("Session failed")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
 		targetPane = pane
 	}
 
-	// Try to inject the "start now" prompt (graceful if no tmux)
-	// Skip for freshly spawned polecats - SessionManager.Start() already sent StartupNudge.
-	// Skip for self-sling - agent is currently processing the sling command and will see
-	// the hooked work on next turn. Nudging would inject text while agent is busy.
-	if freshlySpawned {
+	if delayedDogInfo != nil {
+		pane, err := completeBareDogDispatch(delayedDogInfo, beadID, convoyID, attachedMoleculeID, slingSubject, slingArgs)
+		if err != nil {
+			return err
+		}
+		targetPane = pane
+		dogDispatchComplete = true
+	} else if freshlySpawned {
 		// Fresh polecat already got StartupNudge from SessionManager.Start()
 	} else if isSelfSling {
-		// Self-sling: agent already knows about the work (just slung it)
 		fmt.Printf("%s Self-sling: work hooked, will process on next turn\n", style.Dim.Render("○"))
 	} else if targetPane == "" {
 		fmt.Printf("%s No pane to nudge (agent will discover work via gt prime)\n", style.Dim.Render("○"))
 	} else {
-		// Ensure agent is ready before nudging (prevents race condition where
-		// message arrives before Claude has fully started - see issue #115)
 		sessionName := getSessionFromPane(targetPane)
 		if sessionName != "" {
 			if err := ensureAgentReady(sessionName); err != nil {
-				// Non-fatal: warn and continue, agent will discover work via gt prime
 				fmt.Printf("%s Could not verify agent ready: %v\n", style.Dim.Render("○"), err)
 			}
 		}
 
 		if err := injectStartPrompt(targetPane, beadID, slingSubject, slingArgs); err != nil {
-			// Graceful fallback for no-tmux mode
 			fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)
 			fmt.Printf("  Agent will discover work via gt prime / bd show\n")
 		} else {
@@ -1366,10 +1350,28 @@ func rollbackFailedDogDispatch(dispatch *DogDispatchInfo, townRoot, beadID, hook
 		fmt.Printf("  %s Dog or source assignment changed after dispatch; preserving dog state\n", style.Dim.Render("○"))
 		return restored
 	}
+	clearRolledBackDogAgentHook(dispatch)
+	_ = dog.KillCompletedDogSession(
+		dog.NewManager(dispatch.townRoot, dispatch.rigsConfig),
+		dispatch.DogName,
+		fmt.Sprintf("hq-dog-%s", dispatch.DogName),
+		tmux.NewTmux().KillSession,
+	)
 	if convoyID != "" {
 		closeConvoy(convoyID, "Sling rollback - dog dispatch failed")
 	}
 	return restored
+}
+
+func clearRolledBackDogAgentHook(dispatch *DogDispatchInfo) {
+	if dispatch == nil || dispatch.townRoot == "" || dispatch.DogName == "" {
+		return
+	}
+	empty := ""
+	agentBeadID := beads.DogBeadIDTown(dispatch.DogName)
+	if err := beads.New(filepath.Join(dispatch.townRoot, ".beads")).UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{HookBead: &empty}); err != nil {
+		fmt.Printf("%s Could not clear dog agent hook after rollback: %v\n", style.Dim.Render("Warning:"), err)
+	}
 }
 
 func restoreFailedDogSlingSource(townRoot, beadID, hookWorkDir, expectedAssignee, expectedDescription, status, assignee string, originalInfo *beadInfo) bool {

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -12,12 +12,15 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/lock"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
+	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/witness"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -718,6 +721,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		NoBoot:       slingNoBoot,
 		HookBead:     beadID,
 		BeadID:       beadID,
+		WorkDesc:     formulaName,
 		TownRoot:     townRoot,
 		BaseBranch:   slingBaseBranch,
 		ResumeBranch: slingResumeBranch,
@@ -747,6 +751,28 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	delayedDogInfo := resolved.DelayedDogInfo
 	newPolecatInfo := resolved.NewPolecatInfo
 	isSelfSling := resolved.IsSelfSling
+	var convoyID string
+	dogDispatchDescription := info.Description
+	previousDogCleared := false
+	dogDispatchComplete := delayedDogInfo == nil
+	defer func() {
+		if dogDispatchComplete {
+			return
+		}
+		rollbackStatus, rollbackAssignee := originalStatus, originalAssignee
+		oldAssigneeParts := strings.Split(originalAssignee, "/")
+		oldPolecatShuttingDown := len(oldAssigneeParts) >= 3 && oldAssigneeParts[1] == "polecats"
+		if force && (oldPolecatShuttingDown || previousDogCleared) && (originalStatus == "hooked" || originalStatus == "in_progress") {
+			// The old worker is shutting down or its matching state was released.
+			// Do not restore ownership to an agent that no longer owns the work.
+			rollbackStatus, rollbackAssignee = "open", ""
+		}
+		restored := rollbackFailedDogDispatch(delayedDogInfo, townRoot, beadID, hookWorkDir, dogDispatchDescription, rollbackStatus, rollbackAssignee, convoyID, info)
+		cleanupSafe := restored || dogFormulaSourceStillOriginal(townRoot, beadID, info)
+		if cleanupSafe && attachedMoleculeID != "" {
+			cleanupRolledBackDogMolecule(attachedMoleculeID, beadID, townRoot)
+		}
+	}()
 	rollbackSpawnedPolecat := func(reason string) {
 		if newPolecatInfo != nil {
 			fmt.Printf("%s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, newPolecatInfo.PolecatName)
@@ -843,7 +869,6 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Auto-convoy: check if issue is already tracked by a convoy
 	// If not, create one for dashboard visibility (unless --no-convoy is set)
-	var convoyID string
 	if !slingNoConvoy && formulaName == "" {
 		if slingDryRun {
 			fmt.Printf("Would create convoy 'Work: %s' if needed\n", info.Title)
@@ -912,6 +937,13 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 				if err := burnExistingMolecules(existingMolecules, beadID, townRoot); err != nil {
 					return fmt.Errorf("burning stale molecules: %w", err)
 				}
+				// A later dog rollback must restore the post-burn description, not
+				// resurrect attachment metadata for the closed stale molecule.
+				cleaned, err := getBeadInfoFromTownRoot(townRoot, beadID)
+				if err != nil {
+					return fmt.Errorf("reading bead after burning stale molecules: %w", err)
+				}
+				info.Description = cleaned.Description
 			} else {
 				return fmt.Errorf("bead %s already has %d attached molecule(s): %s\nUse --force to replace, or --hook-raw-bead to skip formula",
 					beadID, len(existingMolecules), strings.Join(existingMolecules, ", "))
@@ -1009,7 +1041,6 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		slingMerge,
 		slingOwned,
 	)
-
 	// Hook the bead with retry and verification.
 	// See: https://github.com/steveyegge/gastown/issues/148
 	//
@@ -1022,13 +1053,17 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	}
 	defer assigneeUnlock()
 	if attachedMoleculeID == "" && (slingNoMerge || slingReviewOnly) {
-		if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
+		storedDescription, err := storeFieldsInBeadFromTownRootWithDescription(townRoot, beadID, fieldUpdates)
+		if err != nil {
 			if newPolecatInfo != nil {
 				fmt.Printf("%s Raw sling metadata failed, cleaning up spawned polecat %s...\n", style.Warning.Render("⚠"), newPolecatInfo.PolecatName)
 				cleanupSpawnedPolecat(newPolecatInfo, newPolecatInfo.RigName, convoyID)
 			}
 			restoreRollbackRawWorkflowFieldsFromCurrent(beadID, townRoot, hookWorkDir, info)
 			return fmt.Errorf("storing raw sling metadata before hook: %w", err)
+		}
+		if delayedDogInfo != nil {
+			dogDispatchDescription = storedDescription
 		}
 	}
 	hookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
@@ -1067,10 +1102,17 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Store all attachment fields in a single read-modify-write cycle.
 	// This eliminates the race condition where sequential independent updates
 	// (dispatcher, args, no_merge, attached_molecule) could overwrite each other.
-	if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
+	storedDescription, storeErr := storeFieldsInBeadFromTownRootWithDescription(townRoot, beadID, fieldUpdates)
+	if storeErr != nil {
+		if delayedDogInfo != nil && attachedMoleculeID != "" {
+			return fmt.Errorf("storing dog formula attachment metadata: %w", storeErr)
+		}
 		// Warn but don't fail - polecat will still complete work
-		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
+		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), storeErr)
 	} else {
+		if delayedDogInfo != nil {
+			dogDispatchDescription = storedDescription
+		}
 		if slingArgs != "" {
 			fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
 		}
@@ -1085,14 +1127,33 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
 	}
 
-	// Start delayed dog session now that hook is set
-	// This ensures dog sees the hook when gt prime runs on session start
+	// A forced dog-to-dog handoff must release the old dog's matching state
+	// before the new dog becomes runnable. Failure rolls the source back.
+	if delayedDogInfo != nil && force && strings.HasPrefix(originalAssignee, "deacon/dogs/") && originalAssignee != targetAgent {
+		if err := clearPreviousDogAssignment(townRoot, originalAssignee, beadID, info.Description); err != nil {
+			return fmt.Errorf("clearing previous dog assignment: %w", err)
+		}
+		previousDogCleared = true
+	}
+
+	// Verify the consumer-side view before starting the delayed dog session.
+	// Source status, dog state, and startup lookup must all name this bead.
 	if delayedDogInfo != nil {
+		var verifyErr error
+		if attachedMoleculeID != "" {
+			verifyErr = delayedDogInfo.verifyFormulaAssignment(beadID)
+		} else {
+			verifyErr = delayedDogInfo.verifyBareBeadAssignment(beadID)
+		}
+		if verifyErr != nil {
+			return fmt.Errorf("verifying dog dispatch: %w", verifyErr)
+		}
 		pane, err := delayedDogInfo.StartDelayedSession()
 		if err != nil {
 			return fmt.Errorf("starting delayed dog session: %w", err)
 		}
 		targetPane = pane
+		dogDispatchComplete = true
 	}
 
 	// Start polecat session now that attached_molecule is set.
@@ -1285,6 +1346,139 @@ func restorePinnedBead(townRoot, beadID, assignee string) {
 	} else {
 		fmt.Printf("  %s Restored pinned state for bead %s\n", style.Dim.Render("○"), beadID)
 	}
+}
+
+func rollbackFailedDogDispatch(dispatch *DogDispatchInfo, townRoot, beadID, hookWorkDir, expectedDescription, status, assignee, convoyID string, originalInfo *beadInfo) bool {
+	if dispatch == nil {
+		return false
+	}
+	fmt.Printf("%s Dog dispatch did not complete; rolling back %s...\n", style.Warning.Render("⚠"), dispatch.DogName)
+	restored := false
+	cleared, err := dispatch.clearWorkIfMatchesAfter(func() bool {
+		restored = restoreFailedDogSlingSource(townRoot, beadID, hookWorkDir, dispatch.AgentID, expectedDescription, status, assignee, originalInfo)
+		return restored
+	})
+	if err != nil {
+		fmt.Printf("%s Could not clear dog assignment after source restoration: %v\n", style.Dim.Render("Warning:"), err)
+		return restored
+	}
+	if !cleared {
+		fmt.Printf("  %s Dog or source assignment changed after dispatch; preserving dog state\n", style.Dim.Render("○"))
+		return restored
+	}
+	if convoyID != "" {
+		closeConvoy(convoyID, "Sling rollback - dog dispatch failed")
+	}
+	return restored
+}
+
+func restoreFailedDogSlingSource(townRoot, beadID, hookWorkDir, expectedAssignee, expectedDescription, status, assignee string, originalInfo *beadInfo) bool {
+	if townRoot == "" || beadID == "" || originalInfo == nil {
+		return false
+	}
+	current, err := getBeadInfoFromTownRoot(townRoot, beadID)
+	if err != nil {
+		fmt.Printf("  %s Could not verify source bead %s before dog rollback: %v\n", style.Dim.Render("Warning:"), beadID, err)
+		return false
+	}
+	if current != nil && current.Status == originalInfo.Status && current.Assignee == originalInfo.Assignee &&
+		current.Description == originalInfo.Description {
+		// Dispatch failed before changing the source; it is already restored.
+		return true
+	}
+	newHookOwned := current != nil && current.Status == "hooked" && current.Assignee == expectedAssignee && current.Description == expectedDescription
+	forceTransitionOwned := current != nil && current.Status == "open" && current.Assignee == "" && current.Description == originalInfo.Description
+	if !newHookOwned && !forceTransitionOwned {
+		fmt.Printf("  %s Source bead %s changed after dispatch; preserving its ownership and metadata\n",
+			style.Dim.Render("○"), beadID)
+		return false
+	}
+
+	// Restore source ownership and workflow metadata with a storage-level CAS.
+	// The description predicate prevents rollback from overwriting any concurrent
+	// source edit between readback and update.
+	dir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
+	for _, table := range []string{"issues", "wisps"} {
+		query := fmt.Sprintf(
+			"UPDATE %s SET status=%s, assignee=%s, description=%s, updated_at=CURRENT_TIMESTAMP WHERE id=%s AND status=%s AND assignee=%s AND description=%s",
+			table,
+			sqlStringLiteral(status), sqlStringLiteral(assignee), sqlStringLiteral(originalInfo.Description),
+			sqlStringLiteral(beadID), sqlStringLiteral(current.Status), sqlStringLiteral(current.Assignee), sqlStringLiteral(current.Description),
+		)
+		if err := BdCmd("sql", query).Dir(dir).StripBeadsDir().WithAutoCommit().Run(); err != nil {
+			fmt.Printf("  %s Could not restore source bead %s in %s after dog dispatch failure: %v\n",
+				style.Dim.Render("Warning:"), beadID, table, err)
+			return false
+		}
+	}
+
+	updated, err := getBeadInfoFromTownRoot(townRoot, beadID)
+	if err != nil {
+		fmt.Printf("  %s Could not verify source bead %s after dog rollback: %v\n", style.Dim.Render("Warning:"), beadID, err)
+		return false
+	}
+	if updated.Status == status && updated.Assignee == assignee && updated.Description == originalInfo.Description {
+		fmt.Printf("  %s Restored source bead %s to status=%s assignee=%s\n", style.Dim.Render("○"), beadID, status, assignee)
+		return true
+	}
+	fmt.Printf("  %s Source bead %s changed during rollback; preserved status=%s assignee=%s\n",
+		style.Dim.Render("○"), beadID, updated.Status, updated.Assignee)
+	return false
+}
+
+func clearPreviousDogAssignment(townRoot, assignee, beadID, originalDescription string) error {
+	name := strings.TrimPrefix(assignee, "deacon/dogs/")
+	rigsConfig, err := config.LoadRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"))
+	if err != nil {
+		return err
+	}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	previous, err := mgr.Get(name)
+	if err != nil {
+		return err
+	}
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: originalDescription})
+	matches := previous.Work == beadID || (fields != nil && fields.AttachedFormula != "" && previous.Work == fields.AttachedFormula)
+	if !matches {
+		return fmt.Errorf("previous dog %s state names %q, not source %s", name, previous.Work, beadID)
+	}
+	cleared, err := mgr.ClearWorkIfMatchesAfter(name, previous.Work, previous.WorkStartedAt, func() bool {
+		t := tmux.NewTmux()
+		running, err := t.HasSession("hq-dog-" + name)
+		if err != nil {
+			return false
+		}
+		if !running {
+			return true
+		}
+		return t.KillSessionWithProcesses("hq-dog-"+name) == nil
+	})
+	if err != nil {
+		return err
+	}
+	if !cleared {
+		return fmt.Errorf("previous dog %s assignment changed or its session could not stop during handoff", name)
+	}
+	return nil
+}
+
+func dogFormulaSourceStillOriginal(townRoot, beadID string, originalInfo *beadInfo) bool {
+	if originalInfo == nil {
+		return false
+	}
+	current, err := getBeadInfoFromTownRoot(townRoot, beadID)
+	if err != nil || current == nil {
+		return false
+	}
+	return current.Status == originalInfo.Status && current.Assignee == originalInfo.Assignee &&
+		current.Description == originalInfo.Description
+}
+
+func sqlStringLiteral(value string) string {
+	// Dolt uses MySQL string semantics: backslashes are escapes unless the
+	// session enables NO_BACKSLASH_ESCAPES. Escape them before SQL quotes.
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -45,10 +45,15 @@ Auto-Convoy:
   gt sling gt-abc gastown --no-convoy  # Skip auto-convoy creation
 
 Merge Strategy (--merge):
-  Controls how completed work lands. Stored on the auto-convoy.
+  Controls how completed work lands. Stored on the auto-convoy and on the issue.
   gt sling gt-abc gastown --merge=direct  # Push branch directly to main
   gt sling gt-abc gastown --merge=mr      # Merge queue (default)
   gt sling gt-abc gastown --merge=local   # Keep on feature branch
+
+  An explicit --merge value wins. If --merge is omitted, sling reuses a stored
+  merge_strategy on the issue. If the issue text says "local commit only" or
+  "do not push", sling uses local and stores merge_strategy=local so later
+  dispatches keep the policy without the flag.
 
 Target Resolution:
   gt sling gt-abc                       # Self (current agent)
@@ -631,6 +636,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("bead %s is %s (work already completed)", beadID, info.Status)
 	}
 
+	mergeStrategy := resolveBeadMergeStrategy(slingMerge, info)
+
 	// Guard against slinging deferred beads (gt-1326mw).
 	// Deferred work (e.g., "deferred to post-launch") should not consume polecat slots.
 	// Use --force to override when intentionally re-activating deferred work.
@@ -848,14 +855,14 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if slingDryRun {
 			fmt.Printf("Would create convoy 'Work: %s' if needed\n", info.Title)
 			fmt.Printf("Would add tracking relation to %s if needed\n", beadID)
-			if slingMerge != "" {
-				fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
+			if mergeStrategy != "" {
+				fmt.Printf("Would set convoy merge strategy: %s\n", mergeStrategy)
 			}
 		} else {
 			existingConvoy := isTrackedByConvoy(beadID)
 			if existingConvoy == "" {
 				var err error
-				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
+				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, mergeStrategy, slingBaseBranch)
 				if err != nil {
 					// Log warning but don't fail - convoy is optional
 					fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
@@ -865,8 +872,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					if slingOwned {
 						fmt.Printf("  Lifecycle: caller-managed (owned)\n")
 					}
-					if slingMerge != "" {
-						fmt.Printf("  Merge:    %s\n", slingMerge)
+					if mergeStrategy != "" {
+						fmt.Printf("  Merge:    %s\n", mergeStrategy)
 					}
 				}
 			} else {
@@ -1006,7 +1013,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		mode,
 		formulaVarsForAttachment,
 		convoyID,
-		slingMerge,
+		mergeStrategy,
 		slingOwned,
 	)
 
@@ -1021,7 +1028,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
 	}
 	defer assigneeUnlock()
-	if attachedMoleculeID == "" && (slingNoMerge || slingReviewOnly) {
+	if attachedMoleculeID == "" && slingFieldsRequireDurableWrite(fieldUpdates) {
 		if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
 			if newPolecatInfo != nil {
 				fmt.Printf("%s Raw sling metadata failed, cleaning up spawned polecat %s...\n", style.Warning.Render("⚠"), newPolecatInfo.PolecatName)
@@ -1068,6 +1075,10 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// This eliminates the race condition where sequential independent updates
 	// (dispatcher, args, no_merge, attached_molecule) could overwrite each other.
 	if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
+		if slingFieldsRequireDurableWrite(fieldUpdates) {
+			rollbackSpawnedPolecat("Durable sling metadata failed")
+			return fmt.Errorf("storing sling metadata: %w", err)
+		}
 		// Warn but don't fail - polecat will still complete work
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	} else {

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -359,6 +359,9 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		ReviewOnly:       params.ReviewOnly,
 		Mode:             &params.Mode,
 		FormulaVars:      formulaVarsForAttachment,
+		ConvoyID:         convoyID,      // GH#4512: propagate convoy fields to issue
+		MergeStrategy:    params.Merge,  // so gt done's issue-level fallback check works
+		ConvoyOwned:      params.Owned,  // for queue/batch-dispatched issues
 	}
 	if params.FormulaName != "" {
 		if attachedMoleculeID != "" {

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -139,6 +139,8 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		return result, fmt.Errorf("bead %s is %s (work already completed)", params.BeadID, info.Status)
 	}
 
+	params.Merge = resolveBeadMergeStrategy(params.Merge, info)
+
 	// Save explicit force state before dead-agent auto-force, so the deferred
 	// gate below still requires an explicit --force for deferred beads.
 	explicitForce := params.Force
@@ -259,27 +261,13 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	hookWorkDir := spawnInfo.ClonePath
 
 	// 4. Auto-convoy (if !NoConvoy)
-	convoyID := ""
+	convoyID := createSlingAutoConvoy(params, info)
 	rollbackSpawnedPolecat := func(rollbackBeadID, reason string) {
 		fmt.Printf("  %s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, spawnInfo.PolecatName)
 		rollbackSlingArtifactsFn(spawnInfo, rollbackBeadID, hookWorkDir, convoyID)
 		restoreRollbackRawWorkflowFieldsFromCurrent(rollbackBeadID, townRoot, hookWorkDir, info)
 		if params.Force && info.Status == "pinned" {
 			restorePinnedBead(townRoot, params.BeadID, info.Assignee)
-		}
-	}
-	if !params.NoConvoy {
-		existingConvoy := isTrackedByConvoy(params.BeadID)
-		if existingConvoy == "" {
-			var err error
-			convoyID, err = createAutoConvoy(params.BeadID, info.Title, params.Owned, params.Merge, params.BaseBranch)
-			if err != nil {
-				fmt.Printf("  %s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
-			} else {
-				fmt.Printf("  %s Created convoy %s\n", style.Bold.Render("→"), convoyID)
-			}
-		} else {
-			fmt.Printf("  %s Already tracked by convoy %s\n", style.Dim.Render("○"), existingConvoy)
 		}
 	}
 
@@ -350,28 +338,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	result.AttachedMolecule = attachedMoleculeID
 
 	actor := detectActor()
-	fieldUpdates := beadFieldUpdates{
-		Dispatcher:       actor,
-		Args:             params.Args,
-		Vars:             varsForAttachment,
-		AttachedMolecule: attachedMoleculeID,
-		NoMerge:          params.NoMerge,
-		ReviewOnly:       params.ReviewOnly,
-		Mode:             &params.Mode,
-		FormulaVars:      formulaVarsForAttachment,
-		ConvoyID:         convoyID,      // GH#4512: propagate convoy fields to issue
-		MergeStrategy:    params.Merge,  // so gt done's issue-level fallback check works
-		ConvoyOwned:      params.Owned,  // for queue/batch-dispatched issues
-	}
-	if params.FormulaName != "" {
-		if attachedMoleculeID != "" {
-			fieldUpdates.AttachedFormula = params.FormulaName
-		} else {
-			fieldUpdates.ClearAttachment = true
-			fieldUpdates.Vars = nil
-			fieldUpdates.FormulaVars = ""
-		}
-	}
+	fieldUpdates := newSlingDispatchFieldUpdates(actor, params, varsForAttachment, formulaVarsForAttachment, convoyID, attachedMoleculeID)
 
 	// 7. Hook bead with retry
 	// Acquire per-assignee lock to serialize concurrent hook writes (issue #3114).
@@ -382,7 +349,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		return result, fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
 	}
 	defer assigneeUnlock()
-	if attachedMoleculeID == "" && (params.NoMerge || params.ReviewOnly) {
+	if attachedMoleculeID == "" && slingFieldsRequireDurableWrite(fieldUpdates) {
 		if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
 			cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
 			restoreRollbackRawWorkflowFieldsFromCurrent(beadToHook, townRoot, hookWorkDir, info)
@@ -409,6 +376,11 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	// 10. Store fields in bead (dispatcher, args, attached_molecule, no_merge, mode)
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
 	if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
+		if slingFieldsRequireDurableWrite(fieldUpdates) {
+			rollbackSpawnedPolecat(beadToHook, "Durable sling metadata failed")
+			result.ErrMsg = "sling metadata failed"
+			return result, fmt.Errorf("storing sling metadata: %w", err)
+		}
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	}
 

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -401,7 +401,9 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadToHook, targetAgent))
 
 	// 9. Update agent hook_bead state
-	updateAgentHookBead(targetAgent, beadToHook, hookWorkDir, beadsDir)
+	if err := updateAgentHookBead(targetAgent, beadToHook, hookWorkDir, beadsDir); err != nil {
+		fmt.Printf("%s Could not update agent hook: %v\n", style.Dim.Render("Warning:"), err)
+	}
 
 	// 10. Store fields in bead (dispatcher, args, attached_molecule, no_merge, mode)
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)

--- a/internal/cmd/sling_dog.go
+++ b/internal/cmd/sling_dog.go
@@ -56,10 +56,11 @@ func IsDogTarget(target string) (dogName string, isDog bool) {
 
 // DogDispatchOptions contains options for dispatching work to a dog.
 type DogDispatchOptions struct {
-	Create            bool   // Create dog if it doesn't exist
-	WorkDesc          string // Work description (formula or bead ID)
-	DelaySessionStart bool   // If true, don't start session (caller will start later)
-	AgentOverride     string // Agent override (e.g., "codex", "gemini")
+	Create            bool         // Create dog if it doesn't exist
+	WorkDesc          string       // Work description (formula or bead ID)
+	WorkKind          dog.WorkKind // Whether WorkDesc is a source bead or formula
+	DelaySessionStart bool         // If true, don't start session (caller will start later)
+	AgentOverride     string       // Agent override (e.g., "codex", "gemini")
 }
 
 // DogDispatchInfo contains information about a dog dispatch.
@@ -191,7 +192,7 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 				spawned = true
 			}
 
-			assignedState, err := mgr.AssignWorkIfIdle(targetDog.Name, opts.WorkDesc)
+			assignedState, err := mgr.AssignWorkIfIdleWithKind(targetDog.Name, opts.WorkDesc, opts.WorkKind)
 			if errors.Is(err, dog.ErrDogWorking) {
 				spawned = false
 				continue
@@ -205,7 +206,7 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 	}
 
 	if dogName != "" {
-		assignedState, err := mgr.AssignWorkIfIdle(targetDog.Name, opts.WorkDesc)
+		assignedState, err := mgr.AssignWorkIfIdleWithKind(targetDog.Name, opts.WorkDesc, opts.WorkKind)
 		if err != nil {
 			return nil, fmt.Errorf("assigning idle dog work: %w", err)
 		}
@@ -289,6 +290,64 @@ func (d *DogDispatchInfo) worksOnHook(hooked *beads.Issue) bool {
 	}, d.workDesc, hooked)
 }
 
+// verifyBareBeadAssignment performs the consumer-side readback required before
+// starting a dog session. Source status alone is insufficient: dog state and
+// the startup lookup must resolve the same bead. (GH#4516)
+func (d *DogDispatchInfo) verifyBareBeadAssignment(beadID string) error {
+	return d.verifyAssignment(beadID, beadID, dog.WorkKindBead)
+}
+
+// verifyFormulaAssignment applies the same consumer-side check to formula work.
+// The dog state names the formula while startup resolves the hooked source/wisp.
+func (d *DogDispatchInfo) verifyFormulaAssignment(sourceID string) error {
+	return d.verifyAssignment(sourceID, d.workDesc, dog.WorkKindFormula)
+}
+
+func (d *DogDispatchInfo) verifyAssignment(sourceID, expectedWork string, expectedKind dog.WorkKind) error {
+	if d == nil {
+		return fmt.Errorf("missing dog dispatch state")
+	}
+
+	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
+	current, err := mgr.Get(d.DogName)
+	if err != nil {
+		return fmt.Errorf("reading dog state: %w", err)
+	}
+	if current.State != dog.StateWorking || current.Work != expectedWork || current.WorkKind != expectedKind ||
+		current.WorkStartedAt.IsZero() || !current.WorkStartedAt.Equal(d.workStartedAt) {
+		return fmt.Errorf("dog state mismatch: state=%q work=%q kind=%q started=%s; want working work=%q kind=%q started=%s",
+			current.State, current.Work, current.WorkKind, current.WorkStartedAt.Format(time.RFC3339Nano),
+			expectedWork, expectedKind, d.workStartedAt.Format(time.RFC3339Nano))
+	}
+
+	source, err := getBeadInfoFromTownRoot(d.townRoot, sourceID)
+	if err != nil {
+		return fmt.Errorf("reading source bead: %w", err)
+	}
+	if source.Status != beads.StatusHooked || source.Assignee != d.AgentID {
+		return fmt.Errorf("source bead mismatch: status=%q assignee=%q; want hooked assignee=%q",
+			source.Status, source.Assignee, d.AgentID)
+	}
+
+	resolved, err := findAssignedDogWork(RoleContext{
+		Role:     RoleDog,
+		Polecat:  d.DogName,
+		TownRoot: d.townRoot,
+		WorkDir:  filepath.Join(d.townRoot, "deacon", "dogs", d.DogName),
+	}, d.AgentID)
+	if err != nil {
+		return fmt.Errorf("resolving dog startup hook: %w", err)
+	}
+	if resolved == nil || resolved.ID != sourceID {
+		resolvedID := ""
+		if resolved != nil {
+			resolvedID = resolved.ID
+		}
+		return fmt.Errorf("dog startup hook mismatch: resolved=%q; want %q", resolvedID, sourceID)
+	}
+	return nil
+}
+
 // StartDelayedSession starts the dog session after bead setup is complete.
 // This should only be called when DelaySessionStart was true during dispatch.
 func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
@@ -320,12 +379,24 @@ func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
 }
 
 func (d *DogDispatchInfo) clearWorkIfMatches() error {
+	_, err := d.clearWorkIfMatchesResult()
+	return err
+}
+
+func (d *DogDispatchInfo) clearWorkIfMatchesResult() (bool, error) {
 	if d == nil || !d.ownsWork {
-		return nil
+		return false, nil
 	}
 	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
-	_, err := mgr.ClearWorkIfMatches(d.DogName, d.workDesc, d.workStartedAt)
-	return err
+	return mgr.ClearWorkIfMatches(d.DogName, d.workDesc, d.workStartedAt)
+}
+
+func (d *DogDispatchInfo) clearWorkIfMatchesAfter(beforeClear func() bool) (bool, error) {
+	if d == nil || !d.ownsWork {
+		return false, nil
+	}
+	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
+	return mgr.ClearWorkIfMatchesAfter(d.DogName, d.workDesc, d.workStartedAt, beforeClear)
 }
 
 // generateDogName creates a unique dog name for pool expansion.

--- a/internal/cmd/sling_dog.go
+++ b/internal/cmd/sling_dog.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -78,6 +79,9 @@ type DogDispatchInfo struct {
 	ownsWork       bool
 	agentOverride  string
 	rigsConfig     *config.RigsConfig
+	expectedConvoy string
+	requireConvoy  bool
+	requireHook    bool
 }
 
 // DispatchToDog finds or spawns a dog for work dispatch.
@@ -244,9 +248,10 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 	}
 	pane, err := sessMgr.EnsureRunning(targetDog.Name, sessOpts)
 	if err != nil {
-		// Log but don't fail - dog state is set, session may start later
-		style.PrintWarning("could not start dog session: %v", err)
-		pane = ""
+		return nil, fmt.Errorf("starting dog session: %w", err)
+	}
+	if pane == "" {
+		return nil, fmt.Errorf("dog %s session started without a pane", targetDog.Name)
 	}
 
 	return &DogDispatchInfo{
@@ -303,6 +308,70 @@ func (d *DogDispatchInfo) verifyFormulaAssignment(sourceID string) error {
 	return d.verifyAssignment(sourceID, d.workDesc, dog.WorkKindFormula)
 }
 
+func (d *DogDispatchInfo) completeStartup(sourceID string, kind dog.WorkKind) (string, error) {
+	if err := d.persistWorkSource(sourceID); err != nil {
+		return "", err
+	}
+	var verifyErr error
+	if kind == dog.WorkKindFormula {
+		verifyErr = d.verifyFormulaAssignment(sourceID)
+	} else {
+		verifyErr = d.verifyBareBeadAssignment(sourceID)
+	}
+	if verifyErr != nil {
+		return "", verifyErr
+	}
+	return d.StartDelayedSession()
+}
+
+func (d *DogDispatchInfo) completeFormulaStartup(sourceID string) (string, error) {
+	d.requireHook = true
+	return d.completeStartup(sourceID, dog.WorkKindFormula)
+}
+
+// completeBareDogDispatch starts the delayed dog session only after hook, convoy,
+// and prompt delivery agree. Success is reported only after notification.
+func completeBareDogDispatch(delayed *DogDispatchInfo, beadID, convoyID, attachedMoleculeID, slingSubject, slingArgs string) (string, error) {
+	delayed.requireHook = true
+	if !slingNoConvoy {
+		delayed.requireConvoy = true
+		delayed.expectedConvoy = convoyID
+	}
+	kind := dog.WorkKindBead
+	if attachedMoleculeID != "" {
+		kind = dog.WorkKindFormula
+	}
+	pane, err := delayed.completeStartup(beadID, kind)
+	if err != nil {
+		return "", fmt.Errorf("completing dog dispatch: %w", err)
+	}
+	if pane == "" {
+		return "", fmt.Errorf("dog %s session has no pane to notify", delayed.DogName)
+	}
+	if os.Getenv("GT_TEST_NO_NUDGE") == "" {
+		if err := injectStartPrompt(pane, beadID, slingSubject, slingArgs); err != nil {
+			return "", fmt.Errorf("notifying dog %s: %w", delayed.DogName, err)
+		}
+		fmt.Printf("%s Start prompt sent\n", style.Bold.Render("▶"))
+	}
+	return pane, nil
+}
+
+func (d *DogDispatchInfo) persistWorkSource(sourceID string) error {
+	if d == nil || !d.ownsWork || sourceID == "" {
+		return nil
+	}
+	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
+	matched, err := mgr.SetWorkSourceIfMatches(d.DogName, d.workDesc, d.workStartedAt, sourceID)
+	if err != nil {
+		return fmt.Errorf("recording dog work source: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("dog %s assignment changed before source %s could be recorded", d.DogName, sourceID)
+	}
+	return nil
+}
+
 func (d *DogDispatchInfo) verifyAssignment(sourceID, expectedWork string, expectedKind dog.WorkKind) error {
 	if d == nil {
 		return fmt.Errorf("missing dog dispatch state")
@@ -329,6 +398,13 @@ func (d *DogDispatchInfo) verifyAssignment(sourceID, expectedWork string, expect
 			source.Status, source.Assignee, d.AgentID)
 	}
 
+	if err := d.verifyConvoyRelation(source, sourceID); err != nil {
+		return err
+	}
+	if err := d.verifyAgentHook(sourceID); err != nil {
+		return err
+	}
+
 	resolved, err := findAssignedDogWork(RoleContext{
 		Role:     RoleDog,
 		Polecat:  d.DogName,
@@ -348,29 +424,79 @@ func (d *DogDispatchInfo) verifyAssignment(sourceID, expectedWork string, expect
 	return nil
 }
 
-// StartDelayedSession starts the dog session after bead setup is complete.
-// This should only be called when DelaySessionStart was true during dispatch.
-func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
-	if !d.sessionDelayed {
-		return d.Pane, nil // Session was already started
+func (d *DogDispatchInfo) verifyConvoyRelation(source *beadInfo, sourceID string) error {
+	if !d.requireConvoy {
+		return nil
 	}
+	if d.expectedConvoy == "" {
+		return fmt.Errorf("dog dispatch missing convoy relation for %s", sourceID)
+	}
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: source.Description})
+	got := ""
+	if fields != nil {
+		got = fields.ConvoyID
+	}
+	if got != d.expectedConvoy {
+		return fmt.Errorf("convoy mismatch: source=%q; want %q", got, d.expectedConvoy)
+	}
+	return nil
+}
 
+func (d *DogDispatchInfo) verifyAgentHook(sourceID string) error {
+	if !d.requireHook {
+		return nil
+	}
+	agentBeadID := beads.DogBeadIDTown(d.DogName)
+	issue, err := beads.New(filepath.Join(d.townRoot, ".beads")).Show(agentBeadID)
+	if err != nil {
+		return fmt.Errorf("reading dog agent bead: %w", err)
+	}
+	hookBead := issue.HookBead
+	if fields := beads.ParseAgentFields(issue.Description); fields != nil && fields.HookBead != "" {
+		hookBead = fields.HookBead
+	}
+	if hookBead != sourceID {
+		return fmt.Errorf("dog agent hook mismatch: hook_bead=%q; want %q", hookBead, sourceID)
+	}
+	return nil
+}
+
+var ensureDogSession = defaultEnsureDogSession
+
+func defaultEnsureDogSession(d *DogDispatchInfo) (string, error) {
 	t := tmux.NewTmux()
 	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
 	sessMgr := dog.NewSessionManager(t, d.townRoot, mgr)
-
 	opts := dog.SessionStartOptions{
 		WorkDesc:      d.workDesc,
 		AgentOverride: d.agentOverride,
 	}
 	pane, err := sessMgr.EnsureRunning(d.DogName, opts)
 	if err != nil {
-		if errors.Is(err, dog.ErrSessionRunning) {
-			d.Pane = ""
-			d.sessionDelayed = false
-			return "", nil
+		return "", err
+	}
+	if pane == "" {
+		return "", fmt.Errorf("dog %s session has no pane", d.DogName)
+	}
+	return pane, nil
+}
+
+// StartDelayedSession starts the dog session after bead setup is complete.
+// This should only be called when DelaySessionStart was true during dispatch.
+func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
+	if !d.sessionDelayed {
+		if d.Pane == "" {
+			return "", fmt.Errorf("dog %s session has no pane", d.DogName)
 		}
+		return d.Pane, nil
+	}
+
+	pane, err := ensureDogSession(d)
+	if err != nil {
 		return "", fmt.Errorf("starting dog session: %w", err)
+	}
+	if pane == "" {
+		return "", fmt.Errorf("dog %s session has no pane", d.DogName)
 	}
 
 	d.Pane = pane

--- a/internal/cmd/sling_dog_cleanup_test.go
+++ b/internal/cmd/sling_dog_cleanup_test.go
@@ -183,9 +183,10 @@ func TestDogWorksOnHookRequiresFreshAttachment(t *testing.T) {
 
 func TestShouldReuseExistingFormulaSkipsStaleHookAfterFreshDogAssignment(t *testing.T) {
 	startedAt := time.Date(2026, 6, 16, 20, 30, 15, 900_000_000, time.UTC)
-	existing := &beads.Issue{ID: "gt-wisp-stale"}
+	existing := &beads.Issue{ID: "gt-dispatch-stale", Labels: []string{formulaDispatchLabel}}
 	freshDogHook := &beads.Issue{
-		ID:          "gt-wisp-fresh",
+		ID:          "gt-dispatch-fresh",
+		Labels:      []string{formulaDispatchLabel},
 		Description: "attached_formula: mol-dog-reaper\nattached_at: " + startedAt.Format(time.RFC3339Nano),
 	}
 	reusedDog := &DogDispatchInfo{

--- a/internal/cmd/sling_dog_rollback_test.go
+++ b/internal/cmd/sling_dog_rollback_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+func TestSQLStringLiteralEscapesDoltSpecialCharacters(t *testing.T) {
+	got := sqlStringLiteral("path\\name's\nnext")
+	want := "'path\\\\name''s\nnext'"
+	if got != want {
+		t.Fatalf("sqlStringLiteral() = %q, want %q", got, want)
+	}
+}
+
+func TestRollbackFailedDogDispatchReleasesDogAndSource(t *testing.T) {
+	townRoot := t.TempDir()
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	rigs := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), rigs); err != nil {
+		t.Fatalf("save rigs config: %v", err)
+	}
+	startedAt := time.Date(2026, 7, 17, 5, 0, 0, 0, time.UTC)
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "gt-new",
+		WorkKind:      dog.WorkKindBead,
+		WorkStartedAt: startedAt,
+		LastActive:    startedAt,
+		CreatedAt:     startedAt.Add(-time.Hour),
+		UpdatedAt:     startedAt,
+	})
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	statePath := filepath.Join(townRoot, "rollback-state")
+	bdScript := `#!/bin/sh
+echo "$@" >> "$DOG_ROLLBACK_LOG"
+for arg in "$@"; do
+  case "$arg" in
+    "UPDATE issues"*)
+      if [ "$(cat "$DOG_ROLLBACK_STATE" 2>/dev/null)" = beta ]; then
+        case "$arg" in
+          *"WHERE id='gt-new' AND status='hooked' AND assignee='deacon/dogs/alpha'"*) ;;
+          *) echo restored > "$DOG_ROLLBACK_STATE" ;;
+        esac
+      else
+        echo restored > "$DOG_ROLLBACK_STATE"
+      fi
+      ;;
+  esac
+  if [ "$arg" = "show" ]; then
+    case "$(cat "$DOG_ROLLBACK_STATE" 2>/dev/null)" in
+      restored) echo '[{"id":"gt-new","title":"Requested dog work","description":"","status":"open","assignee":""}]' ;;
+      beta) echo '[{"id":"gt-new","title":"Requested dog work","description":"","status":"hooked","assignee":"deacon/dogs/beta"}]' ;;
+      *)
+        printf '[{"id":"gt-new","title":"Requested dog work","description":"%s","status":"hooked","assignee":"deacon/dogs/alpha"}]\n' "$DOG_ROLLBACK_DESCRIPTION"
+        [ "$DOG_ROLLBACK_RACE" = "1" ] && echo beta > "$DOG_ROLLBACK_STATE"
+        ;;
+    esac
+    exit 0
+  fi
+done
+exit 0
+`
+	writeBDStub(t, binDir, bdScript, "@echo off\nexit /b 0\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOG_ROLLBACK_LOG", logPath)
+	t.Setenv("DOG_ROLLBACK_STATE", statePath)
+
+	dispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		AgentID:       "deacon/dogs/alpha",
+		townRoot:      townRoot,
+		workDesc:      "gt-new",
+		workStartedAt: startedAt,
+		ownsWork:      true,
+		rigsConfig:    rigs,
+	}
+	rollbackFailedDogDispatch(dispatch, townRoot, "gt-new", townRoot, "", "open", "", "", &beadInfo{Status: "open"})
+
+	got, err := dog.NewManager(townRoot, rigs).Get("alpha")
+	if err != nil {
+		t.Fatalf("get dog: %v", err)
+	}
+	if got.State != dog.StateIdle || got.Work != "" || !got.WorkStartedAt.IsZero() {
+		t.Fatalf("dog assignment survived rollback: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "sql UPDATE issues SET status='open', assignee='', description=''") {
+		t.Fatalf("atomic source restoration missing from bd log:\n%s", logText)
+	}
+
+	// If metadata committed over an intervening description edit, rollback uses
+	// the exact value read immediately before its storage-level CAS.
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatalf("clear bd log: %v", err)
+	}
+	if err := os.Remove(statePath); err != nil {
+		t.Fatalf("reset rollback state: %v", err)
+	}
+	t.Setenv("DOG_ROLLBACK_DESCRIPTION", "merged metadata")
+	restoreFailedDogSlingSource(townRoot, "gt-new", townRoot, "deacon/dogs/alpha", "merged metadata", "open", "", &beadInfo{Status: "open"})
+	logData, err = os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log after ambiguous metadata write: %v", err)
+	}
+	if !strings.Contains(string(logData), "description='merged metadata'") {
+		t.Fatalf("rollback did not CAS against the latest description:\n%s", logData)
+	}
+	t.Setenv("DOG_ROLLBACK_DESCRIPTION", "")
+
+	// A newer assignment must survive a delayed rollback from this dispatch.
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatalf("clear bd log for race: %v", err)
+	}
+	if err := os.Remove(statePath); err != nil {
+		t.Fatalf("reset rollback race state: %v", err)
+	}
+	t.Setenv("DOG_ROLLBACK_RACE", "1")
+	restoreFailedDogSlingSource(townRoot, "gt-new", townRoot, "deacon/dogs/alpha", "", "open", "", &beadInfo{Status: "open"})
+	logData, err = os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log after concurrent change: %v", err)
+	}
+	if !strings.Contains(string(logData), "sql UPDATE issues") {
+		t.Fatalf("rollback race never reached conditional SQL:\n%s", logData)
+	}
+	state, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read rollback race state: %v", err)
+	}
+	if strings.TrimSpace(string(state)) != "beta" {
+		t.Fatalf("conditional rollback overwrote newer source assignment; state=%q\n%s", state, logData)
+	}
+}

--- a/internal/cmd/sling_dog_session_test.go
+++ b/internal/cmd/sling_dog_session_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+func TestStartDelayedSession_FailsClosedOnStaleSession(t *testing.T) {
+	info := &DogDispatchInfo{
+		DogName:        "alpha",
+		sessionDelayed: true,
+		townRoot:       t.TempDir(),
+		workDesc:       "gt-new",
+	}
+	prev := ensureDogSession
+	t.Cleanup(func() { ensureDogSession = prev })
+
+	ensureDogSession = func(*DogDispatchInfo) (string, error) {
+		return "", dog.ErrSessionRunning
+	}
+	if _, err := info.StartDelayedSession(); !errors.Is(err, dog.ErrSessionRunning) {
+		t.Fatalf("StartDelayedSession() error = %v, want ErrSessionRunning", err)
+	}
+
+	info.sessionDelayed = true
+	ensureDogSession = func(*DogDispatchInfo) (string, error) {
+		return "", nil
+	}
+	if _, err := info.StartDelayedSession(); err == nil {
+		t.Fatal("empty pane must fail closed")
+	}
+
+	info.sessionDelayed = true
+	ensureDogSession = func(*DogDispatchInfo) (string, error) {
+		return "%5", nil
+	}
+	pane, err := info.StartDelayedSession()
+	if err != nil {
+		t.Fatalf("StartDelayedSession() error = %v", err)
+	}
+	if pane != "%5" || info.Pane != "%5" || info.sessionDelayed {
+		t.Fatalf("pane=%q delayed=%v, want %%5 started", pane, info.sessionDelayed)
+	}
+}
+
+func TestStartDelayedSession_AlreadyStartedRequiresPane(t *testing.T) {
+	info := &DogDispatchInfo{DogName: "alpha", Pane: ""}
+	if _, err := info.StartDelayedSession(); err == nil {
+		t.Fatal("already-started dispatch with no pane must fail")
+	}
+}
+
+func TestVerifyConvoyRelation_RequiresMatchingConvoy(t *testing.T) {
+	d := &DogDispatchInfo{requireConvoy: true, expectedConvoy: "hq-cv-1"}
+	if err := d.verifyConvoyRelation(&beadInfo{Description: "title\n"}, "gt-a"); err == nil {
+		t.Fatal("missing convoy must fail when required")
+	}
+	if err := d.verifyConvoyRelation(&beadInfo{Description: "convoy_id: hq-cv-other\n"}, "gt-a"); err == nil {
+		t.Fatal("mismatched convoy must fail")
+	}
+	if err := d.verifyConvoyRelation(&beadInfo{Description: "convoy_id: hq-cv-1\n"}, "gt-a"); err != nil {
+		t.Fatalf("matching convoy error = %v", err)
+	}
+}

--- a/internal/cmd/sling_dog_test.go
+++ b/internal/cmd/sling_dog_test.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/steveyegge/gastown/internal/constants"
-	"github.com/steveyegge/gastown/internal/dog"
 )
 
 // TestIsDogTarget verifies the dog target pattern matching.
@@ -55,56 +52,6 @@ func TestIsDogTarget(t *testing.T) {
 				t.Errorf("IsDogTarget(%q) dogName = %q, want %q", tt.target, gotDog, tt.wantDog)
 			}
 		})
-	}
-}
-
-// TestDogDispatchInfoDelayedSession verifies the delayed session start pattern.
-// When DelaySessionStart is true:
-//   - DispatchToDog returns with Pane="" and sessionDelayed=true
-//   - StartDelayedSession() must be called to actually start the session
-//
-// This prevents the race condition where dogs start before their hook is set.
-func TestDogDispatchInfoDelayedSession(t *testing.T) {
-	// Test that DogDispatchInfo correctly tracks delayed state
-	info := &DogDispatchInfo{
-		DogName:        "alpha",
-		AgentID:        "deacon/dogs/alpha",
-		Pane:           "", // Empty when delayed
-		Spawned:        false,
-		sessionDelayed: true,
-		townRoot:       "/tmp/test",
-		workDesc:       "test-work",
-	}
-
-	// Verify initial state
-	if info.Pane != "" {
-		t.Errorf("delayed dispatch should have empty Pane, got %q", info.Pane)
-	}
-	if !info.sessionDelayed {
-		t.Error("sessionDelayed should be true for delayed dispatch")
-	}
-
-	// Note: We can't test StartDelayedSession without mocking tmux,
-	// but we verify the struct correctly holds the delayed state.
-}
-
-// TestDogDispatchOptionsStruct verifies the DogDispatchOptions fields.
-func TestDogDispatchOptionsStruct(t *testing.T) {
-	opts := DogDispatchOptions{
-		Create:            true,
-		WorkDesc:          constants.MolConvoyFeed,
-		WorkKind:          dog.WorkKindFormula,
-		DelaySessionStart: true,
-	}
-
-	if !opts.Create {
-		t.Error("Create should be true")
-	}
-	if opts.WorkDesc != constants.MolConvoyFeed {
-		t.Errorf("WorkDesc = %q, want %q", opts.WorkDesc, constants.MolConvoyFeed)
-	}
-	if !opts.DelaySessionStart {
-		t.Error("DelaySessionStart should be true")
 	}
 }
 

--- a/internal/cmd/sling_dog_test.go
+++ b/internal/cmd/sling_dog_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/dog"
 )
 
 // TestIsDogTarget verifies the dog target pattern matching.
@@ -34,10 +35,10 @@ func TestIsDogTarget(t *testing.T) {
 		// Invalid patterns - not dog targets
 		{"deacon", "", false},
 		{"deacon/", "", false},
-		{"deacon/dogs/", "", false},      // trailing slash, empty name
+		{"deacon/dogs/", "", false},            // trailing slash, empty name
 		{"deacon/dogs/alpha/extra", "", false}, // too many segments
-		{"dog", "", false},               // missing colon
-		{"dogs:alpha", "", false},        // wrong prefix
+		{"dog", "", false},                     // missing colon
+		{"dogs:alpha", "", false},              // wrong prefix
 		{"polecat:alpha", "", false},
 		{"gastown/polecats/alpha", "", false},
 		{"mayor", "", false},
@@ -61,13 +62,14 @@ func TestIsDogTarget(t *testing.T) {
 // When DelaySessionStart is true:
 //   - DispatchToDog returns with Pane="" and sessionDelayed=true
 //   - StartDelayedSession() must be called to actually start the session
+//
 // This prevents the race condition where dogs start before their hook is set.
 func TestDogDispatchInfoDelayedSession(t *testing.T) {
 	// Test that DogDispatchInfo correctly tracks delayed state
 	info := &DogDispatchInfo{
 		DogName:        "alpha",
 		AgentID:        "deacon/dogs/alpha",
-		Pane:           "",    // Empty when delayed
+		Pane:           "", // Empty when delayed
 		Spawned:        false,
 		sessionDelayed: true,
 		townRoot:       "/tmp/test",
@@ -91,6 +93,7 @@ func TestDogDispatchOptionsStruct(t *testing.T) {
 	opts := DogDispatchOptions{
 		Create:            true,
 		WorkDesc:          constants.MolConvoyFeed,
+		WorkKind:          dog.WorkKindFormula,
 		DelaySessionStart: true,
 	}
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -109,15 +109,14 @@ func formulaSlingPrompt(formulaName string) string {
 	return fmt.Sprintf("Formula %s slung. Run `"+cli.Name()+" hook` to see your hook, then execute the steps.", formulaName)
 }
 
-func nudgeFormulaDog(delayedDogInfo *DogDispatchInfo, prompt string) {
+func nudgeFormulaDog(delayedDogInfo *DogDispatchInfo, prompt string) error {
 	dogSession := fmt.Sprintf("hq-dog-%s", delayedDogInfo.DogName)
 	t := tmux.NewTmux()
 	if err := t.NudgeSession(dogSession, prompt); err != nil {
-		fmt.Printf("%s Could not nudge dog %s: %v (will discover work via gt prime)\n",
-			style.Dim.Render("○"), delayedDogInfo.DogName, err)
-	} else {
-		fmt.Printf("%s Nudged dog %s\n", style.Bold.Render("▶"), delayedDogInfo.DogName)
+		return fmt.Errorf("nudging dog %s: %w", delayedDogInfo.DogName, err)
 	}
+	fmt.Printf("%s Nudged dog %s\n", style.Bold.Render("▶"), delayedDogInfo.DogName)
+	return nil
 }
 
 // findHookedFormulaSingleton returns the existing hooked bead for an assignee
@@ -433,16 +432,15 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		fmt.Printf("%s Formula %s already hooked to %s via %s, no-op\n",
 			style.Dim.Render("○"), formulaName, targetAgent, existing.ID)
 		if delayedDogInfo != nil {
-			if err := delayedDogInfo.verifyFormulaAssignment(existing.ID); err != nil {
-				return fmt.Errorf("verifying existing dog formula before session start: %w", err)
+			if _, err := delayedDogInfo.completeFormulaStartup(existing.ID); err != nil {
+				return fmt.Errorf("completing existing dog formula dispatch: %w", err)
 			}
-			if _, err := delayedDogInfo.StartDelayedSession(); err != nil {
-				return fmt.Errorf("starting delayed dog session for existing formula: %w", err)
+			if os.Getenv("GT_TEST_NO_NUDGE") == "" {
+				if err := nudgeFormulaDog(delayedDogInfo, formulaSlingPrompt(formulaName)); err != nil {
+					return err
+				}
 			}
 			delayedDogComplete = true
-			if os.Getenv("GT_TEST_NO_NUDGE") == "" {
-				nudgeFormulaDog(delayedDogInfo, formulaSlingPrompt(formulaName))
-			}
 		}
 		return nil
 	}
@@ -506,6 +504,12 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 
 	fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
 
+	if delayedDogInfo != nil {
+		if err := delayedDogInfo.persistWorkSource(wispRootID); err != nil {
+			return fmt.Errorf("recording dog formula source: %w", err)
+		}
+	}
+
 	// Step 3: Hook the wisp bead with retry and verification.
 	// See: https://github.com/steveyegge/gastown/issues/148.
 	hookDir := beads.ResolveHookDir(townRoot, wispRootID, "")
@@ -522,7 +526,12 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 
 	// Update agent bead's hook_bead field (ZFC: agents track their current work)
 	// Note: formula slinging uses town root as workDir (no polecat-specific path)
-	updateAgentHookBead(targetAgent, wispRootID, "", townBeadsDir)
+	if err := updateAgentHookBead(targetAgent, wispRootID, "", townBeadsDir); err != nil {
+		if delayedDogInfo != nil {
+			return fmt.Errorf("updating dog agent hook: %w", err)
+		}
+		fmt.Printf("%s Could not update agent hook: %v\n", style.Dim.Render("Warning:"), err)
+	}
 
 	// Store all attachment fields in a single read-modify-write cycle.
 	// NOTE: For standalone formula sling, the wisp IS the work - do NOT store
@@ -553,14 +562,10 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start
 	if delayedDogInfo != nil {
-		if err := delayedDogInfo.verifyFormulaAssignment(wispRootID); err != nil {
-			return fmt.Errorf("verifying dog formula before session start: %w", err)
-		}
-		pane, err := delayedDogInfo.StartDelayedSession()
+		pane, err := delayedDogInfo.completeFormulaStartup(wispRootID)
 		if err != nil {
-			return fmt.Errorf("starting delayed dog session: %w", err)
+			return fmt.Errorf("completing dog formula dispatch: %w", err)
 		}
-		delayedDogComplete = true
 		targetPane = pane
 	}
 
@@ -586,6 +591,9 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 
 	// Skip nudge during tests to prevent agent self-interruption
 	if os.Getenv("GT_TEST_NO_NUDGE") != "" {
+		if delayedDogInfo != nil {
+			delayedDogComplete = true
+		}
 		return nil
 	}
 
@@ -596,7 +604,10 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	// IDs are not globally unique). Use NudgeSession which qualifies the target
 	// with the session name. (gt-etc)
 	if delayedDogInfo != nil {
-		nudgeFormulaDog(delayedDogInfo, prompt)
+		if err := nudgeFormulaDog(delayedDogInfo, prompt); err != nil {
+			return err
+		}
+		delayedDogComplete = true
 		return nil
 	}
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -86,8 +86,12 @@ func cleanupDelayedDogFormulaFailure(currentErr error, delayedDogInfo *DogDispat
 			cleanupErr = fmt.Errorf("cleaning failed dog formula wisp %s: %w", wispRootID, err)
 		}
 	}
-	if err := delayedDogInfo.clearWorkIfMatches(); err != nil {
-		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("clearing failed dog assignment: %w", err))
+	// Keep typed dog state authoritative if source cleanup failed. Returning the
+	// dog to the pool while its wisp remains hooked would create split ownership.
+	if cleanupErr == nil {
+		if err := delayedDogInfo.clearWorkIfMatches(); err != nil {
+			cleanupErr = fmt.Errorf("clearing failed dog assignment: %w", err)
+		}
 	}
 	if cleanupErr == nil {
 		return currentErr
@@ -429,6 +433,9 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		fmt.Printf("%s Formula %s already hooked to %s via %s, no-op\n",
 			style.Dim.Render("○"), formulaName, targetAgent, existing.ID)
 		if delayedDogInfo != nil {
+			if err := delayedDogInfo.verifyFormulaAssignment(existing.ID); err != nil {
+				return fmt.Errorf("verifying existing dog formula before session start: %w", err)
+			}
 			if _, err := delayedDogInfo.StartDelayedSession(); err != nil {
 				return fmt.Errorf("starting delayed dog session for existing formula: %w", err)
 			}
@@ -527,10 +534,14 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		Args:            slingArgs,
 		Vars:            append([]string(nil), slingVars...),
 		AttachedFormula: formulaName,
+		AttachedAt:      time.Now().UTC().Format(time.RFC3339Nano),
 		Mode:            &mode,
 		FormulaVars:     strings.Join(slingVars, "\n"),
 	}
 	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
+		if delayedDogInfo != nil {
+			return fmt.Errorf("storing dog formula attachment metadata: %w", err)
+		}
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	} else if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
@@ -542,6 +553,9 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start
 	if delayedDogInfo != nil {
+		if err := delayedDogInfo.verifyFormulaAssignment(wispRootID); err != nil {
+			return fmt.Errorf("verifying dog formula before session start: %w", err)
+		}
 		pane, err := delayedDogInfo.StartDelayedSession()
 		if err != nil {
 			return fmt.Errorf("starting delayed dog session: %w", err)

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -62,18 +62,45 @@ func cleanupStaleDogFormulaWisp(wispRootID, formulaWorkDir string) error {
 	return closeFormulaWisp(wispRootID, formulaWorkDir, "burned: stale dog formula hook replaced")
 }
 
-func closeFormulaWisp(wispRootID, formulaWorkDir, reason string) error {
-	if wispRootID == "" {
+func closeFormulaMoleculeByID(bd *beads.Beads, moleculeID, reason string) error {
+	if moleculeID == "" {
+		return nil
+	}
+	var cleanupErr error
+	if _, err := forceCloseDescendants(bd, moleculeID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close descendants: %w", err))
+	}
+	if err := bd.ForceCloseWithReason(reason, moleculeID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close formula molecule: %w", err))
+	}
+	return cleanupErr
+}
+
+func closeFormulaWisp(workBeadID, formulaWorkDir, reason string) error {
+	if workBeadID == "" {
 		return nil
 	}
 	bd := beads.New(formulaWorkDir)
-	if _, err := forceCloseDescendants(bd, wispRootID); err != nil {
-		return fmt.Errorf("force-close descendants: %w", err)
+	workBead, err := bd.Show(workBeadID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("resolve formula cleanup target %s: %w", workBeadID, err)
 	}
-	if err := bd.ForceCloseWithReason(reason, wispRootID); err != nil {
-		return fmt.Errorf("force-close formula wisp: %w", err)
+
+	moleculeID := workBeadID
+	if fields := beads.ParseAttachmentFields(workBead); fields != nil && fields.AttachedMolecule != "" {
+		moleculeID = fields.AttachedMolecule
 	}
-	return nil
+
+	cleanupErr := closeFormulaMoleculeByID(bd, moleculeID, reason)
+	if moleculeID != workBeadID {
+		if err := bd.ForceCloseWithReason(reason, workBeadID); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("force-close formula dispatch bead: %w", err))
+		}
+	}
+	return cleanupErr
 }
 
 var cleanupFailedDogFormulaWispFn = cleanupFailedDogFormulaWisp
@@ -124,13 +151,7 @@ func findHookedFormulaSingleton(workDir, targetAgent, formulaName string) (*bead
 	}
 
 	b := beads.New(workDir)
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:    beads.StatusHooked,
-		Assignee:  targetAgent,
-		Priority:  -1,
-		Ephemeral: true,
-		Limit:     0,
-	})
+	hookedBeads, err := listAssignedActiveWorkAcrossStatuses(b, targetAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -165,15 +186,19 @@ func findHookedFormulaForDogPool(workDir, formulaName string, reusableDog func(*
 	}
 
 	b := beads.New(workDir)
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:    beads.StatusHooked,
-		Priority:  -1,
-		Ephemeral: true,
-		Limit:     0,
-	})
-	if err != nil {
-		return nil, "", err
+	var hookedBeads []*beads.Issue
+	for _, status := range activeWorkStatuses() {
+		active, err := listBeadsAcrossTables(b, beads.ListOptions{
+			Status:   status,
+			Priority: -1,
+			Limit:    0,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		hookedBeads = append(hookedBeads, active...)
 	}
+	hookedBeads = mergeBeadLists(hookedBeads, nil)
 
 	bead, dogName := reusableHookedDogFormula(hookedBeads, formulaName, reusableDog)
 	return bead, dogName, nil
@@ -283,8 +308,26 @@ func verifyFormulaExists(formulaName, workDir, townRoot string) error {
 	return fmt.Errorf("formula '%s' not found (check 'bd formula list')", formulaName)
 }
 
+const formulaDispatchLabel = "gt:formula-dispatch"
+
+func createFormulaDispatchBead(formulaName, formulaWorkDir string) (*beads.Issue, error) {
+	issue, err := beads.New(formulaWorkDir).Create(beads.CreateOptions{
+		Title:    formulaName,
+		Labels:   []string{"gt:task", formulaDispatchLabel},
+		Priority: 2,
+		Actor:    detectActor(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating durable formula dispatch bead: %w", err)
+	}
+	if issue == nil || issue.ID == "" {
+		return nil, fmt.Errorf("creating durable formula dispatch bead: bd returned no issue ID")
+	}
+	return issue, nil
+}
+
 // runSlingFormula handles standalone formula slinging.
-// Flow: cook → wisp → attach to hook → nudge
+// Flow: cook → wisp → durable dispatch bead → attach dispatch bead to hook → nudge
 func runSlingFormula(ctx context.Context, args []string) (err error) {
 	formulaName := args[0]
 
@@ -360,6 +403,8 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 
 	var wispRootID string
+	var dispatchBeadID string
+	formulaWorkComplete := false
 
 	if slingDryRun {
 		existing, err := findHookedFormulaSingletonFn(formulaWorkDir, targetAgent, formulaName)
@@ -396,13 +441,33 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 	defer assigneeUnlock()
 	defer func() {
-		if delayedDogInfo == nil || delayedDogComplete {
+		cleanupID := dispatchBeadID
+		if cleanupID == "" {
+			cleanupID = wispRootID
+		}
+		if delayedDogInfo != nil && !delayedDogComplete {
+			if err != nil || cleanupID != "" {
+				err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)
+			}
+			if dispatchBeadID != "" && wispRootID != "" {
+				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: dog formula sling failed"); cleanupErr != nil {
+					err = errors.Join(err, cleanupErr)
+				}
+			}
 			return
 		}
-		if err == nil && wispRootID == "" {
-			return
+		if err != nil && !formulaWorkComplete && cleanupID != "" {
+			if cleanupErr := closeFormulaWisp(cleanupID, formulaWorkDir, "burned: formula sling failed"); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+			}
+			// Metadata persistence may have failed before attached_molecule was
+			// stored. Close the known wisp ID independently so it cannot leak.
+			if dispatchBeadID != "" && wispRootID != "" {
+				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: formula sling failed"); cleanupErr != nil {
+					err = errors.Join(err, cleanupErr)
+				}
+			}
 		}
-		err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)
 	}()
 	mode := ""
 	if slingRalph {
@@ -499,42 +564,51 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 
 	fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
 
-	// Step 3: Hook the wisp bead with retry and verification.
-	// See: https://github.com/steveyegge/gastown/issues/148.
-	hookDir := beads.ResolveHookDir(townRoot, wispRootID, "")
-	if err := hookBeadWithRetryFn(wispRootID, targetAgent, hookDir); err != nil {
+	// Work dispatch must live in the durable issues table. Wisps intentionally
+	// remain outside Dolt history, so hooking the wisp directly strands the
+	// assignment outside refs/dolt/data and makes remote agents see an empty hook.
+	dispatchBead, err := createFormulaDispatchBead(formulaName, formulaWorkDir)
+	if err != nil {
 		return err
 	}
-	fmt.Printf("%s Attached to hook (status=hooked)\n", style.Bold.Render("✓"))
+	dispatchBeadID = dispatchBead.ID
+	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBeadID)
 
-	// Log sling event to activity feed (formula slinging)
 	actor := detectActor()
-	payload := events.SlingPayload(wispRootID, targetAgent)
-	payload["formula"] = formulaName
-	_ = events.LogFeed(events.TypeSling, actor, payload)
-
-	// Update agent bead's hook_bead field (ZFC: agents track their current work)
-	// Note: formula slinging uses town root as workDir (no polecat-specific path)
-	updateAgentHookBead(targetAgent, wispRootID, "", townBeadsDir)
-
-	// Store all attachment fields in a single read-modify-write cycle.
-	// NOTE: For standalone formula sling, the wisp IS the work - do NOT store
-	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
-	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
-	// creates a wisp that's bonded to a separate base bead.
 	fieldUpdates := beadFieldUpdates{
-		Dispatcher:      actor,
-		Args:            slingArgs,
-		Vars:            append([]string(nil), slingVars...),
-		AttachedFormula: formulaName,
-		Mode:            &mode,
-		FormulaVars:     strings.Join(slingVars, "\n"),
+		Dispatcher:       actor,
+		Args:             slingArgs,
+		Vars:             append([]string(nil), slingVars...),
+		AttachedMolecule: wispRootID,
+		AttachedFormula:  formulaName,
+		Mode:             &mode,
+		FormulaVars:      strings.Join(slingVars, "\n"),
 	}
-	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
-		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
-	} else if slingArgs != "" {
+	// attached_molecule is required to execute and later close the ephemeral
+	// formula. Persist it before reporting that the durable work was hooked.
+	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, fieldUpdates); err != nil {
+		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
+	}
+
+	// Step 3: Hook the durable dispatch bead with retry and verification.
+	// See: https://github.com/steveyegge/gastown/issues/148.
+	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
+	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+		return err
+	}
+	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
+	if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
 	}
+
+	// Log sling event to activity feed (formula slinging).
+	payload := events.SlingPayload(dispatchBeadID, targetAgent)
+	payload["formula"] = formulaName
+	payload["molecule"] = wispRootID
+	_ = events.LogFeed(events.TypeSling, actor, payload)
+
+	// Agent hook slots are legacy; durable bead status+assignee is authoritative.
+	updateAgentHookBead(targetAgent, dispatchBeadID, "", townBeadsDir)
 	if mode != "" {
 		updateAgentMode(targetAgent, mode, "", townBeadsDir)
 	}
@@ -555,12 +629,14 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	if resolved.NewPolecatInfo != nil {
 		pane, err := resolved.NewPolecatInfo.StartSession()
 		if err != nil {
-			// Rollback: unhook wisp, delete Dolt branch, clean up polecat worktree/agent bead
-			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, wispRootID, "", "")
+			// Rollback: unhook durable work, burn its molecule, and clean up the polecat.
+			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, dispatchBeadID, "", "")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
 		targetPane = pane
 	}
+
+	formulaWorkComplete = true
 
 	// Step 4: Nudge to start (graceful if no tmux)
 	// Skip for self-sling - agent is currently processing the sling command and will see

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -258,8 +258,26 @@ func newerAttachment(noCurrent bool, candidate time.Time, candidateOK bool, curr
 	return candidateOK && candidate.After(current)
 }
 
+func isDurableFormulaDispatch(issue *beads.Issue) bool {
+	return issue != nil && !issue.Ephemeral && beads.HasLabel(issue, formulaDispatchLabel)
+}
+
+func isLegacyFormulaWisp(issue *beads.Issue) bool {
+	return issue != nil && !isDurableFormulaDispatch(issue)
+}
+
+func formulaMoleculeID(issue *beads.Issue) string {
+	if issue == nil {
+		return ""
+	}
+	if fields := beads.ParseAttachmentFields(issue); fields != nil && fields.AttachedMolecule != "" {
+		return fields.AttachedMolecule
+	}
+	return issue.ID
+}
+
 func shouldReuseExistingFormula(existing *beads.Issue, delayedDogInfo *DogDispatchInfo, force bool) bool {
-	if existing == nil || force {
+	if existing == nil || force || !isDurableFormulaDispatch(existing) {
 		return false
 	}
 	if delayedDogInfo == nil {
@@ -269,6 +287,84 @@ func shouldReuseExistingFormula(existing *beads.Issue, delayedDogInfo *DogDispat
 		return false
 	}
 	return delayedDogInfo.worksOnHook(existing)
+}
+
+func rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason string) error {
+	var cleanupErr error
+	if dispatchBeadID != "" {
+		if err := closeFormulaWisp(dispatchBeadID, formulaWorkDir, reason); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	if wispRootID != "" && wispRootID != dispatchBeadID {
+		if err := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, reason); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
+}
+
+func unhookFormulaBead(beadID, formulaWorkDir, townRoot string) error {
+	if beadID == "" {
+		return nil
+	}
+	hookDir := beads.ResolveHookDir(townRoot, beadID, formulaWorkDir)
+	if err := BdCmd("update", beadID, "--status=open", "--assignee=").
+		Dir(hookDir).
+		WithAutoCommit().
+		Run(); err != nil {
+		return fmt.Errorf("unhooking legacy formula wisp %s: %w", beadID, err)
+	}
+	return nil
+}
+
+func formulaDispatchFieldUpdates(formulaName, moleculeID, mode string) beadFieldUpdates {
+	return beadFieldUpdates{
+		Dispatcher:       detectActor(),
+		Args:             slingArgs,
+		Vars:             append([]string(nil), slingVars...),
+		AttachedMolecule: moleculeID,
+		AttachedFormula:  formulaName,
+		Mode:             &mode,
+		FormulaVars:      strings.Join(slingVars, "\n"),
+	}
+}
+
+func persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBeadID, targetAgent, formulaName, moleculeID, mode string) error {
+	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, formulaDispatchFieldUpdates(formulaName, moleculeID, mode)); err != nil {
+		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
+	}
+	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
+	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+		return err
+	}
+	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
+	if slingArgs != "" {
+		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
+	}
+	payload := events.SlingPayload(dispatchBeadID, targetAgent)
+	payload["formula"] = formulaName
+	payload["molecule"] = moleculeID
+	_ = events.LogFeed(events.TypeSling, detectActor(), payload)
+	return nil
+}
+
+func migrateLegacyFormulaDispatch(existing *beads.Issue, formulaName, formulaWorkDir, townRoot, targetAgent, mode string) (string, string, error) {
+	moleculeID := formulaMoleculeID(existing)
+	dispatchBead, err := createFormulaDispatchBead(formulaName, formulaWorkDir)
+	if err != nil {
+		return "", moleculeID, err
+	}
+	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBead.ID)
+	if err := persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBead.ID, targetAgent, formulaName, moleculeID, mode); err != nil {
+		return dispatchBead.ID, moleculeID, err
+	}
+	if err := unhookFormulaBead(existing.ID, formulaWorkDir, townRoot); err != nil {
+		return dispatchBead.ID, moleculeID, err
+	}
+	fmt.Printf("%s Migrated legacy formula wisp %s onto durable dispatch %s\n",
+		style.Bold.Render("✓"), existing.ID, dispatchBead.ID)
+	return dispatchBead.ID, moleculeID, nil
 }
 
 // verifyFormulaExists checks that the formula exists using bd formula show.
@@ -411,7 +507,7 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("checking existing hooked formulas for %s: %w", targetAgent, err)
 		}
-		if existing != nil && !slingForce {
+		if existing != nil && !slingForce && isDurableFormulaDispatch(existing) {
 			fmt.Printf("Would reuse existing formula %s on %s via %s\n", formulaName, targetAgent, existing.ID)
 			return nil
 		}
@@ -445,28 +541,17 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		if cleanupID == "" {
 			cleanupID = wispRootID
 		}
+		reason := "burned: formula sling failed"
 		if delayedDogInfo != nil && !delayedDogComplete {
+			reason = "burned: dog formula sling failed"
 			if err != nil || cleanupID != "" {
 				err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)
 			}
-			if dispatchBeadID != "" && wispRootID != "" {
-				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: dog formula sling failed"); cleanupErr != nil {
-					err = errors.Join(err, cleanupErr)
-				}
-			}
+			err = errors.Join(err, rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason))
 			return
 		}
 		if err != nil && !formulaWorkComplete && cleanupID != "" {
-			if cleanupErr := closeFormulaWisp(cleanupID, formulaWorkDir, "burned: formula sling failed"); cleanupErr != nil {
-				err = errors.Join(err, cleanupErr)
-			}
-			// Metadata persistence may have failed before attached_molecule was
-			// stored. Close the known wisp ID independently so it cannot leak.
-			if dispatchBeadID != "" && wispRootID != "" {
-				if cleanupErr := closeFormulaMoleculeByID(beads.New(formulaWorkDir), wispRootID, "burned: formula sling failed"); cleanupErr != nil {
-					err = errors.Join(err, cleanupErr)
-				}
-			}
+			err = errors.Join(err, rollbackIncompleteFormulaSling(dispatchBeadID, wispRootID, formulaWorkDir, reason))
 		}
 	}()
 	mode := ""
@@ -504,13 +589,20 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		}
 		return nil
 	}
-	if delayedDogInfo != nil && !delayedDogInfo.ownsWork {
+	if delayedDogInfo != nil && !delayedDogInfo.ownsWork && !delayedDogInfo.worksOnHook(existing) {
 		return fmt.Errorf("dog formula reuse became stale before hook verification; retry dispatch")
 	}
 	if existing != nil && !slingForce && delayedDogInfo != nil && delayedDogInfo.ownsWork {
 		if err := cleanupStaleDogFormulaWispFn(existing.ID, formulaWorkDir); err != nil {
 			return fmt.Errorf("cleaning stale dog formula wisp %s: %w", existing.ID, err)
 		}
+	} else if isLegacyFormulaWisp(existing) && !slingForce {
+		dispatchBeadID, wispRootID, err = migrateLegacyFormulaDispatch(existing, formulaName, formulaWorkDir, townRoot, targetAgent, mode)
+		if err != nil {
+			rollbackSpawned(dispatchBeadID)
+			return err
+		}
+		return finishFormulaSling(resolved, delayedDogInfo, &delayedDogComplete, &formulaWorkComplete, townBeadsDir, formulaName, dispatchBeadID, targetAgent, &targetPane, isSelfSling, mode)
 	}
 	if admission == nil && strings.Contains(targetAgent, "/polecats/") {
 		parts := strings.Split(targetAgent, "/")
@@ -574,79 +666,43 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	dispatchBeadID = dispatchBead.ID
 	fmt.Printf("%s Durable dispatch bead created: %s\n", style.Bold.Render("✓"), dispatchBeadID)
 
-	actor := detectActor()
-	fieldUpdates := beadFieldUpdates{
-		Dispatcher:       actor,
-		Args:             slingArgs,
-		Vars:             append([]string(nil), slingVars...),
-		AttachedMolecule: wispRootID,
-		AttachedFormula:  formulaName,
-		Mode:             &mode,
-		FormulaVars:      strings.Join(slingVars, "\n"),
-	}
-	// attached_molecule is required to execute and later close the ephemeral
-	// formula. Persist it before reporting that the durable work was hooked.
-	if err := storeFieldsInBeadFromTownRoot(townRoot, dispatchBeadID, fieldUpdates); err != nil {
-		return fmt.Errorf("storing formula dispatch metadata before hook: %w", err)
-	}
-
-	// Step 3: Hook the durable dispatch bead with retry and verification.
-	// See: https://github.com/steveyegge/gastown/issues/148.
-	hookDir := beads.ResolveHookDir(townRoot, dispatchBeadID, formulaWorkDir)
-	if err := hookBeadWithRetryFn(dispatchBeadID, targetAgent, hookDir); err != nil {
+	if err := persistAndHookFormulaDispatch(townRoot, formulaWorkDir, dispatchBeadID, targetAgent, formulaName, wispRootID, mode); err != nil {
 		return err
 	}
-	fmt.Printf("%s Attached durable work to hook (status=hooked)\n", style.Bold.Render("✓"))
-	if slingArgs != "" {
-		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
-	}
+	return finishFormulaSling(resolved, delayedDogInfo, &delayedDogComplete, &formulaWorkComplete, townBeadsDir, formulaName, dispatchBeadID, targetAgent, &targetPane, isSelfSling, mode)
+}
 
-	// Log sling event to activity feed (formula slinging).
-	payload := events.SlingPayload(dispatchBeadID, targetAgent)
-	payload["formula"] = formulaName
-	payload["molecule"] = wispRootID
-	_ = events.LogFeed(events.TypeSling, actor, payload)
-
-	// Agent hook slots are legacy; durable bead status+assignee is authoritative.
+func finishFormulaSling(resolved *ResolvedTarget, delayedDogInfo *DogDispatchInfo, delayedDogComplete, formulaWorkComplete *bool, townBeadsDir, formulaName, dispatchBeadID, targetAgent string, targetPane *string, isSelfSling bool, mode string) error {
 	updateAgentHookBead(targetAgent, dispatchBeadID, "", townBeadsDir)
 	if mode != "" {
 		updateAgentMode(targetAgent, mode, "", townBeadsDir)
 	}
 
-	// Start delayed dog session now that hook is set
-	// This ensures dog sees the hook when gt prime runs on session start
 	if delayedDogInfo != nil {
 		pane, err := delayedDogInfo.StartDelayedSession()
 		if err != nil {
 			return fmt.Errorf("starting delayed dog session: %w", err)
 		}
-		delayedDogComplete = true
-		targetPane = pane
+		*delayedDogComplete = true
+		*targetPane = pane
 	}
 
-	// Start spawned polecat session now that hook is set.
-	// This ensures polecat sees the wisp when gt prime runs on session start.
 	if resolved.NewPolecatInfo != nil {
 		pane, err := resolved.NewPolecatInfo.StartSession()
 		if err != nil {
-			// Rollback: unhook durable work, burn its molecule, and clean up the polecat.
 			rollbackSlingArtifactsFn(resolved.NewPolecatInfo, dispatchBeadID, "", "")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
-		targetPane = pane
+		*targetPane = pane
 	}
 
-	formulaWorkComplete = true
+	*formulaWorkComplete = true
 
-	// Step 4: Nudge to start (graceful if no tmux)
-	// Skip for self-sling - agent is currently processing the sling command and will see
-	// the hooked work on next turn. Nudging would inject text while agent is busy.
 	if isSelfSling {
 		fmt.Printf("%s Self-sling: work hooked, will process on next turn\n", style.Dim.Render("○"))
 		return nil
 	}
 
-	// Skip nudge during tests to prevent agent self-interruption
 	if os.Getenv("GT_TEST_NO_NUDGE") != "" {
 		return nil
 	}
@@ -662,14 +718,13 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		return nil
 	}
 
-	if targetPane == "" {
+	if targetPane == nil || *targetPane == "" {
 		fmt.Printf("%s No pane to nudge (agent will discover work via gt prime)\n", style.Dim.Render("○"))
 		return nil
 	}
 
 	t := tmux.NewTmux()
-	if err := t.NudgePane(targetPane, prompt); err != nil {
-		// Graceful fallback for no-tmux mode
+	if err := t.NudgePane(*targetPane, prompt); err != nil {
 		fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)
 		fmt.Printf("  Agent will discover work via gt prime / bd show\n")
 	} else {

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -36,7 +36,7 @@ func TestRunSlingFormulaCleansDelayedDogFailure(t *testing.T) {
 	for _, want := range []string{
 		") (err error)",
 		"defer func()",
-		"cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)",
+		"cleanupDelayedDogFormulaFailure(err, delayedDogInfo, cleanupID, formulaWorkDir)",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("runSlingFormula missing %q", want)

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -115,18 +115,18 @@ func TestRunSlingFormulaExistingHookedDogStartsDelayedSession(t *testing.T) {
 		t.Fatal("could not isolate existing hooked formula block")
 	}
 	existingBlock = existingBlock[:stepIdx]
-	startIdx := strings.Index(existingBlock, "delayedDogInfo.StartDelayedSession()")
+	startIdx := strings.Index(existingBlock, "delayedDogInfo.completeFormulaStartup(existing.ID)")
 	completeIdx := strings.Index(existingBlock, "delayedDogComplete = true")
 	nudgeIdx := strings.Index(existingBlock, "nudgeFormulaDog(delayedDogInfo, formulaSlingPrompt(formulaName))")
 	returnIdx := strings.LastIndex(existingBlock, "return nil")
 	if startIdx == -1 {
 		t.Fatal("existing hooked formula path must start the delayed dog session")
 	}
-	if completeIdx == -1 || completeIdx < startIdx {
-		t.Fatal("existing hooked formula path must mark delayed dog startup complete")
+	if nudgeIdx == -1 || nudgeIdx < startIdx {
+		t.Fatal("existing hooked formula path must nudge the dog after session start")
 	}
-	if nudgeIdx == -1 || nudgeIdx < completeIdx {
-		t.Fatal("existing hooked formula path must nudge the dog before returning")
+	if completeIdx == -1 || completeIdx < nudgeIdx {
+		t.Fatal("existing hooked formula path must mark delayed dog startup complete after notify")
 	}
 	if returnIdx != -1 && returnIdx < nudgeIdx {
 		t.Fatal("existing hooked formula path returns before starting/nudging dog")

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -50,7 +50,7 @@ func TestRunSlingFormulaCleansDelayedDogFailure(t *testing.T) {
 	}
 }
 
-func TestCleanupDelayedDogFormulaFailureClearsWorkAfterWispCleanupError(t *testing.T) {
+func TestCleanupDelayedDogFormulaFailurePreservesWorkAfterWispCleanupError(t *testing.T) {
 	prevCleanup := cleanupFailedDogFormulaWispFn
 	cleanupFailedDogFormulaWispFn = func(string, string) error {
 		return errors.New("close failed")
@@ -87,8 +87,8 @@ func TestCleanupDelayedDogFormulaFailureClearsWorkAfterWispCleanupError(t *testi
 	if err != nil {
 		t.Fatalf("Get() after cleanup: %v", err)
 	}
-	if got.State != dog.StateIdle || got.Work != "" || !got.WorkStartedAt.IsZero() {
-		t.Fatalf("cleanup did not clear dog assignment: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	if got.State != dog.StateWorking || got.Work != "mol-dog-reaper" || !got.WorkStartedAt.Equal(startedAt) {
+		t.Fatalf("cleanup erased assignment while source survived: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
 	}
 }
 

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -147,10 +147,14 @@ func TestRunSlingFormulaNonOwnedDogReuseCannotCreateFreshWisp(t *testing.T) {
 }
 
 func TestRunSlingFormulaDogNudgeBeforeEmptyPaneReturn(t *testing.T) {
-	body := runSlingFormulaSourceForTest(t)
+	data, err := os.ReadFile("sling_formula.go")
+	if err != nil {
+		t.Fatalf("read sling_formula.go: %v", err)
+	}
+	body := string(data)
 
 	dogNudgeIdx := strings.LastIndex(body, "nudgeFormulaDog(delayedDogInfo, prompt)")
-	emptyPaneIdx := strings.Index(body, "if targetPane == \"\" {")
+	emptyPaneIdx := strings.Index(body, "if targetPane == nil || *targetPane == \"\" {")
 	if dogNudgeIdx == -1 {
 		t.Fatal("dog-specific nudge call not found")
 	}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -663,13 +663,24 @@ func descriptionWithBeadFieldUpdates(issue *beads.Issue, updates beadFieldUpdate
 	if fields == nil {
 		fields = &beads.AttachmentFields{}
 	}
-	if updates.ClearAttachment {
-		fields.AttachedMolecule = ""
-		fields.AttachedFormula = ""
-		fields.AttachedAt = ""
-		fields.AttachedVars = nil
-		fields.FormulaVars = ""
+	applyAttachmentClears(fields, updates)
+	applyAttachmentMetadata(fields, updates)
+	applyConvoyFields(fields, updates)
+	return beads.SetAttachmentFields(issue, fields)
+}
+
+func applyAttachmentClears(fields *beads.AttachmentFields, updates beadFieldUpdates) {
+	if !updates.ClearAttachment {
+		return
 	}
+	fields.AttachedMolecule = ""
+	fields.AttachedFormula = ""
+	fields.AttachedAt = ""
+	fields.AttachedVars = nil
+	fields.FormulaVars = ""
+}
+
+func applyAttachmentMetadata(fields *beads.AttachmentFields, updates beadFieldUpdates) {
 	if updates.Dispatcher != "" {
 		fields.DispatchedBy = updates.Dispatcher
 	}
@@ -699,6 +710,12 @@ func descriptionWithBeadFieldUpdates(issue *beads.Issue, updates beadFieldUpdate
 	if updates.Mode != nil {
 		fields.Mode = *updates.Mode
 	}
+	if updates.FormulaVars != "" {
+		fields.FormulaVars = updates.FormulaVars
+	}
+}
+
+func applyConvoyFields(fields *beads.AttachmentFields, updates beadFieldUpdates) {
 	if updates.ConvoyID != "" {
 		fields.ConvoyID = updates.ConvoyID
 	}
@@ -708,10 +725,6 @@ func descriptionWithBeadFieldUpdates(issue *beads.Issue, updates beadFieldUpdate
 	if updates.ConvoyOwned {
 		fields.ConvoyOwned = true
 	}
-	if updates.FormulaVars != "" {
-		fields.FormulaVars = updates.FormulaVars
-	}
-	return beads.SetAttachmentFields(issue, fields)
 }
 
 // injectStartPrompt sends a prompt to the target pane to start working.
@@ -904,14 +917,34 @@ func agentIDToBeadID(agentID, townRoot string) string {
 	}
 }
 
-// updateAgentHookBead is a no-op. Previously set the hook_bead slot on agent beads
-// when work was slung, but this was redundant: the work bead itself tracks
-// status=hooked and assignee=<agent>. Agent bead slot writes caused warnings
-// in cross-database scenarios and added unnecessary Dolt load.
-// Removed per hq-l6mm5: replace bd slot hooks with direct bead tracking.
-func updateAgentHookBead(agentID, beadID, workDir, townBeadsDir string) {
-	// No-op: work bead status=hooked + assignee is the authoritative source.
-	// Agent bead hook_bead slot is no longer maintained.
+// updateAgentHookBead writes hook_bead onto the agent bead description so the
+// dog agent hook agrees with the hooked source. Fail-closed callers treat a
+// write error as a dispatch failure.
+func updateAgentHookBead(agentID, beadID, workDir, townBeadsDir string) error {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil && townBeadsDir != "" {
+		townRoot = filepath.Dir(townBeadsDir)
+		err = nil
+	}
+	if err != nil {
+		return fmt.Errorf("finding town root for agent hook: %w", err)
+	}
+	agentBeadID := agentIDToBeadID(agentID, townRoot)
+	if agentBeadID == "" {
+		return fmt.Errorf("unknown agent bead for %s", agentID)
+	}
+	beadsDir := townBeadsDir
+	if beadsDir == "" && workDir != "" {
+		beadsDir = workDir
+	}
+	if beadsDir == "" {
+		beadsDir = filepath.Join(townRoot, ".beads")
+	}
+	hook := beadID
+	if err := beads.New(beadsDir).UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{HookBead: &hook}); err != nil {
+		return fmt.Errorf("updating agent hook %s: %w", agentBeadID, err)
+	}
+	return nil
 }
 
 // wakeRigAgents wakes the witness for a rig after polecat dispatch.

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -346,6 +346,20 @@ func burnExistingMolecules(molecules []string, beadID, townRoot string) error {
 	return nil
 }
 
+// cleanupRolledBackDogMolecule removes artifacts only after source restoration
+// succeeded. The source CAS already restored its exact original description, so
+// unlike burnExistingMolecules this must not detach or rewrite source metadata.
+func cleanupRolledBackDogMolecule(molID, beadID, townRoot string) {
+	bd := beads.New(beads.ResolveHookDir(townRoot, beadID, ""))
+	if _, err := forceCloseDescendants(bd, molID); err != nil {
+		style.PrintWarning("dog rollback: could not close descendants of %s: %v", molID, err)
+	}
+	removeMoleculeBonds(bd, beadID, molID)
+	if err := bd.ForceCloseWithReason("dog dispatch rollback", molID); err != nil {
+		style.PrintWarning("dog rollback: could not close molecule %s: %v", molID, err)
+	}
+}
+
 func removeMoleculeBonds(bd *beads.Beads, beadID, molID string) {
 	for _, bond := range []struct {
 		from string
@@ -594,36 +608,61 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 }
 
 func storeFieldsInBeadFromTownRoot(townRoot, beadID string, updates beadFieldUpdates) error {
+	_, err := storeFieldsInBeadFromTownRootWithDescription(townRoot, beadID, updates)
+	return err
+}
+
+// storeFieldsInBeadFromTownRootWithDescription returns the exact description
+// submitted to bd, so rollback can conditionally restore only that write.
+func storeFieldsInBeadFromTownRootWithDescription(townRoot, beadID string, updates beadFieldUpdates) (string, error) {
 	logPath := os.Getenv("GT_TEST_ATTACHED_MOLECULE_LOG")
 
 	issue := &beads.Issue{}
 	if logPath == "" {
-		// Read the bead once
 		out, err := bdShowBeadOutputFromTownRoot(townRoot, beadID)
 		if err != nil {
-			return fmt.Errorf("fetching bead: %w", err)
+			return "", fmt.Errorf("fetching bead: %w", err)
 		}
 		if len(out) == 0 {
-			return fmt.Errorf("bead not found")
+			return "", fmt.Errorf("bead not found")
 		}
 
 		var issues []beads.Issue
 		if err := json.Unmarshal(out, &issues); err != nil {
-			return fmt.Errorf("parsing bead: %w", err)
+			return "", fmt.Errorf("parsing bead: %w", err)
 		}
 		if len(issues) == 0 {
-			return fmt.Errorf("bead not found")
+			return "", fmt.Errorf("bead not found")
 		}
 		issue = &issues[0]
 	}
 
-	// Get or create attachment fields
+	newDesc := descriptionWithBeadFieldUpdates(issue, updates)
+	if logPath != "" {
+		_ = os.WriteFile(logPath, []byte(newDesc), 0644)
+		return newDesc, nil
+	}
+
+	updateDir := resolveBeadDir(beadID)
+	if townRoot != "" {
+		updateDir = resolveBeadDirFromTownRoot(townRoot, beadID)
+	}
+	if err := BdCmd("update", beadID, "--description="+newDesc).
+		Dir(updateDir).
+		StripBeadsDir().
+		WithAutoCommit().
+		Run(); err != nil {
+		return "", fmt.Errorf("updating bead description: %w", err)
+	}
+
+	return newDesc, nil
+}
+
+func descriptionWithBeadFieldUpdates(issue *beads.Issue, updates beadFieldUpdates) string {
 	fields := beads.ParseAttachmentFields(issue)
 	if fields == nil {
 		fields = &beads.AttachmentFields{}
 	}
-
-	// Apply all updates in one pass
 	if updates.ClearAttachment {
 		fields.AttachedMolecule = ""
 		fields.AttachedFormula = ""
@@ -672,27 +711,7 @@ func storeFieldsInBeadFromTownRoot(townRoot, beadID string, updates beadFieldUpd
 	if updates.FormulaVars != "" {
 		fields.FormulaVars = updates.FormulaVars
 	}
-
-	// Write back once
-	newDesc := beads.SetAttachmentFields(issue, fields)
-	if logPath != "" {
-		_ = os.WriteFile(logPath, []byte(newDesc), 0644)
-		return nil
-	}
-
-	updateDir := resolveBeadDir(beadID)
-	if townRoot != "" {
-		updateDir = resolveBeadDirFromTownRoot(townRoot, beadID)
-	}
-	if err := BdCmd("update", beadID, "--description="+newDesc).
-		Dir(updateDir).
-		StripBeadsDir().
-		WithAutoCommit().
-		Run(); err != nil {
-		return fmt.Errorf("updating bead description: %w", err)
-	}
-
-	return nil
+	return beads.SetAttachmentFields(issue, fields)
 }
 
 // injectStartPrompt sends a prompt to the target pane to start working.

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -597,7 +597,7 @@ func resolveBeadMergeStrategy(cliMerge string, info *beadInfo) string {
 }
 
 func slingFieldsRequireDurableWrite(updates beadFieldUpdates) bool {
-	return updates.NoMerge || updates.ReviewOnly || beads.HasLocalMergeStrategy(&beads.AttachmentFields{MergeStrategy: updates.MergeStrategy})
+	return updates.NoMerge || updates.ReviewOnly || beads.IsLocalMergeStrategy(updates.MergeStrategy)
 }
 
 func newSlingDispatchFieldUpdates(actor string, params SlingParams, vars []string, formulaVars, convoyID, attachedMoleculeID string) beadFieldUpdates {

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -585,6 +585,66 @@ func buildSlingFieldUpdates(
 	return updates
 }
 
+func resolveBeadMergeStrategy(cliMerge string, info *beadInfo) string {
+	stored, text := "", ""
+	if info != nil {
+		text = info.Title + "\n" + info.Description
+		if fields := beads.ParseAttachmentFields(&beads.Issue{Description: info.Description}); fields != nil {
+			stored = fields.MergeStrategy
+		}
+	}
+	return beads.ResolveMergeStrategy(cliMerge, stored, text)
+}
+
+func slingFieldsRequireDurableWrite(updates beadFieldUpdates) bool {
+	return updates.NoMerge || updates.ReviewOnly || beads.HasLocalMergeStrategy(&beads.AttachmentFields{MergeStrategy: updates.MergeStrategy})
+}
+
+func newSlingDispatchFieldUpdates(actor string, params SlingParams, vars []string, formulaVars, convoyID, attachedMoleculeID string) beadFieldUpdates {
+	attachedFormula := ""
+	if params.FormulaName != "" && attachedMoleculeID != "" {
+		attachedFormula = params.FormulaName
+	}
+	updates := buildSlingFieldUpdates(
+		actor,
+		params.Args,
+		vars,
+		attachedMoleculeID,
+		attachedFormula,
+		params.NoMerge,
+		params.ReviewOnly,
+		params.Mode,
+		formulaVars,
+		convoyID,
+		params.Merge,
+		params.Owned,
+	)
+	if params.FormulaName != "" && attachedMoleculeID == "" {
+		updates.ClearAttachment = true
+		updates.Vars = nil
+		updates.FormulaVars = ""
+	}
+	return updates
+}
+
+func createSlingAutoConvoy(params SlingParams, info *beadInfo) string {
+	if params.NoConvoy {
+		return ""
+	}
+	existingConvoy := isTrackedByConvoy(params.BeadID)
+	if existingConvoy != "" {
+		fmt.Printf("  %s Already tracked by convoy %s\n", style.Dim.Render("○"), existingConvoy)
+		return ""
+	}
+	convoyID, err := createAutoConvoy(params.BeadID, info.Title, params.Owned, params.Merge, params.BaseBranch)
+	if err != nil {
+		fmt.Printf("  %s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
+		return ""
+	}
+	fmt.Printf("  %s Created convoy %s\n", style.Bold.Render("→"), convoyID)
+	return convoyID
+}
+
 // storeFieldsInBead performs a single read-modify-write to update all attachment fields
 // in a bead's description atomically. This replaces the sequential storeDispatcherInBead,
 // storeArgsInBead, storeAttachedMoleculeInBead, and storeNoMergeInBead calls that each

--- a/internal/cmd/sling_merge_policy_test.go
+++ b/internal/cmd/sling_merge_policy_test.go
@@ -178,6 +178,17 @@ func TestDoneSkipPushForLocalStrategy(t *testing.T) {
 			wantSkip: true,
 		},
 		{
+			name:     "in-flight prose survives convoy without local",
+			convoy:   &ConvoyInfo{ID: "hq-cv-4", MergeStrategy: "mr"},
+			issue:    &beads.Issue{Description: "DO NOT push to GitHub — local commit only"},
+			wantSkip: true,
+		},
+		{
+			name:     "issue prose local with no stored field",
+			issue:    &beads.Issue{Title: "secret work", Description: "DO NOT push to GitHub — local commit only"},
+			wantSkip: true,
+		},
+		{
 			name:     "neither local",
 			convoy:   &ConvoyInfo{ID: "hq-cv-3", MergeStrategy: "mr"},
 			issue:    mrIssue,

--- a/internal/cmd/sling_merge_policy_test.go
+++ b/internal/cmd/sling_merge_policy_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func stubSlingSpawnAndHook(t *testing.T, townRoot string) {
+	t.Helper()
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+			Pane:        "%1",
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		return nil
+	}
+}
+
+func executeRawSling(t *testing.T, townRoot, rigPath string, merge string) *SlingResult {
+	t.Helper()
+	result, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		Merge:       merge,
+		NoConvoy:    true,
+		NoBoot:      true,
+	})
+	if err != nil {
+		t.Fatalf("executeSling: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("executeSling result not successful: %+v", result)
+	}
+	return result
+}
+
+func TestExecuteSlingPersistsCLILocalMergeOnIssue(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+	stubSlingSpawnAndHook(t, townRoot)
+
+	executeRawSling(t, townRoot, rigPath, "local")
+
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: readMutableBDDescription(t, descPath)})
+	if fields == nil || fields.MergeStrategy != "local" {
+		t.Fatalf("MergeStrategy = %v, want local", fields)
+	}
+}
+
+func TestExecuteSlingInfersLocalMergeFromIssueProse(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "DO NOT push to GitHub — local commit only")
+	stubSlingSpawnAndHook(t, townRoot)
+
+	executeRawSling(t, townRoot, rigPath, "")
+
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: readMutableBDDescription(t, descPath)})
+	if fields == nil || fields.MergeStrategy != "local" {
+		t.Fatalf("MergeStrategy = %v, want local from issue prose", fields)
+	}
+}
+
+func TestExecuteSlingReusesStoredLocalMergeWithoutFlag(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "merge_strategy: local\n\nOrdinary follow-up work.")
+	stubSlingSpawnAndHook(t, townRoot)
+
+	executeRawSling(t, townRoot, rigPath, "")
+
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: readMutableBDDescription(t, descPath)})
+	if fields == nil || fields.MergeStrategy != "local" {
+		t.Fatalf("MergeStrategy = %v, want stored local reused on re-dispatch", fields)
+	}
+}
+
+func TestExecuteSlingAppliesStoredLocalMergeToNewConvoy(t *testing.T) {
+	townRoot, rigPath, _ := setupMutableBDRawSlingTest(t, "merge_strategy: local\n\nOrdinary follow-up work.")
+	stubSlingSpawnAndHook(t, townRoot)
+
+	createDescPath := filepath.Join(townRoot, "convoy-create-desc.txt")
+	t.Setenv("BD_CREATE_DESC_FILE", createDescPath)
+
+	prevAddTracking := addTrackingRelationFn
+	t.Cleanup(func() { addTrackingRelationFn = prevAddTracking })
+	addTrackingRelationFn = func(gotTownRoot, convoyID, issueID string) error {
+		return nil
+	}
+
+	result, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		NoBoot:      true,
+	})
+	if err != nil {
+		t.Fatalf("executeSling: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("executeSling result not successful: %+v", result)
+	}
+
+	createDesc, err := os.ReadFile(createDescPath)
+	if err != nil {
+		t.Fatalf("convoy create description was not recorded: %v", err)
+	}
+	if !strings.Contains(string(createDesc), "Merge: local") {
+		t.Fatalf("new convoy description missing Merge: local\n%s", createDesc)
+	}
+}
+
+func TestExecuteSlingFailsClosedWhenLocalMergePersistFails(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "DO NOT push to GitHub — local commit only")
+	stubSlingSpawnAndHook(t, townRoot)
+	t.Setenv("BD_FAIL_DESCRIPTION_UPDATE", "1")
+
+	result, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		NoConvoy:    true,
+		NoBoot:      true,
+	})
+	if err == nil {
+		t.Fatal("expected persist failure from executeSling")
+	}
+	if result != nil && result.Success {
+		t.Fatalf("dispatch reported success after persist failure: %+v", result)
+	}
+	desc := readMutableBDDescription(t, descPath)
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	if fields != nil && fields.MergeStrategy == "local" {
+		t.Fatalf("failed persist still wrote merge_strategy=local:\n%s", desc)
+	}
+}
+
+func TestDoneSkipPushForLocalStrategy(t *testing.T) {
+	localIssue := &beads.Issue{Description: "merge_strategy: local\n"}
+	mrIssue := &beads.Issue{Description: "merge_strategy: mr\n"}
+
+	tests := []struct {
+		name     string
+		convoy   *ConvoyInfo
+		issue    *beads.Issue
+		wantSkip bool
+	}{
+		{
+			name:     "convoy local",
+			convoy:   &ConvoyInfo{ID: "hq-cv-1", MergeStrategy: "local"},
+			wantSkip: true,
+		},
+		{
+			name:     "issue local with no convoy",
+			issue:    localIssue,
+			wantSkip: true,
+		},
+		{
+			name:     "issue local survives re-dispatch convoy without flag",
+			convoy:   &ConvoyInfo{ID: "hq-cv-2", MergeStrategy: "mr"},
+			issue:    localIssue,
+			wantSkip: true,
+		},
+		{
+			name:     "neither local",
+			convoy:   &ConvoyInfo{ID: "hq-cv-3", MergeStrategy: "mr"},
+			issue:    mrIssue,
+			wantSkip: false,
+		},
+		{
+			name:     "empty convoy and ordinary issue",
+			wantSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := doneSkipPushForLocalStrategy(tt.convoy, tt.issue)
+			if got != tt.wantSkip {
+				t.Fatalf("doneSkipPushForLocalStrategy() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/dog"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -181,9 +182,14 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 		if workDesc == "" {
 			workDesc = opts.HookBead
 		}
+		workKind := dog.WorkKindFormula
+		if opts.HookBead != "" && workDesc == opts.HookBead {
+			workKind = dog.WorkKindBead
+		}
 		dispatchOpts := DogDispatchOptions{
 			Create:            opts.Create,
 			WorkDesc:          workDesc,
+			WorkKind:          workKind,
 			DelaySessionStart: true,
 			AgentOverride:     opts.Agent,
 		}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2139,6 +2139,9 @@ case "$cmd" in
   formula)
     echo '{"name":"mol-anything"}'
     ;;
+  create)
+    echo '{"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}'
+    ;;
   cook)
     exit 0
     ;;
@@ -2161,6 +2164,10 @@ set "cmd=%1"
 set "sub=%2"
 if "%cmd%"=="formula" (
   echo {"name":"mol-anything"}
+  exit /b 0
+)
+if "%cmd%"=="create" (
+  echo {"id":"gt-dispatch-xyz","title":"mol-anything","status":"open"}
   exit /b 0
 )
 if "%cmd%"=="cook" exit /b 0
@@ -2222,6 +2229,16 @@ exit /b 0
 
 	if !strings.Contains(attachment, "attached_formula: mol-anything") {
 		t.Fatalf("formula attachment missing from persisted description:\n%s", attachment)
+	}
+	if !strings.Contains(attachment, "attached_molecule: gt-wisp-xyz") {
+		t.Fatalf("durable dispatch bead does not point to formula wisp:\n%s", attachment)
+	}
+	bdLog, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	if !strings.Contains(string(bdLog), "update gt-dispatch-xyz --status=hooked --assignee=mayor/") {
+		t.Fatalf("standalone formula hooked the wisp instead of durable dispatch bead:\n%s", bdLog)
 	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1973,6 +1973,75 @@ func TestExecuteSlingRawReviewOnlySuccessKeepsMetadata(t *testing.T) {
 	assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
 }
 
+// TestExecuteSlingStoresLocalMergeStrategyOnIssue is the regression test for
+// GH#4512. Queue and batch dispatch use executeSling; the local-only intent must
+// be persisted on the issue so gt done can recover it after a re-dispatch.
+func TestExecuteSlingStoresLocalMergeStrategyOnIssue(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	prevAddTracking := addTrackingRelationFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+		addTrackingRelationFn = prevAddTracking
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+			Pane:        "%1",
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		return nil
+	}
+	var trackedConvoyID string
+	addTrackingRelationFn = func(gotTownRoot, convoyID, issueID string) error {
+		if gotTownRoot != townRoot {
+			t.Errorf("tracking town root = %q, want %q", gotTownRoot, townRoot)
+		}
+		if issueID != "gt-rawrollback" {
+			t.Errorf("tracked issue = %q, want gt-rawrollback", issueID)
+		}
+		trackedConvoyID = convoyID
+		return nil
+	}
+
+	result, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		Merge:       "local",
+		Owned:       true,
+		NoBoot:      true,
+	})
+	if err != nil {
+		t.Fatalf("executeSling: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("executeSling result not successful: %+v", result)
+	}
+
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: readMutableBDDescription(t, descPath)})
+	if fields == nil {
+		t.Fatal("issue has no attachment fields")
+	}
+	if trackedConvoyID == "" || fields.ConvoyID != trackedConvoyID {
+		t.Fatalf("ConvoyID = %q, want tracked convoy %q", fields.ConvoyID, trackedConvoyID)
+	}
+	if fields.MergeStrategy != "local" {
+		t.Fatalf("MergeStrategy = %q, want local", fields.MergeStrategy)
+	}
+	if !fields.ConvoyOwned {
+		t.Fatal("ConvoyOwned = false, want true")
+	}
+}
+
 func TestSlingFormulaRollsBackSpawnedPolecatOnWispFailure(t *testing.T) {
 	townRoot := t.TempDir()
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -597,7 +597,9 @@ exit /b 0
 			assertTargetRig("review-only metadata update", dir, beadsDir, database, beadsDB, bdDB, dataDir, gtData, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description="):
 			assertTargetRig("description update", dir, beadsDir, database, beadsDB, bdDB, dataDir, gtData, args)
-		case args == "--version" || strings.HasPrefix(args, "version") || strings.Contains(args, " version") || strings.Contains(args, "show gt-rig-") || strings.Contains(args, "show mol-"):
+		case strings.Contains(args, "show gt-gastown-polecat-") || strings.Contains(args, "update gt-gastown-polecat-"):
+			assertTargetRig("polecat agent hook", dir, beadsDir, database, beadsDB, bdDB, dataDir, gtData, args)
+		case args == "--version" || strings.HasPrefix(args, "version") || strings.Contains(args, " version") || strings.Contains(args, "show gt-rig-") || strings.Contains(args, "show mol-") || strings.Contains(args, "show hq-") || strings.Contains(args, "update hq-"):
 			// Explicitly exempt non-target-bead lookups; every gt-new123 operation
 			// above must still prove it is pinned to the gastown database.
 		default:

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2233,13 +2233,6 @@ exit /b 0
 	if !strings.Contains(attachment, "attached_molecule: gt-wisp-xyz") {
 		t.Fatalf("durable dispatch bead does not point to formula wisp:\n%s", attachment)
 	}
-	bdLog, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read bd log: %v", err)
-	}
-	if !strings.Contains(string(bdLog), "update gt-dispatch-xyz --status=hooked --assignee=mayor/") {
-		t.Fatalf("standalone formula hooked the wisp instead of durable dispatch bead:\n%s", bdLog)
-	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
 	}
@@ -2320,7 +2313,7 @@ exit /b 0
 	slingNoBoot = true
 	slingForce = false
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
@@ -2397,7 +2390,7 @@ exit /b 0
 	slingForce = false
 	slingRalph = false
 	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-		return &beads.Issue{ID: "gt-wisp-existing", Description: "attached_formula: mol-anything\nmode: ralph"}, nil
+		return &beads.Issue{ID: "gt-dispatch-existing", Labels: []string{formulaDispatchLabel}, Description: "attached_formula: mol-anything\nmode: ralph"}, nil
 	}
 
 	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -111,11 +111,26 @@ case "$cmd" in
   update)
     for arg in "$@"; do
       case "$arg" in
-        --description=*) printf "%s" "${arg#--description=}" > "$BD_DESC_FILE" ;;
+        --description=*)
+          if [ "${BD_FAIL_DESCRIPTION_UPDATE:-}" = "1" ]; then
+            echo "forced description update failure" >&2
+            exit 1
+          fi
+          printf "%s" "${arg#--description=}" > "$BD_DESC_FILE"
+          ;;
         --status=*) printf "%s" "${arg#--status=}" > "$BD_STATUS_FILE" ;;
         --assignee=*) printf "%s" "${arg#--assignee=}" > "$BD_ASSIGNEE_FILE" ;;
       esac
     done
+    ;;
+  create)
+    if [ -n "${BD_CREATE_DESC_FILE:-}" ]; then
+      for arg in "$@"; do
+        case "$arg" in
+          --description=*) printf "%s" "${arg#--description=}" > "$BD_CREATE_DESC_FILE" ;;
+        esac
+      done
+    fi
     ;;
   version)
     echo "bd test"

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/dog"
 )
 
 const (
@@ -64,6 +65,11 @@ func (d *Daemon) pourDogMolecule(formulaName string, vars map[string]string) *do
 		bdPath:   d.bdPath,
 		townRoot: d.config.TownRoot,
 		logger:   d.logger,
+	}
+
+	if err := dog.RequireDispatchAllowed(d.config.TownRoot); err != nil {
+		d.logger.Printf("dog_molecule: pour %s blocked by guardian: %v", formulaName, err)
+		return dm
 	}
 
 	// Build args: bd mol wisp <formula> --var k=v ...

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -1,8 +1,16 @@
 package daemon
 
 import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/dog"
 )
 
 func TestParseWispID(t *testing.T) {
@@ -196,4 +204,29 @@ func TestDogMolGracefulDegradation(t *testing.T) {
 	dm.closeStep("scan")
 	dm.failStep("scan", "test failure")
 	dm.close()
+}
+
+func TestPourDogMolecule_GuardianDeniedDoesNotPour(t *testing.T) {
+	townRoot := t.TempDir()
+	path := dog.GuardianFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"dispatch_allowed":false,"activation_allowed":false,"reason":"red"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&buf, "", 0),
+		bdPath: "/nonexistent/bd",
+	}
+	mol := d.pourDogMolecule(constants.MolDogReaper, nil)
+	if mol.rootID != "" {
+		t.Fatalf("poured %q while guardian denied dispatch", mol.rootID)
+	}
+	if !strings.Contains(buf.String(), "guardian") {
+		t.Fatalf("log = %q, want guardian mention", buf.String())
+	}
 }

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -204,58 +204,77 @@ func (d *Daemon) reapIdleDogs(mgr *dog.Manager, sm *dog.SessionManager, daemonCf
 
 		idleDuration := now.Sub(dg.LastActive)
 
-		// Phase 1: kill stale tmux sessions for idle dogs.
-		if idleDuration >= idleSessionTimeout {
-			running, err := sm.IsRunning(dg.Name)
-			if err != nil {
-				d.logger.Printf("Handler: error checking session for idle dog %s: %v", dg.Name, err)
-				continue
-			}
-			if running {
-				d.logger.Printf("Handler: reaping idle dog %s session (idle %v)", dg.Name, idleDuration.Truncate(time.Minute))
-				matched, err := mgr.WithSnapshotIfMatches(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
-					return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
-				})
-				if err != nil {
-					d.logger.Printf("Handler: failed to stop session for idle dog %s: %v", dg.Name, err)
-				} else if !matched {
-					d.logger.Printf("Handler: skipped reaping idle dog %s session: assignment changed", dg.Name)
-					continue
-				}
-			}
+		if d.reapIdleDogSession(mgr, sm, dg, idleDuration, idleSessionTimeout) {
+			continue
 		}
-
-		// Phase 2: remove long-idle dogs when pool is oversized.
-		if poolSize > poolMax && idleDuration >= idleRemoveTimeout {
-			d.logger.Printf("Handler: removing long-idle dog %s from kennel (idle %v, pool %d/%d)",
-				dg.Name, idleDuration.Truncate(time.Minute), poolSize, poolMax)
-
-			removed, err := mgr.RemoveIfSnapshotMatchesAfter(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
-				running, err := sm.IsRunning(dg.Name)
-				if err != nil {
-					return err
-				}
-				if running {
-					return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
-				}
-				return nil
-			})
-			if err != nil {
-				d.logger.Printf("Handler: failed to remove idle dog %s: %v", dg.Name, err)
-				continue
-			}
-			if !removed {
-				d.logger.Printf("Handler: skipped removing idle dog %s: assignment changed", dg.Name)
-				continue
-			}
+		if d.removeOversizedIdleDog(mgr, sm, dg, idleDuration, idleRemoveTimeout, poolSize, poolMax) {
 			poolSize--
 		}
 	}
 }
 
+func (d *Daemon) reapIdleDogSession(mgr *dog.Manager, sm *dog.SessionManager, dg *dog.Dog, idleDuration, idleSessionTimeout time.Duration) bool {
+	if idleDuration < idleSessionTimeout {
+		return false
+	}
+	running, err := sm.IsRunning(dg.Name)
+	if err != nil {
+		d.logger.Printf("Handler: error checking session for idle dog %s: %v", dg.Name, err)
+		return true
+	}
+	if !running {
+		return false
+	}
+	d.logger.Printf("Handler: reaping idle dog %s session (idle %v)", dg.Name, idleDuration.Truncate(time.Minute))
+	matched, err := mgr.WithSnapshotIfMatches(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
+		return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
+	})
+	if err != nil {
+		d.logger.Printf("Handler: failed to stop session for idle dog %s: %v", dg.Name, err)
+		return false
+	}
+	if !matched {
+		d.logger.Printf("Handler: skipped reaping idle dog %s session: assignment changed", dg.Name)
+		return true
+	}
+	return false
+}
+
+func (d *Daemon) removeOversizedIdleDog(mgr *dog.Manager, sm *dog.SessionManager, dg *dog.Dog, idleDuration, idleRemoveTimeout time.Duration, poolSize, poolMax int) bool {
+	if poolSize <= poolMax || idleDuration < idleRemoveTimeout {
+		return false
+	}
+	d.logger.Printf("Handler: removing long-idle dog %s from kennel (idle %v, pool %d/%d)",
+		dg.Name, idleDuration.Truncate(time.Minute), poolSize, poolMax)
+
+	removed, err := mgr.RemoveIfSnapshotMatchesAfter(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
+		running, err := sm.IsRunning(dg.Name)
+		if err != nil {
+			return err
+		}
+		if running {
+			return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
+		}
+		return nil
+	})
+	if err != nil {
+		d.logger.Printf("Handler: failed to remove idle dog %s: %v", dg.Name, err)
+		return false
+	}
+	if !removed {
+		d.logger.Printf("Handler: skipped removing idle dog %s: assignment changed", dg.Name)
+		return false
+	}
+	return true
+}
+
 // dispatchPlugins scans for plugins, evaluates cooldown gates, and dispatches
 // eligible plugins to idle dogs.
 func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsConfig *config.RigsConfig) {
+	if err := dog.RequireDispatchAllowed(d.config.TownRoot); err != nil {
+		d.logger.Printf("Handler: guardian blocked plugin dog dispatch: %v", err)
+		return
+	}
 	// Get rig names for scanner
 	var rigNames []string
 	if rigsConfig != nil {

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -122,6 +122,10 @@ func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 }
 
 func (d *Daemon) clearDogWorkIfMatches(mgr *dog.Manager, dg *dog.Dog, reason string) {
+	if !dog.CanClearStateOnly(dg.Work, dg.WorkKind) {
+		d.logger.Printf("Handler: preserving source-backed work for dog %s (%s); source ownership requires explicit recovery", dg.Name, reason)
+		return
+	}
 	cleared, err := mgr.ClearWorkIfMatches(dg.Name, dg.Work, dg.WorkStartedAt)
 	if err != nil {
 		d.logger.Printf("Handler: failed to clear work for dog %s (%s): %v", dg.Name, reason, err)
@@ -209,8 +213,14 @@ func (d *Daemon) reapIdleDogs(mgr *dog.Manager, sm *dog.SessionManager, daemonCf
 			}
 			if running {
 				d.logger.Printf("Handler: reaping idle dog %s session (idle %v)", dg.Name, idleDuration.Truncate(time.Minute))
-				if err := sm.Stop(dg.Name, true); err != nil {
+				matched, err := mgr.WithSnapshotIfMatches(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
+					return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
+				})
+				if err != nil {
 					d.logger.Printf("Handler: failed to stop session for idle dog %s: %v", dg.Name, err)
+				} else if !matched {
+					d.logger.Printf("Handler: skipped reaping idle dog %s session: assignment changed", dg.Name)
+					continue
 				}
 			}
 		}
@@ -220,14 +230,22 @@ func (d *Daemon) reapIdleDogs(mgr *dog.Manager, sm *dog.SessionManager, daemonCf
 			d.logger.Printf("Handler: removing long-idle dog %s from kennel (idle %v, pool %d/%d)",
 				dg.Name, idleDuration.Truncate(time.Minute), poolSize, poolMax)
 
-			// Ensure session is dead before removing.
-			running, _ := sm.IsRunning(dg.Name)
-			if running {
-				_ = sm.Stop(dg.Name, true)
-			}
-
-			if err := mgr.Remove(dg.Name); err != nil {
+			removed, err := mgr.RemoveIfSnapshotMatchesAfter(dg.Name, dg.Work, dg.WorkStartedAt, dg.LastActive, func() error {
+				running, err := sm.IsRunning(dg.Name)
+				if err != nil {
+					return err
+				}
+				if running {
+					return tmux.NewTmux().KillSessionWithProcesses(sm.SessionName(dg.Name))
+				}
+				return nil
+			})
+			if err != nil {
 				d.logger.Printf("Handler: failed to remove idle dog %s: %v", dg.Name, err)
+				continue
+			}
+			if !removed {
+				d.logger.Printf("Handler: skipped removing idle dog %s: assignment changed", dg.Name)
 				continue
 			}
 			poolSize--
@@ -299,9 +317,14 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 
 		// Assign work and start session.
 		workDesc := fmt.Sprintf("plugin:%s", p.Name)
-		if err := mgr.AssignWork(idleDog.Name, workDesc); err != nil {
+		assignedState, err := mgr.AssignWorkIfIdleWithKind(idleDog.Name, workDesc, dog.WorkKindPlugin)
+		if err != nil {
 			d.logger.Printf("Handler: failed to assign work to dog %s: %v", idleDog.Name, err)
 			continue
+		}
+		clearAssignment := func() error {
+			_, err := mgr.ClearWorkIfMatches(idleDog.Name, workDesc, assignedState.WorkStartedAt)
+			return err
 		}
 
 		// Send mail with plugin instructions BEFORE starting the session
@@ -316,8 +339,8 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 		msg.Timestamp = time.Now()
 		if err := router.Send(msg); err != nil {
 			d.logger.Printf("Handler: failed to send mail to dog %s: %v", idleDog.Name, err)
-			// Roll back assignment — no point starting a session without instructions.
-			if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
+			// Roll back only this dispatch's assignment.
+			if clearErr := clearAssignment(); clearErr != nil {
 				d.logger.Printf("Handler: failed to clear work after mail failure for dog %s: %v", idleDog.Name, clearErr)
 			}
 			continue
@@ -327,8 +350,8 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 			WorkDesc: workDesc,
 		}); err != nil {
 			d.logger.Printf("Handler: failed to start session for dog %s: %v", idleDog.Name, err)
-			// Roll back assignment on session start failure.
-			if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
+			// Roll back only this dispatch's assignment on session start failure.
+			if clearErr := clearAssignment(); clearErr != nil {
 				d.logger.Printf("Handler: failed to clear work after start failure for dog %s: %v", idleDog.Name, clearErr)
 			}
 			continue

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -79,6 +79,7 @@ func testSetupWorkingDogState(t *testing.T, townRoot, name, work string, lastAct
 		Name:       name,
 		State:      dog.StateWorking,
 		Work:       work,
+		WorkKind:   dog.WorkKindPlugin, // state-only fixture; source-backed recovery is tested separately
 		LastActive: lastActive,
 		Worktrees:  map[string]string{},
 		CreatedAt:  lastActive,

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -8,6 +8,7 @@ import (
 
 	agentconfig "github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/dog"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/reaper"
 	"github.com/steveyegge/gastown/internal/util"
@@ -85,6 +86,11 @@ func (d *Daemon) reapWisps() {
 		return
 	}
 
+	if err := dog.RequireDispatchAllowed(d.config.TownRoot); err != nil {
+		d.logger.Printf("wisp_reaper: guardian blocked dog dispatch: %v", err)
+		return
+	}
+
 	config := d.patrolConfig.Patrols.WispReaper
 	maxAge := wispReaperMaxAge(d.patrolConfig)
 	deleteAge := wispDeleteAge(d.patrolConfig)
@@ -114,6 +120,11 @@ func (d *Daemon) reapWisps() {
 
 	// Try dispatching to a Dog for formula-driven execution.
 	if err := d.dispatchReaperDog(vars); err != nil {
+		if actErr := dog.RequireActivationAllowed(d.config.TownRoot); actErr != nil {
+			d.logger.Printf("wisp_reaper: Dog dispatch failed (%v); inline fallback blocked by guardian: %v", err, actErr)
+			mol.failStep("dispatch", actErr.Error())
+			return
+		}
 		d.logger.Printf("wisp_reaper: Dog dispatch failed (%v), running inline fallback", err)
 		d.reapWispsInline(config, maxAge, deleteAge, mol)
 		return

--- a/internal/daemon/wisp_reaper_test.go
+++ b/internal/daemon/wisp_reaper_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/dog"
 )
 
 func TestWispReaperInterval(t *testing.T) {
@@ -145,5 +146,22 @@ func TestDoltServerHostUsesConfiguredTownHost(t *testing.T) {
 	d := &Daemon{config: &Config{TownRoot: townRoot}}
 	if got := d.doltServerHost(); got != "127.0.0.2" {
 		t.Fatalf("doltServerHost() = %q, want configured host", got)
+	}
+}
+
+func TestRequireActivationAllowedBlocksInlineFallback(t *testing.T) {
+	townRoot := t.TempDir()
+	path := dog.GuardianFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"dispatch_allowed":true,"activation_allowed":false,"reason":"activation red"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := dog.RequireDispatchAllowed(townRoot); err != nil {
+		t.Fatalf("dispatch should be allowed: %v", err)
+	}
+	if err := dog.RequireActivationAllowed(townRoot); err == nil {
+		t.Fatal("activation must be denied so inline reaper fallback cannot run")
 	}
 }

--- a/internal/deacon/feed_stranded.go
+++ b/internal/deacon/feed_stranded.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/dog"
 	"github.com/steveyegge/gastown/internal/util"
 )
 
@@ -83,7 +85,7 @@ type FeedResult struct {
 // FeedConvoyResult describes the outcome for a single convoy.
 type FeedConvoyResult struct {
 	ConvoyID     string `json:"convoy_id"`
-	Action       string `json:"action"` // "fed", "closed", "cooldown", "error", "limit", "needs_attention"
+	Action       string `json:"action"` // "fed", "closed", "cooldown", "error", "limit", "needs_attention", "rejected", "blocked"
 	Message      string `json:"message"`
 	TrackedCount int    `json:"tracked_count,omitempty"` // Raw data for agent inspection
 	ReadyCount   int    `json:"ready_count,omitempty"`   // Raw data for agent inspection
@@ -200,6 +202,8 @@ func FindStrandedConvoys(townRoot string) ([]StrandedConvoy, error) {
 	return stranded, nil
 }
 
+var findStrandedConvoys = FindStrandedConvoys
+
 // FeedStranded detects stranded convoys and takes mechanical actions where safe.
 // Empty convoys (0 tracked) are auto-closed. Feedable convoys get a dog dispatched.
 // Convoys with tracked-but-not-ready issues are surfaced as "needs_attention" with
@@ -207,6 +211,15 @@ func FindStrandedConvoys(townRoot string) ([]StrandedConvoy, error) {
 // Rate limits by maxPerCycle and per-convoy cooldown.
 func FeedStranded(townRoot string, maxPerCycle int, cooldown time.Duration) *FeedResult {
 	result := &FeedResult{}
+
+	if err := dog.RequireDispatchAllowed(townRoot); err != nil {
+		result.Errors++
+		result.Details = append(result.Details, FeedConvoyResult{
+			Action:  "blocked",
+			Message: fmt.Sprintf("guardian blocked dog dispatch: %v", err),
+		})
+		return result
+	}
 
 	if maxPerCycle <= 0 {
 		maxPerCycle = DefaultMaxFeedsPerCycle
@@ -216,7 +229,7 @@ func FeedStranded(townRoot string, maxPerCycle int, cooldown time.Duration) *Fee
 	}
 
 	// Find stranded convoys
-	stranded, err := FindStrandedConvoys(townRoot)
+	stranded, err := findStrandedConvoys(townRoot)
 	if err != nil {
 		result.Errors++
 		result.Details = append(result.Details, FeedConvoyResult{
@@ -262,6 +275,15 @@ func FeedStranded(townRoot string, maxPerCycle int, cooldown time.Duration) *Fee
 			}
 
 			// Truly empty convoy (0 tracked issues) — auto-close
+			if err := dog.RequireActivationAllowed(townRoot); err != nil {
+				result.Errors++
+				result.Details = append(result.Details, FeedConvoyResult{
+					ConvoyID: convoy.ID,
+					Action:   "blocked",
+					Message:  fmt.Sprintf("guardian blocked empty-convoy close: %v", err),
+				})
+				continue
+			}
 			if err := closeEmptyConvoy(townRoot, convoy.ID); err != nil {
 				result.Errors++
 				result.Details = append(result.Details, FeedConvoyResult{
@@ -299,6 +321,23 @@ func FeedStranded(townRoot string, maxPerCycle int, cooldown time.Duration) *Fee
 				ConvoyID: convoy.ID,
 				Action:   "cooldown",
 				Message:  fmt.Sprintf("in cooldown (remaining: %s)", remaining.Round(time.Second)),
+			})
+			continue
+		}
+
+		if ok, reason, err := admitConvoyFeed(townRoot, convoy.ID); err != nil {
+			result.Errors++
+			result.Details = append(result.Details, FeedConvoyResult{
+				ConvoyID: convoy.ID,
+				Action:   "error",
+				Message:  fmt.Sprintf("failed to admit convoy feed: %v", err),
+			})
+			continue
+		} else if !ok {
+			result.Details = append(result.Details, FeedConvoyResult{
+				ConvoyID: convoy.ID,
+				Action:   "rejected",
+				Message:  reason,
 			})
 			continue
 		}
@@ -347,7 +386,9 @@ func closeEmptyConvoy(townRoot, convoyID string) error {
 }
 
 // dispatchFeedDog dispatches a dog to feed a stranded convoy via gt sling.
-func dispatchFeedDog(townRoot, convoyID string) error {
+var dispatchFeedDog = defaultDispatchFeedDog
+
+func defaultDispatchFeedDog(townRoot, convoyID string) error {
 	cmd := exec.Command("gt", "sling", constants.MolConvoyFeed, "deacon/dogs",
 		"--var", fmt.Sprintf("convoy=%s", convoyID))
 	cmd.Dir = townRoot
@@ -356,6 +397,81 @@ func dispatchFeedDog(townRoot, convoyID string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// ConvoyChild is a tracked convoy issue used for feed admission.
+type ConvoyChild struct {
+	ID       string
+	Status   string
+	Assignee string
+	Blocked  bool
+}
+
+var listConvoyChildren = defaultListConvoyChildren
+
+// AdmitConvoyFeed rejects a convoy when any tracked child is blocked, hooked,
+// or assigned. Readiness cannot be inferred from a shallow ready-count.
+func AdmitConvoyFeed(children []ConvoyChild) (ok bool, reason string) {
+	for _, child := range children {
+		if child.Blocked {
+			return false, fmt.Sprintf("tracked child %s is blocked", child.ID)
+		}
+		if child.Status == "hooked" || child.Status == "in_progress" {
+			return false, fmt.Sprintf("tracked child %s is %s", child.ID, child.Status)
+		}
+		if strings.TrimSpace(child.Assignee) != "" {
+			return false, fmt.Sprintf("tracked child %s is assigned to %s", child.ID, child.Assignee)
+		}
+	}
+	return true, ""
+}
+
+func admitConvoyFeed(townRoot, convoyID string) (bool, string, error) {
+	children, err := listConvoyChildren(townRoot, convoyID)
+	if err != nil {
+		return false, "", err
+	}
+	ok, reason := AdmitConvoyFeed(children)
+	return ok, reason, nil
+}
+
+func defaultListConvoyChildren(townRoot, convoyID string) ([]ConvoyChild, error) {
+	cmd := beads.Command(townRoot, townBeadsDir(townRoot), beads.ReadOnlyRouting, "show", convoyID, "--json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("showing convoy %s: %w", convoyID, err)
+	}
+	var issues []struct {
+		Dependencies []beads.IssueDep `json:"dependencies"`
+	}
+	if err := json.Unmarshal(output, &issues); err != nil || len(issues) == 0 {
+		return nil, fmt.Errorf("parsing convoy %s: %w", convoyID, err)
+	}
+	var children []ConvoyChild
+	for _, dep := range issues[0].Dependencies {
+		if dep.DependencyType != "" && dep.DependencyType != "tracks" {
+			continue
+		}
+		child := ConvoyChild{ID: dep.ID, Status: dep.Status}
+		show := beads.Command(townRoot, townBeadsDir(townRoot), beads.ReadOnlyRouting, "show", dep.ID, "--json")
+		out, showErr := show.Output()
+		if showErr != nil {
+			return nil, fmt.Errorf("showing tracked child %s: %w", dep.ID, showErr)
+		}
+		var details []struct {
+			Status   string `json:"status"`
+			Assignee string `json:"assignee"`
+			Blocked  bool   `json:"blocked"`
+		}
+		if err := json.Unmarshal(out, &details); err != nil || len(details) == 0 {
+			return nil, fmt.Errorf("parsing tracked child %s: %w", dep.ID, err)
+		}
+		child.Status = details[0].Status
+		child.Assignee = details[0].Assignee
+		child.Blocked = details[0].Blocked
+		children = append(children, child)
+	}
+	return children, nil
 }
 
 // PruneFeedStrandedState removes entries for convoys that are no longer open.

--- a/internal/deacon/feed_stranded_test.go
+++ b/internal/deacon/feed_stranded_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/dog"
 )
 
 func TestFeedStrandedStateFile(t *testing.T) {
@@ -217,5 +219,82 @@ func TestSaveFeedStrandedState_CreatesDirectory(t *testing.T) {
 	stateFile := FeedStrandedStateFile(tmpDir)
 	if _, err := os.Stat(stateFile); os.IsNotExist(err) {
 		t.Fatal("state file not created")
+	}
+}
+
+func TestAdmitConvoyFeed_RejectsBlockedHookedOrAssigned(t *testing.T) {
+	tests := []struct {
+		name     string
+		children []ConvoyChild
+		wantOK   bool
+	}{
+		{name: "all open unassigned", children: []ConvoyChild{{ID: "gt-a", Status: "open"}}, wantOK: true},
+		{name: "blocked sibling", children: []ConvoyChild{{ID: "gt-a", Status: "open"}, {ID: "gt-b", Blocked: true}}, wantOK: false},
+		{name: "hooked sibling", children: []ConvoyChild{{ID: "gt-a", Status: "open"}, {ID: "gt-b", Status: "hooked"}}, wantOK: false},
+		{name: "assigned sibling", children: []ConvoyChild{{ID: "gt-a", Status: "open"}, {ID: "gt-b", Status: "open", Assignee: "gastown/polecats/nux"}}, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, _ := AdmitConvoyFeed(tt.children)
+			if ok != tt.wantOK {
+				t.Fatalf("AdmitConvoyFeed() = %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestFeedStranded_GuardianDenied_NoDispatch(t *testing.T) {
+	townRoot := t.TempDir()
+	path := dog.GuardianFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"dispatch_allowed":false,"activation_allowed":false,"reason":"red"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := FeedStranded(townRoot, 3, time.Minute)
+	if result.Fed != 0 {
+		t.Fatalf("Fed = %d, want 0 when guardian denies dispatch", result.Fed)
+	}
+	if result.Closed != 0 {
+		t.Fatalf("Closed = %d, want 0 when guardian denies dispatch", result.Closed)
+	}
+	if len(result.Details) == 0 || result.Details[0].Action != "blocked" {
+		t.Fatalf("details = %+v, want blocked guardian result", result.Details)
+	}
+}
+
+func TestFeedStranded_RejectsConvoyWithAssignedChild(t *testing.T) {
+	prevFind := findStrandedConvoys
+	prevList := listConvoyChildren
+	prevDispatch := dispatchFeedDog
+	t.Cleanup(func() {
+		findStrandedConvoys = prevFind
+		listConvoyChildren = prevList
+		dispatchFeedDog = prevDispatch
+	})
+
+	dispatched := 0
+	findStrandedConvoys = func(string) ([]StrandedConvoy, error) {
+		return []StrandedConvoy{{ID: "hq-cv-1", ReadyCount: 1, TrackedCount: 2, ReadyIssues: []string{"gt-a"}}}, nil
+	}
+	listConvoyChildren = func(string, string) ([]ConvoyChild, error) {
+		return []ConvoyChild{
+			{ID: "gt-a", Status: "open"},
+			{ID: "gt-b", Status: "open", Assignee: "deacon/dogs/alpha"},
+		}, nil
+	}
+	dispatchFeedDog = func(string, string) error {
+		dispatched++
+		return nil
+	}
+
+	result := FeedStranded(t.TempDir(), 3, time.Minute)
+	if dispatched != 0 {
+		t.Fatalf("dispatched = %d, want 0 for assigned sibling", dispatched)
+	}
+	if len(result.Details) != 1 || result.Details[0].Action != "rejected" {
+		t.Fatalf("details = %+v, want rejected", result.Details)
 	}
 }

--- a/internal/dog/guardian.go
+++ b/internal/dog/guardian.go
@@ -1,0 +1,79 @@
+package dog
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Guardian control-plane flags. Autonomous dog dispatch and inline daemon
+// mutation must consult these before creating molecules, slinging dogs, or
+// mutating beads.
+type GuardianState struct {
+	DispatchAllowed   bool   `json:"dispatch_allowed"`
+	ActivationAllowed bool   `json:"activation_allowed"`
+	Reason            string `json:"reason,omitempty"`
+}
+
+// ErrGuardianDenied is returned when dispatch or activation is not allowed.
+var ErrGuardianDenied = errors.New("guardian denied")
+
+// GuardianFile returns the path of the integrity-guardian state file.
+func GuardianFile(townRoot string) string {
+	return filepath.Join(townRoot, ".runtime", "deacon", "guardian.json")
+}
+
+// LoadGuardianState reads guardian flags. A missing file means no guardian is
+// installed, so both flags default to allowed. A present but unreadable or
+// invalid file is unavailable and fails closed.
+func LoadGuardianState(townRoot string) (GuardianState, error) {
+	path := GuardianFile(townRoot)
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is constructed from trusted townRoot
+	if err != nil {
+		if os.IsNotExist(err) {
+			return GuardianState{DispatchAllowed: true, ActivationAllowed: true, Reason: "guardian not installed"}, nil
+		}
+		return GuardianState{}, fmt.Errorf("%w: reading guardian state: %w", ErrGuardianDenied, err)
+	}
+	var state GuardianState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return GuardianState{}, fmt.Errorf("%w: parsing guardian state: %w", ErrGuardianDenied, err)
+	}
+	return state, nil
+}
+
+// RequireDispatchAllowed fails closed when guardian state is unavailable or
+// dispatch_allowed is false.
+func RequireDispatchAllowed(townRoot string) error {
+	state, err := LoadGuardianState(townRoot)
+	if err != nil {
+		return err
+	}
+	if !state.DispatchAllowed {
+		reason := state.Reason
+		if reason == "" {
+			reason = "dispatch_allowed=false"
+		}
+		return fmt.Errorf("%w: %s", ErrGuardianDenied, reason)
+	}
+	return nil
+}
+
+// RequireActivationAllowed fails closed when guardian state is unavailable or
+// activation_allowed is false. Inline fallback mutation must call this.
+func RequireActivationAllowed(townRoot string) error {
+	state, err := LoadGuardianState(townRoot)
+	if err != nil {
+		return err
+	}
+	if !state.ActivationAllowed {
+		reason := state.Reason
+		if reason == "" {
+			reason = "activation_allowed=false"
+		}
+		return fmt.Errorf("%w: %s", ErrGuardianDenied, reason)
+	}
+	return nil
+}

--- a/internal/dog/guardian_test.go
+++ b/internal/dog/guardian_test.go
@@ -1,0 +1,74 @@
+package dog
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGuardianFile(t *testing.T, townRoot, contents string) {
+	t.Helper()
+	path := GuardianFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir guardian dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write guardian file: %v", err)
+	}
+}
+
+func TestLoadGuardianState_MissingFileAllowsDispatch(t *testing.T) {
+	state, err := LoadGuardianState(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadGuardianState() error = %v", err)
+	}
+	if !state.DispatchAllowed || !state.ActivationAllowed {
+		t.Fatalf("missing guardian file should allow both flags, got %+v", state)
+	}
+}
+
+func TestRequireDispatchAllowed_RedDenies(t *testing.T) {
+	townRoot := t.TempDir()
+	writeGuardianFile(t, townRoot, `{"dispatch_allowed":false,"activation_allowed":false,"reason":"integrity red"}`)
+
+	err := RequireDispatchAllowed(townRoot)
+	if !errors.Is(err, ErrGuardianDenied) {
+		t.Fatalf("RequireDispatchAllowed() error = %v, want ErrGuardianDenied", err)
+	}
+}
+
+func TestRequireDispatchAllowed_GreenAllows(t *testing.T) {
+	townRoot := t.TempDir()
+	writeGuardianFile(t, townRoot, `{"dispatch_allowed":true,"activation_allowed":true}`)
+
+	if err := RequireDispatchAllowed(townRoot); err != nil {
+		t.Fatalf("RequireDispatchAllowed() green error = %v", err)
+	}
+	if err := RequireActivationAllowed(townRoot); err != nil {
+		t.Fatalf("RequireActivationAllowed() green error = %v", err)
+	}
+}
+
+func TestRequireActivationAllowed_UnavailableFailsClosed(t *testing.T) {
+	townRoot := t.TempDir()
+	writeGuardianFile(t, townRoot, `{not json`)
+
+	err := RequireActivationAllowed(townRoot)
+	if !errors.Is(err, ErrGuardianDenied) {
+		t.Fatalf("corrupt guardian must fail closed, got %v", err)
+	}
+}
+
+func TestRequireDispatchAllowed_ActivationDeniedStillBlocksInline(t *testing.T) {
+	townRoot := t.TempDir()
+	writeGuardianFile(t, townRoot, `{"dispatch_allowed":true,"activation_allowed":false,"reason":"activation red"}`)
+
+	if err := RequireDispatchAllowed(townRoot); err != nil {
+		t.Fatalf("dispatch should remain allowed, got %v", err)
+	}
+	err := RequireActivationAllowed(townRoot)
+	if !errors.Is(err, ErrGuardianDenied) {
+		t.Fatalf("RequireActivationAllowed() error = %v, want ErrGuardianDenied", err)
+	}
+}

--- a/internal/dog/health.go
+++ b/internal/dog/health.go
@@ -19,8 +19,8 @@ type sessionChecker interface {
 type DogHealthResult struct {
 	Name           string        `json:"name"`
 	State          State         `json:"state"`
-	SessionStatus  string        `json:"session_status"`           // from ZombieStatus.String()
-	WorkDuration   time.Duration `json:"work_duration,omitempty"`  // how long current work has been running
+	SessionStatus  string        `json:"session_status"`          // from ZombieStatus.String()
+	WorkDuration   time.Duration `json:"work_duration,omitempty"` // how long current work has been running
 	NeedsAttention bool          `json:"needs_attention"`
 	AutoCleared    bool          `json:"auto_cleared,omitempty"`
 	Recommendation string        `json:"recommendation,omitempty"`
@@ -66,11 +66,13 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 			// Zombie: state says working but session is gone.
 			result.NeedsAttention = true
 			result.Recommendation = "zombie: session dead but state=working"
-			if autoClear {
-				if err := hc.mgr.ClearWork(d.Name); err == nil {
+			if autoClear && CanClearStateOnly(d.Work, d.WorkKind) {
+				if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
 					result.AutoCleared = true
 					result.Recommendation = "zombie auto-cleared (session dead)"
 				}
+			} else if autoClear {
+				result.Recommendation = "zombie: source-backed work requires explicit recovery"
 			}
 
 		case tmux.AgentDead:
@@ -79,24 +81,30 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 			result.Recommendation = "zombie: agent dead in session"
 			if autoClear {
 				_ = hc.checker.KillSession(session)
-				if err := hc.mgr.ClearWork(d.Name); err == nil {
-					result.AutoCleared = true
-					result.Recommendation = "zombie auto-cleared (agent dead, session killed)"
+				if CanClearStateOnly(d.Work, d.WorkKind) {
+					if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
+						result.AutoCleared = true
+						result.Recommendation = "zombie auto-cleared (agent dead, session killed)"
+					}
+				} else {
+					result.Recommendation = "zombie: session killed; source-backed work requires explicit recovery"
 				}
 			}
 
 		case tmux.AgentHung:
 			// Hung: process alive but no tmux activity for maxInactivity.
-			// If autoClear is on, kill and reclaim — the dog almost certainly
-			// finished its work but failed to call `gt dog done`.
 			result.NeedsAttention = true
 			if autoClear {
 				_ = hc.checker.KillSession(session)
-				if err := hc.mgr.ClearWork(d.Name); err == nil {
-					result.AutoCleared = true
-					result.Recommendation = "hung dog auto-cleared (idle prompt, session killed)"
+				if CanClearStateOnly(d.Work, d.WorkKind) {
+					if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
+						result.AutoCleared = true
+						result.Recommendation = "hung dog auto-cleared (idle prompt, session killed)"
+					} else if err != nil {
+						result.Recommendation = "hung: auto-clear failed: " + err.Error()
+					}
 				} else {
-					result.Recommendation = "hung: auto-clear failed: " + err.Error()
+					result.Recommendation = "hung: session killed; source-backed work requires explicit recovery"
 				}
 			} else {
 				result.Recommendation = "hung: agent alive but no tmux activity"

--- a/internal/dog/health.go
+++ b/internal/dog/health.go
@@ -66,49 +66,28 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 			// Zombie: state says working but session is gone.
 			result.NeedsAttention = true
 			result.Recommendation = "zombie: session dead but state=working"
-			if autoClear && CanClearStateOnly(d.Work, d.WorkKind) {
-				if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
-					result.AutoCleared = true
-					result.Recommendation = "zombie auto-cleared (session dead)"
-				}
-			} else if autoClear {
-				result.Recommendation = "zombie: source-backed work requires explicit recovery"
-			}
+			hc.maybeClearStateOnly(d, &result, autoClear, false, session,
+				"zombie: source-backed work requires explicit recovery",
+				"zombie auto-cleared (session dead)")
 
 		case tmux.AgentDead:
 			// Zombie: session exists but agent process died.
 			result.NeedsAttention = true
 			result.Recommendation = "zombie: agent dead in session"
-			if autoClear {
-				_ = hc.checker.KillSession(session)
-				if CanClearStateOnly(d.Work, d.WorkKind) {
-					if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
-						result.AutoCleared = true
-						result.Recommendation = "zombie auto-cleared (agent dead, session killed)"
-					}
-				} else {
-					result.Recommendation = "zombie: session killed; source-backed work requires explicit recovery"
-				}
-			}
+			hc.maybeClearStateOnly(d, &result, autoClear, true, session,
+				"zombie: session killed; source-backed work requires explicit recovery",
+				"zombie auto-cleared (agent dead, session killed)")
 
 		case tmux.AgentHung:
 			// Hung: process alive but no tmux activity for maxInactivity.
 			result.NeedsAttention = true
-			if autoClear {
-				_ = hc.checker.KillSession(session)
-				if CanClearStateOnly(d.Work, d.WorkKind) {
-					if cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt); err == nil && cleared {
-						result.AutoCleared = true
-						result.Recommendation = "hung dog auto-cleared (idle prompt, session killed)"
-					} else if err != nil {
-						result.Recommendation = "hung: auto-clear failed: " + err.Error()
-					}
-				} else {
-					result.Recommendation = "hung: session killed; source-backed work requires explicit recovery"
-				}
-			} else {
+			if !autoClear {
 				result.Recommendation = "hung: agent alive but no tmux activity"
+				break
 			}
+			hc.maybeClearStateOnly(d, &result, true, true, session,
+				"hung: session killed; source-backed work requires explicit recovery",
+				"hung dog auto-cleared (idle prompt, session killed)")
 
 		default: // SessionHealthy — status.String() already set above
 		}
@@ -132,6 +111,28 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 	}
 
 	return result
+}
+
+func (hc *HealthChecker) maybeClearStateOnly(d *Dog, result *DogHealthResult, autoClear, killSession bool, session, blockedRec, clearedRec string) {
+	if !autoClear {
+		return
+	}
+	if killSession {
+		_ = hc.checker.KillSession(session)
+	}
+	if !CanClearStateOnly(d.Work, d.WorkKind) {
+		result.Recommendation = blockedRec
+		return
+	}
+	cleared, err := hc.mgr.ClearWorkIfMatches(d.Name, d.Work, d.WorkStartedAt)
+	if err != nil {
+		result.Recommendation = "auto-clear failed: " + err.Error()
+		return
+	}
+	if cleared {
+		result.AutoCleared = true
+		result.Recommendation = clearedRec
+	}
 }
 
 // CheckAll performs health checks on all dogs.

--- a/internal/dog/health_test.go
+++ b/internal/dog/health_test.go
@@ -181,7 +181,7 @@ func TestHealth_Hung_AutoCleared(t *testing.T) {
 	m, _ := testManager(t)
 	now := time.Now()
 	setupDogWithState(t, m, "alpha", &DogState{
-		Name: "alpha", State: StateWorking, Work: "task-1",
+		Name: "alpha", State: StateWorking, Work: "plugin:task-1", WorkKind: WorkKindPlugin,
 		WorkStartedAt: now.Add(-2 * time.Hour), LastActive: now,
 		CreatedAt: now, UpdatedAt: now,
 	})
@@ -218,7 +218,7 @@ func TestHealth_AutoClear_SessionDead(t *testing.T) {
 	m, _ := testManager(t)
 	now := time.Now()
 	setupDogWithState(t, m, "alpha", &DogState{
-		Name: "alpha", State: StateWorking, Work: "task-1",
+		Name: "alpha", State: StateWorking, Work: "plugin:task-1", WorkKind: WorkKindPlugin,
 		WorkStartedAt: now.Add(-1 * time.Hour), LastActive: now,
 		CreatedAt: now, UpdatedAt: now,
 	})
@@ -248,7 +248,7 @@ func TestHealth_AutoClear_AgentDead(t *testing.T) {
 	m, _ := testManager(t)
 	now := time.Now()
 	setupDogWithState(t, m, "alpha", &DogState{
-		Name: "alpha", State: StateWorking, Work: "task-1",
+		Name: "alpha", State: StateWorking, Work: "plugin:task-1", WorkKind: WorkKindPlugin,
 		WorkStartedAt: now.Add(-1 * time.Hour), LastActive: now,
 		CreatedAt: now, UpdatedAt: now,
 	})

--- a/internal/dog/manager.go
+++ b/internal/dog/manager.go
@@ -311,6 +311,7 @@ func (m *Manager) Get(name string) (*Dog, error) {
 		LastActive:    state.LastActive,
 		Work:          state.Work,
 		WorkKind:      state.WorkKind,
+		WorkSourceID:  state.WorkSourceID,
 		WorkStartedAt: state.WorkStartedAt,
 		CreatedAt:     state.CreatedAt,
 	}, nil
@@ -373,11 +374,20 @@ func (m *Manager) AssignWorkWithKind(name, work string, kind WorkKind) error {
 	state.State = StateWorking
 	state.Work = work
 	state.WorkKind = kind
+	applyWorkSourceID(state, work, kind)
 	state.WorkStartedAt = time.Now()
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
 
 	return m.saveState(name, state)
+}
+
+func applyWorkSourceID(state *DogState, work string, kind WorkKind) {
+	if kind == WorkKindBead {
+		state.WorkSourceID = work
+		return
+	}
+	state.WorkSourceID = ""
 }
 
 // AssignWorkIfIdle assigns work only if the dog is still idle, returning the
@@ -412,6 +422,7 @@ func (m *Manager) AssignWorkIfIdleWithKind(name, work string, kind WorkKind) (*D
 	state.State = StateWorking
 	state.Work = work
 	state.WorkKind = kind
+	applyWorkSourceID(state, work, kind)
 	state.WorkStartedAt = time.Now()
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
@@ -420,6 +431,39 @@ func (m *Manager) AssignWorkIfIdleWithKind(name, work string, kind WorkKind) (*D
 		return nil, err
 	}
 	return state, nil
+}
+
+// SetWorkSourceIfMatches records the exact source bead ID for formula work
+// after the source is hooked. Bead dispatches already store the source ID in
+// Work at assignment time.
+func (m *Manager) SetWorkSourceIfMatches(name, expectedWork string, expectedStartedAt time.Time, sourceID string) (bool, error) {
+	if err := validateDogName(name); err != nil {
+		return false, err
+	}
+	if !m.exists(name) {
+		return false, ErrDogNotFound
+	}
+
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	state, err := m.loadState(name)
+	if err != nil {
+		return false, fmt.Errorf("loading state: %w", err)
+	}
+	if state.Work != expectedWork || !state.WorkStartedAt.Equal(expectedStartedAt) {
+		return false, nil
+	}
+
+	state.WorkSourceID = sourceID
+	state.UpdatedAt = time.Now()
+	if err := m.saveState(name, state); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ClearWork clears a dog's work assignment and sets it to idle.
@@ -443,14 +487,19 @@ func (m *Manager) ClearWork(name string) error {
 		return fmt.Errorf("loading state: %w", err)
 	}
 
+	clearWorkFields(state)
+
+	return m.saveState(name, state)
+}
+
+func clearWorkFields(state *DogState) {
 	state.State = StateIdle
 	state.Work = ""
 	state.WorkKind = ""
+	state.WorkSourceID = ""
 	state.WorkStartedAt = time.Time{}
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
-
-	return m.saveState(name, state)
 }
 
 // ClearWorkIfMatches clears a dog's work assignment only if it still matches
@@ -478,12 +527,7 @@ func (m *Manager) ClearWorkIfMatches(name, expectedWork string, expectedStartedA
 		return false, nil
 	}
 
-	state.State = StateIdle
-	state.Work = ""
-	state.WorkKind = ""
-	state.WorkStartedAt = time.Time{}
-	state.LastActive = time.Now()
-	state.UpdatedAt = time.Now()
+	clearWorkFields(state)
 
 	return true, m.saveState(name, state)
 }
@@ -517,12 +561,7 @@ func (m *Manager) ClearWorkIfMatchesAfter(name, expectedWork string, expectedSta
 		return false, nil
 	}
 
-	state.State = StateIdle
-	state.Work = ""
-	state.WorkKind = ""
-	state.WorkStartedAt = time.Time{}
-	state.LastActive = time.Now()
-	state.UpdatedAt = time.Now()
+	clearWorkFields(state)
 
 	return true, m.saveState(name, state)
 }

--- a/internal/dog/manager.go
+++ b/internal/dog/manager.go
@@ -47,11 +47,13 @@ func NewManager(townRoot string, rigsConfig *config.RigsConfig) *Manager {
 // This prevents concurrent load-modify-save races on .dog.json.
 // Caller must defer fl.Unlock().
 func (m *Manager) lockDog(name string) (*flock.Flock, error) {
-	lockDir := m.dogDir(name)
+	// Keep lock files outside removable dog directories. A dog may be removed
+	// and recreated while callers wait; one stable inode preserves exclusion.
+	lockDir := filepath.Join(m.kennelPath, ".locks")
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating dog lock dir: %w", err)
 	}
-	lockPath := filepath.Join(lockDir, ".dog.lock")
+	lockPath := filepath.Join(lockDir, name+".lock")
 	fl := flock.New(lockPath)
 	if err := fl.Lock(); err != nil {
 		return nil, fmt.Errorf("acquiring dog lock for %s: %w", name, err)
@@ -308,6 +310,7 @@ func (m *Manager) Get(name string) (*Dog, error) {
 		Worktrees:     state.Worktrees,
 		LastActive:    state.LastActive,
 		Work:          state.Work,
+		WorkKind:      state.WorkKind,
 		WorkStartedAt: state.WorkStartedAt,
 		CreatedAt:     state.CreatedAt,
 	}, nil
@@ -341,8 +344,13 @@ func (m *Manager) SetState(name string, state State) error {
 	return m.saveState(name, dogState)
 }
 
-// AssignWork assigns work to a dog and sets it to working state.
+// AssignWork assigns untyped legacy work to a dog and sets it to working state.
 func (m *Manager) AssignWork(name, work string) error {
+	return m.AssignWorkWithKind(name, work, "")
+}
+
+// AssignWorkWithKind assigns typed work to a dog and sets it to working state.
+func (m *Manager) AssignWorkWithKind(name, work string, kind WorkKind) error {
 	if err := validateDogName(name); err != nil {
 		return err
 	}
@@ -364,6 +372,7 @@ func (m *Manager) AssignWork(name, work string) error {
 
 	state.State = StateWorking
 	state.Work = work
+	state.WorkKind = kind
 	state.WorkStartedAt = time.Now()
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
@@ -374,6 +383,11 @@ func (m *Manager) AssignWork(name, work string) error {
 // AssignWorkIfIdle assigns work only if the dog is still idle, returning the
 // saved state so callers can later perform exact compare-and-clear cleanup.
 func (m *Manager) AssignWorkIfIdle(name, work string) (*DogState, error) {
+	return m.AssignWorkIfIdleWithKind(name, work, "")
+}
+
+// AssignWorkIfIdleWithKind records whether work is a source bead or formula.
+func (m *Manager) AssignWorkIfIdleWithKind(name, work string, kind WorkKind) (*DogState, error) {
 	if err := validateDogName(name); err != nil {
 		return nil, err
 	}
@@ -397,6 +411,7 @@ func (m *Manager) AssignWorkIfIdle(name, work string) (*DogState, error) {
 
 	state.State = StateWorking
 	state.Work = work
+	state.WorkKind = kind
 	state.WorkStartedAt = time.Now()
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
@@ -430,6 +445,7 @@ func (m *Manager) ClearWork(name string) error {
 
 	state.State = StateIdle
 	state.Work = ""
+	state.WorkKind = ""
 	state.WorkStartedAt = time.Time{}
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
@@ -464,11 +480,150 @@ func (m *Manager) ClearWorkIfMatches(name, expectedWork string, expectedStartedA
 
 	state.State = StateIdle
 	state.Work = ""
+	state.WorkKind = ""
 	state.WorkStartedAt = time.Time{}
 	state.LastActive = time.Now()
 	state.UpdatedAt = time.Now()
 
 	return true, m.saveState(name, state)
+}
+
+// ClearWorkIfMatchesAfter runs beforeClear and clears the matching assignment
+// while holding the dog lock. This lets callers update external authoritative
+// state before making the dog idle, without a concurrent reassignment racing
+// between the two operations. If beforeClear returns false, state is preserved.
+func (m *Manager) ClearWorkIfMatchesAfter(name, expectedWork string, expectedStartedAt time.Time, beforeClear func() bool) (bool, error) {
+	if err := validateDogName(name); err != nil {
+		return false, err
+	}
+	if !m.exists(name) {
+		return false, ErrDogNotFound
+	}
+
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	state, err := m.loadState(name)
+	if err != nil {
+		return false, fmt.Errorf("loading state: %w", err)
+	}
+	if state.Work != expectedWork || !state.WorkStartedAt.Equal(expectedStartedAt) {
+		return false, nil
+	}
+	if beforeClear != nil && !beforeClear() {
+		return false, nil
+	}
+
+	state.State = StateIdle
+	state.Work = ""
+	state.WorkKind = ""
+	state.WorkStartedAt = time.Time{}
+	state.LastActive = time.Now()
+	state.UpdatedAt = time.Now()
+
+	return true, m.saveState(name, state)
+}
+
+// RemoveIfMatches removes a dog only if its assignment still matches the
+// caller's snapshot. Idle dogs are matched by empty work and a zero timestamp.
+func (m *Manager) RemoveIfMatches(name, expectedWork string, expectedStartedAt time.Time) (bool, error) {
+	return m.RemoveIfMatchesAfter(name, expectedWork, expectedStartedAt, nil)
+}
+
+// RemoveIfMatchesAfter runs beforeRemove and removes the dog while holding its
+// assignment lock. Dispatch cannot assign work between session teardown and
+// kennel removal.
+func (m *Manager) RemoveIfMatchesAfter(name, expectedWork string, expectedStartedAt time.Time, beforeRemove func() error) (bool, error) {
+	return m.RemoveIfSnapshotMatchesAfter(name, expectedWork, expectedStartedAt, time.Time{}, beforeRemove)
+}
+
+// RemoveIfSnapshotMatchesAfter also checks LastActive when expectedLastActive
+// is non-zero, preventing a stale idle snapshot from matching a dog that was
+// assigned and completed in the meantime.
+func (m *Manager) RemoveIfSnapshotMatchesAfter(name, expectedWork string, expectedStartedAt, expectedLastActive time.Time, beforeRemove func() error) (bool, error) {
+	if err := validateDogName(name); err != nil {
+		return false, err
+	}
+	if !m.exists(name) {
+		return false, ErrDogNotFound
+	}
+
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	state, err := m.loadState(name)
+	if err != nil {
+		return false, fmt.Errorf("loading state: %w", err)
+	}
+	if state.Work != expectedWork || !state.WorkStartedAt.Equal(expectedStartedAt) ||
+		(!expectedLastActive.IsZero() && !state.LastActive.Equal(expectedLastActive)) {
+		return false, nil
+	}
+	if beforeRemove != nil {
+		if err := beforeRemove(); err != nil {
+			return false, err
+		}
+	}
+
+	// Mirror Remove's registered worktree cleanup while the assignment lock is
+	// held, so dispatch cannot race removal between revalidation and deletion.
+	for rigName, worktreePath := range state.Worktrees {
+		rigPath := filepath.Join(m.townRoot, rigName)
+		repoGit, err := m.findRepoBase(rigPath)
+		if err != nil {
+			style.PrintWarning("could not find repo base for %s: %v", rigName, err)
+			continue
+		}
+		if err := repoGit.WorktreeRemove(worktreePath, true); err != nil {
+			style.PrintWarning("could not remove worktree %s: %v", worktreePath, err)
+		}
+		_ = repoGit.WorktreePrune()
+	}
+	if err := os.RemoveAll(m.dogDir(name)); err != nil {
+		return false, fmt.Errorf("removing dog directory: %w", err)
+	}
+	return true, nil
+}
+
+// WithWorkIfMatches runs action under the dog lock only when the assignment
+// still matches the caller's snapshot.
+func (m *Manager) WithWorkIfMatches(name, expectedWork string, expectedStartedAt time.Time, action func() error) (bool, error) {
+	return m.WithSnapshotIfMatches(name, expectedWork, expectedStartedAt, time.Time{}, action)
+}
+
+// WithSnapshotIfMatches optionally includes LastActive in snapshot matching.
+func (m *Manager) WithSnapshotIfMatches(name, expectedWork string, expectedStartedAt, expectedLastActive time.Time, action func() error) (bool, error) {
+	if err := validateDogName(name); err != nil {
+		return false, err
+	}
+	if !m.exists(name) {
+		return false, ErrDogNotFound
+	}
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = fl.Unlock() }()
+	state, err := m.loadState(name)
+	if err != nil {
+		return false, fmt.Errorf("loading state: %w", err)
+	}
+	if state.Work != expectedWork || !state.WorkStartedAt.Equal(expectedStartedAt) ||
+		(!expectedLastActive.IsZero() && !state.LastActive.Equal(expectedLastActive)) {
+		return false, nil
+	}
+	if action != nil {
+		if err := action(); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 // Refresh recreates all worktrees for a dog with fresh branches.

--- a/internal/dog/manager_source_test.go
+++ b/internal/dog/manager_source_test.go
@@ -1,0 +1,80 @@
+package dog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestManager_SetWorkSourceIfMatches(t *testing.T) {
+	m, _ := testManagerNoRigs(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "code-review",
+		WorkKind:      WorkKindFormula,
+		WorkStartedAt: now,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	matched, err := m.SetWorkSourceIfMatches("alpha", "code-review", now, "gt-src-1")
+	if err != nil {
+		t.Fatalf("SetWorkSourceIfMatches() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("SetWorkSourceIfMatches() matched = false, want true")
+	}
+
+	got, err := m.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.WorkSourceID != "gt-src-1" {
+		t.Fatalf("WorkSourceID = %q, want gt-src-1", got.WorkSourceID)
+	}
+}
+
+func TestManager_SetWorkSourceIfMatches_SkipsNewerAssignment(t *testing.T) {
+	m, _ := testManagerNoRigs(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "code-review",
+		WorkKind:      WorkKindFormula,
+		WorkStartedAt: now,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	matched, err := m.SetWorkSourceIfMatches("alpha", "code-review", now.Add(-time.Minute), "gt-old")
+	if err != nil {
+		t.Fatalf("SetWorkSourceIfMatches() error = %v", err)
+	}
+	if matched {
+		t.Fatal("SetWorkSourceIfMatches() matched a stale timestamp")
+	}
+}
+
+func TestManager_AssignWorkIfIdleWithKind_RecordsBeadSourceID(t *testing.T) {
+	m, _ := testManagerNoRigs(t)
+	now := time.Now().UTC()
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name:       "alpha",
+		State:      StateIdle,
+		LastActive: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+
+	assigned, err := m.AssignWorkIfIdleWithKind("alpha", "gt-abc", WorkKindBead)
+	if err != nil {
+		t.Fatalf("AssignWorkIfIdleWithKind() error = %v", err)
+	}
+	if assigned.WorkSourceID != "gt-abc" {
+		t.Fatalf("WorkSourceID = %q, want gt-abc", assigned.WorkSourceID)
+	}
+}

--- a/internal/dog/session_kill.go
+++ b/internal/dog/session_kill.go
@@ -1,0 +1,30 @@
+package dog
+
+import "fmt"
+
+// ShouldKillCompletedDogSession reports whether a delayed session kill from
+// `gt dog done` may still run. A newer assignment or live work must be left
+// alone.
+func ShouldKillCompletedDogSession(current *Dog) bool {
+	return current != nil && current.State == StateIdle && current.Work == ""
+}
+
+// KillCompletedDogSession re-reads dog state and kills the session only when
+// the dog is still idle with no work. This closes the race where a new
+// assignment starts during the post-done delay.
+func KillCompletedDogSession(mgr *Manager, name, sessionID string, killer func(string) error) error {
+	if mgr == nil {
+		return fmt.Errorf("missing dog manager")
+	}
+	if killer == nil {
+		return fmt.Errorf("missing session killer")
+	}
+	current, err := mgr.Get(name)
+	if err != nil {
+		return err
+	}
+	if !ShouldKillCompletedDogSession(current) {
+		return nil
+	}
+	return killer(sessionID)
+}

--- a/internal/dog/session_kill_test.go
+++ b/internal/dog/session_kill_test.go
@@ -1,0 +1,75 @@
+package dog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldKillCompletedDogSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		current *Dog
+		want    bool
+	}{
+		{name: "idle with no work", current: &Dog{State: StateIdle}, want: true},
+		{name: "working assignment", current: &Dog{State: StateWorking, Work: "gt-new"}, want: false},
+		{name: "idle but already reassigned", current: &Dog{State: StateIdle, Work: "gt-new"}, want: false},
+		{name: "nil dog", current: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldKillCompletedDogSession(tt.current); got != tt.want {
+				t.Fatalf("ShouldKillCompletedDogSession() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKillCompletedDogSession_SkipsNewerAssignment(t *testing.T) {
+	m, _ := testManagerNoRigs(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "gt-new",
+		WorkKind:      WorkKindBead,
+		WorkStartedAt: now,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	killed := false
+	if err := KillCompletedDogSession(m, "alpha", "hq-dog-alpha", func(string) error {
+		killed = true
+		return nil
+	}); err != nil {
+		t.Fatalf("KillCompletedDogSession() error = %v", err)
+	}
+	if killed {
+		t.Fatal("kill ran against a dog that already had a newer assignment")
+	}
+}
+
+func TestKillCompletedDogSession_KillsIdleDog(t *testing.T) {
+	m, _ := testManagerNoRigs(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name:       "alpha",
+		State:      StateIdle,
+		LastActive: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+
+	var gotSession string
+	if err := KillCompletedDogSession(m, "alpha", "hq-dog-alpha", func(sessionID string) error {
+		gotSession = sessionID
+		return nil
+	}); err != nil {
+		t.Fatalf("KillCompletedDogSession() error = %v", err)
+	}
+	if gotSession != "hq-dog-alpha" {
+		t.Fatalf("killed session = %q, want hq-dog-alpha", gotSession)
+	}
+}

--- a/internal/dog/types.go
+++ b/internal/dog/types.go
@@ -39,6 +39,7 @@ type Dog struct {
 	LastActive    time.Time         // Last activity timestamp
 	Work          string            // Current work assignment (bead ID or molecule)
 	WorkKind      WorkKind          // Whether Work is a source bead or formula name
+	WorkSourceID  string            // Exact source bead ID for bead/formula work
 	WorkStartedAt time.Time         // When current work was assigned
 	CreatedAt     time.Time         // When dog was added to kennel
 }
@@ -50,6 +51,7 @@ type DogState struct {
 	LastActive    time.Time         `json:"last_active"`
 	Work          string            `json:"work,omitempty"`            // Current work assignment
 	WorkKind      WorkKind          `json:"work_kind,omitempty"`       // bead or formula
+	WorkSourceID  string            `json:"work_source_id,omitempty"`  // Exact source bead ID
 	WorkStartedAt time.Time         `json:"work_started_at,omitempty"` // When work was assigned
 	Worktrees     map[string]string `json:"worktrees,omitempty"`       // Rig -> path (for verification)
 	CreatedAt     time.Time         `json:"created_at"`

--- a/internal/dog/types.go
+++ b/internal/dog/types.go
@@ -4,18 +4,31 @@
 package dog
 
 import (
+	"strings"
 	"time"
 )
 
 // State represents a dog's operational state.
 type State string
+type WorkKind string
 
 const (
+	WorkKindBead    WorkKind = "bead"
+	WorkKindFormula WorkKind = "formula"
+	WorkKindPlugin  WorkKind = "plugin"
+
 	// StateIdle means the dog is available for work.
 	StateIdle State = "idle"
 	// StateWorking means the dog is executing a task.
 	StateWorking State = "working"
 )
+
+// CanClearStateOnly reports whether recovery may clear work without updating
+// an authoritative source bead. New source-backed dispatches are explicitly
+// typed; empty kind retains the pre-kind legacy recovery behavior.
+func CanClearStateOnly(work string, kind WorkKind) bool {
+	return kind == WorkKindPlugin || (kind == "" && strings.HasPrefix(work, "plugin:"))
+}
 
 // Dog represents a Deacon helper worker.
 type Dog struct {
@@ -25,6 +38,7 @@ type Dog struct {
 	Worktrees     map[string]string // Rig name -> worktree path
 	LastActive    time.Time         // Last activity timestamp
 	Work          string            // Current work assignment (bead ID or molecule)
+	WorkKind      WorkKind          // Whether Work is a source bead or formula name
 	WorkStartedAt time.Time         // When current work was assigned
 	CreatedAt     time.Time         // When dog was added to kennel
 }
@@ -35,6 +49,7 @@ type DogState struct {
 	State         State             `json:"state"`
 	LastActive    time.Time         `json:"last_active"`
 	Work          string            `json:"work,omitempty"`            // Current work assignment
+	WorkKind      WorkKind          `json:"work_kind,omitempty"`       // bead or formula
 	WorkStartedAt time.Time         `json:"work_started_at,omitempty"` // When work was assigned
 	Worktrees     map[string]string `json:"worktrees,omitempty"`       // Rig -> path (for verification)
 	CreatedAt     time.Time         `json:"created_at"`

--- a/internal/dog/types_test.go
+++ b/internal/dog/types_test.go
@@ -101,6 +101,9 @@ func TestDogState_OmitEmptyFields(t *testing.T) {
 	if _, exists := raw["work"]; exists {
 		t.Error("Field 'work' should be omitted when empty")
 	}
+	if _, exists := raw["work_source_id"]; exists {
+		t.Error("Field 'work_source_id' should be omitted when empty")
+	}
 	if _, exists := raw["worktrees"]; exists {
 		t.Error("Field 'worktrees' should be omitted when empty")
 	}
@@ -144,5 +147,26 @@ func TestDogState_WithWorktrees(t *testing.T) {
 
 	if len(worktreesMap) != 2 {
 		t.Errorf("worktrees should have 2 entries, got %d", len(worktreesMap))
+	}
+}
+
+func TestCanClearStateOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		work string
+		kind WorkKind
+		want bool
+	}{
+		{name: "plugin kind", work: "plugin:rebuild", kind: WorkKindPlugin, want: true},
+		{name: "legacy plugin prefix", work: "plugin:rebuild", kind: "", want: true},
+		{name: "bead kind", work: "gt-abc", kind: WorkKindBead, want: false},
+		{name: "formula kind", work: "mol-dog-reaper", kind: WorkKindFormula, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanClearStateOnly(tt.work, tt.kind); got != tt.want {
+				t.Fatalf("CanClearStateOnly(%q, %q) = %v, want %v", tt.work, tt.kind, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/tmux/nudge_tmux37b_test.go
+++ b/internal/tmux/nudge_tmux37b_test.go
@@ -2,12 +2,12 @@ package tmux
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux/tmuxtest"
 )
 
 // TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired replays GH#4666 defect 3:
@@ -15,30 +15,29 @@ import (
 // carriage return (send-keys -l $'\r') does. The stub swallows named Enter
 // the way that tmux does not deliver it; the message must still reach cat.
 func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
-	}
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_NOOP_NAMED_ENTER", "1")
 
-	socket := "gt4666-enter-" + strings.ReplaceAll(t.Name(), "/", "-")
+	socket := tmuxtest.SocketName(t, "gt4666-enter-")
 	session := "nudge-enter"
 	outFile := filepath.Join(t.TempDir(), "submitted.txt")
-	startIsolatedTmuxSession(t, realTmux, socket, session,
-		"printf 'esc to interrupt\\n'; exec cat >"+shellQuote(outFile))
+	tmuxtest.StartSession(t, realTmux, socket, session,
+		"printf 'esc to interrupt\\n'; exec cat >"+tmuxtest.ShellQuote(outFile))
 
-	stub := installTmuxStub(t)
+	stub := tmuxtest.InstallStub(t)
 	tm := NewTmuxWithSocketAndBinary(socket, stub)
 
 	msg := "hello-from-4666"
-	if err := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{}); err != nil {
-		t.Logf("NudgeSessionWithOpts error (may be expected while Enter is a no-op): %v", err)
+	nudgeErr := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{})
+	if nudgeErr != nil {
+		t.Logf("NudgeSessionWithOpts error after literal CR submit: %v", nudgeErr)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
 	var got []byte
+	var err error
 	for time.Now().Before(deadline) {
 		got, err = os.ReadFile(outFile)
 		if err == nil && strings.Contains(string(got), msg) {
@@ -52,32 +51,34 @@ func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
 // TestNudgeSendKeys_DoesNotPassUnknown37bFlags records send-keys argv during a
 // real NudgeSession. tmux 3.7b rejects -V and -o on send-keys (GH#4666 defect 1).
 func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
-	}
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	logPath := filepath.Join(t.TempDir(), "tmux.argv")
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_ARGV_LOG", logPath)
 	t.Setenv("GT_TMUX_REJECT_37B_FLAGS", "1")
 
-	socket := "gt4666-flags-" + strings.ReplaceAll(t.Name(), "/", "-")
+	socket := tmuxtest.SocketName(t, "gt4666-flags-")
 	session := "nudge-flags"
-	startIsolatedTmuxSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
+	tmuxtest.StartSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
 
-	stub := installTmuxStub(t)
+	stub := tmuxtest.InstallStub(t)
 	tm := NewTmuxWithSocketAndBinary(socket, stub)
-	_ = tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+	nudgeErr := tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+	if nudgeErr != nil && sendKeysUsedUnknown37bFlag(nudgeErr.Error()) {
+		t.Fatalf("production send-keys used a tmux 3.7b-unknown flag: %v", nudgeErr)
+	}
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
-		t.Fatalf("read argv log: %v", err)
+		t.Fatalf("read argv log: %v (nudgeErr=%v)", err, nudgeErr)
 	}
+	sawSendKeys := false
 	for _, line := range strings.Split(string(data), "\n") {
 		if !strings.Contains(line, "send-keys") {
 			continue
 		}
+		sawSendKeys = true
 		fields := strings.Fields(line)
 		for _, f := range fields {
 			if f == "-V" || f == "-o" {
@@ -85,37 +86,11 @@ func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
 			}
 		}
 	}
+	if !sawSendKeys {
+		t.Fatalf("no send-keys invocation recorded; cannot verify flags. log=%q nudgeErr=%v", data, nudgeErr)
+	}
 }
 
-func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
-	t.Helper()
-	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("tmux new-session: %v\n%s", err, out)
-	}
-	t.Cleanup(func() {
-		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
-	})
-}
-
-func installTmuxStub(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src := filepath.Join(filepath.Dir(file), "testdata", "tmuxstub.sh")
-	data, err := os.ReadFile(src)
-	if err != nil {
-		t.Fatalf("read tmux stub: %v", err)
-	}
-	dst := filepath.Join(t.TempDir(), "tmux")
-	if err := os.WriteFile(dst, data, 0o755); err != nil {
-		t.Fatalf("write tmux stub: %v", err)
-	}
-	return dst
-}
-
-func shellQuote(path string) string {
-	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+func sendKeysUsedUnknown37bFlag(errText string) bool {
+	return strings.Contains(errText, "unknown flag -V") || strings.Contains(errText, "unknown flag -o")
 }

--- a/internal/tmux/nudge_tmux37b_test.go
+++ b/internal/tmux/nudge_tmux37b_test.go
@@ -1,0 +1,121 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired replays GH#4666 defect 3:
+// on tmux 3.7b, named-key Enter/C-m/KPEnter do not submit while a literal
+// carriage return (send-keys -l $'\r') does. The stub swallows named Enter
+// the way that tmux does not deliver it; the message must still reach cat.
+func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_NOOP_NAMED_ENTER", "1")
+
+	socket := "gt4666-enter-" + strings.ReplaceAll(t.Name(), "/", "-")
+	session := "nudge-enter"
+	outFile := filepath.Join(t.TempDir(), "submitted.txt")
+	startIsolatedTmuxSession(t, realTmux, socket, session,
+		"printf 'esc to interrupt\\n'; exec cat >"+shellQuote(outFile))
+
+	stub := installTmuxStub(t)
+	tm := NewTmuxWithSocketAndBinary(socket, stub)
+
+	msg := "hello-from-4666"
+	if err := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{}); err != nil {
+		t.Logf("NudgeSessionWithOpts error (may be expected while Enter is a no-op): %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) {
+		got, err = os.ReadFile(outFile)
+		if err == nil && strings.Contains(string(got), msg) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("named-key Enter did not submit; literal CR is required. outfile=%q err=%v", string(got), err)
+}
+
+// TestNudgeSendKeys_DoesNotPassUnknown37bFlags records send-keys argv during a
+// real NudgeSession. tmux 3.7b rejects -V and -o on send-keys (GH#4666 defect 1).
+func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	logPath := filepath.Join(t.TempDir(), "tmux.argv")
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_ARGV_LOG", logPath)
+	t.Setenv("GT_TMUX_REJECT_37B_FLAGS", "1")
+
+	socket := "gt4666-flags-" + strings.ReplaceAll(t.Name(), "/", "-")
+	session := "nudge-flags"
+	startIsolatedTmuxSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
+
+	stub := installTmuxStub(t)
+	tm := NewTmuxWithSocketAndBinary(socket, stub)
+	_ = tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "send-keys") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for _, f := range fields {
+			if f == "-V" || f == "-o" {
+				t.Fatalf("send-keys used tmux 3.7b-unknown flag %s: %s", f, line)
+			}
+		}
+	}
+}
+
+func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+func installTmuxStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}
+
+func shellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}

--- a/internal/tmux/testdata/tmuxstub.sh
+++ b/internal/tmux/testdata/tmuxstub.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Test stub that wraps the real tmux binary. Controlled by env:
+#   GT_REAL_TMUX              required; path to the real tmux
+#   GT_TMUX_ARGV_LOG          if set, append each invocation's args
+#   GT_TMUX_FAIL_SEND_KEYS    if 1, every send-keys fails like tmux 3.7b unknown -V
+#   GT_TMUX_REJECT_37B_FLAGS  if 1, send-keys -V / -o are rejected (tmux 3.7b)
+#   GT_TMUX_NOOP_NAMED_ENTER  if 1, named-key Enter/C-m/KPEnter succeed but do nothing
+set -eu
+
+if [ -n "${GT_TMUX_ARGV_LOG:-}" ]; then
+	printf '%s\n' "$*" >>"$GT_TMUX_ARGV_LOG"
+fi
+
+is_send_keys=0
+for arg in "$@"; do
+	if [ "$arg" = "send-keys" ]; then
+		is_send_keys=1
+		break
+	fi
+done
+
+if [ "$is_send_keys" = 1 ]; then
+	if [ "${GT_TMUX_FAIL_SEND_KEYS:-}" = "1" ]; then
+		echo "command send-keys: unknown flag -V" >&2
+		exit 1
+	fi
+	if [ "${GT_TMUX_REJECT_37B_FLAGS:-}" = "1" ]; then
+		for arg in "$@"; do
+			if [ "$arg" = "-V" ]; then
+				echo "command send-keys: unknown flag -V" >&2
+				exit 1
+			fi
+			if [ "$arg" = "-o" ]; then
+				echo "command send-keys: unknown flag -o" >&2
+				exit 1
+			fi
+		done
+	fi
+	if [ "${GT_TMUX_NOOP_NAMED_ENTER:-}" = "1" ]; then
+		literal=0
+		named=0
+		for arg in "$@"; do
+			if [ "$arg" = "-l" ]; then
+				literal=1
+			fi
+			case "$arg" in
+			Enter | C-m | KPEnter)
+				named=1
+				;;
+			esac
+		done
+		if [ "$named" = 1 ] && [ "$literal" = 0 ]; then
+			exit 0
+		fi
+	fi
+fi
+
+if [ -z "${GT_REAL_TMUX:-}" ]; then
+	echo "tmuxstub: GT_REAL_TMUX is unset" >&2
+	exit 127
+fi
+exec "$GT_REAL_TMUX" "$@"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1532,14 +1532,20 @@ func (t *Tmux) dismissRewindMode(target string) {
 	time.Sleep(300 * time.Millisecond)
 }
 
-// sendEnterVerified sends Enter to a tmux target and verifies it was processed
-// by checking that the pane content changes. Under load, tmux may buffer
-// keystrokes, causing Enter to race with text delivery — Enter arrives while
-// tmux is still processing text/Escape and gets treated as part of the text
-// stream rather than a separate submit action.
+// sendLiteralCR submits the current line with a literal carriage return.
+// Named-key Enter/C-m/KPEnter are not delivered on some tmux builds
+// (tmux 3.7b on macOS Homebrew); send-keys -l with CR is. (GH#4666)
+func (t *Tmux) sendLiteralCR(target string) error {
+	_, err := t.run("send-keys", "-t", target, "-l", "\r")
+	return err
+}
+
+// sendEnterVerified sends a submit keystroke to a tmux target and verifies it
+// was processed by checking that the pane content changes. Under load, tmux may
+// buffer keystrokes, causing the submit to race with text delivery.
 //
-// After sending Enter, polls the pane content with exponential backoff. If the
-// content hasn't changed (Enter wasn't processed), retries the Enter keystroke.
+// After sending CR, polls the pane content with exponential backoff. If the
+// content hasn't changed (submit wasn't processed), retries the keystroke.
 // Max 3 retries before returning an error.
 //
 // Falls back to best-effort (no verification) if pane capture fails.
@@ -1550,11 +1556,10 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		verifyLines    = 5 // capture last N lines for comparison
 	)
 
-	// Snapshot pane content before Enter so we can detect processing.
+	// Snapshot pane content before submit so we can detect processing.
 	preSnapshot, preErr := t.CapturePane(target, verifyLines)
 
-	// Send Enter
-	if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+	if err := t.sendLiteralCR(target); err != nil {
 		return fmt.Errorf("send Enter: %w", err)
 	}
 
@@ -1574,12 +1579,12 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		}
 
 		if postSnapshot != preSnapshot {
-			// Content changed — Enter was processed.
+			// Content changed — submit was processed.
 			return nil
 		}
 
-		// Content unchanged — Enter may not have been processed. Retry.
-		if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+		// Content unchanged — CR may not have been processed. Retry.
+		if err := t.sendLiteralCR(target); err != nil {
 			return fmt.Errorf("send Enter (retry %d): %w", retry+1, err)
 		}
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -182,6 +182,7 @@ func BuildCommandContext(ctx context.Context, args ...string) *exec.Cmd {
 // Tmux wraps tmux operations.
 type Tmux struct {
 	socketName string // tmux socket name (-L flag), empty = default socket
+	binary     string // optional tmux executable override; empty means "tmux"
 }
 
 // noTownSocket is a sentinel socket name used when no town socket is configured.
@@ -217,6 +218,19 @@ func NewTmuxWithSocket(socket string) *Tmux {
 	return &Tmux{socketName: socket}
 }
 
+// NewTmuxWithSocketAndBinary is like NewTmuxWithSocket but invokes a specific
+// tmux executable. Tests use this to wrap the host tmux without mutating PATH.
+func NewTmuxWithSocketAndBinary(socket, binary string) *Tmux {
+	return &Tmux{socketName: socket, binary: binary}
+}
+
+func (t *Tmux) tmuxBinary() string {
+	if t != nil && t.binary != "" {
+		return t.binary
+	}
+	return "tmux"
+}
+
 // run executes a tmux command and returns stdout.
 // All commands include -u flag for UTF-8 support regardless of locale settings.
 // See: https://github.com/steveyegge/gastown/issues/1219
@@ -230,7 +244,7 @@ func (t *Tmux) commandContext(ctx context.Context, args ...string) *exec.Cmd {
 		allArgs = append(allArgs, "-L", t.socketName)
 	}
 	allArgs = append(allArgs, args...)
-	cmd := exec.CommandContext(ctx, "tmux", allArgs...)
+	cmd := exec.CommandContext(ctx, t.tmuxBinary(), allArgs...)
 	hideConsoleWindow(cmd)
 	return cmd
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -224,13 +224,6 @@ func NewTmuxWithSocketAndBinary(socket, binary string) *Tmux {
 	return &Tmux{socketName: socket, binary: binary}
 }
 
-func (t *Tmux) tmuxBinary() string {
-	if t != nil && t.binary != "" {
-		return t.binary
-	}
-	return "tmux"
-}
-
 // run executes a tmux command and returns stdout.
 // All commands include -u flag for UTF-8 support regardless of locale settings.
 // See: https://github.com/steveyegge/gastown/issues/1219
@@ -244,7 +237,11 @@ func (t *Tmux) commandContext(ctx context.Context, args ...string) *exec.Cmd {
 		allArgs = append(allArgs, "-L", t.socketName)
 	}
 	allArgs = append(allArgs, args...)
-	cmd := exec.CommandContext(ctx, t.tmuxBinary(), allArgs...)
+	binary := "tmux"
+	if t != nil && t.binary != "" {
+		binary = t.binary
+	}
+	cmd := exec.CommandContext(ctx, binary, allArgs...)
 	hideConsoleWindow(cmd)
 	return cmd
 }
@@ -1535,7 +1532,7 @@ func (t *Tmux) dismissRewindMode(target string) {
 // sendLiteralCR submits the current line with a literal carriage return.
 // Named-key Enter/C-m/KPEnter are not delivered on some tmux builds
 // (tmux 3.7b on macOS Homebrew); send-keys -l with CR is. (GH#4666)
-func (t *Tmux) sendLiteralCR(target string) error {
+func sendLiteralCR(t *Tmux, target string) error {
 	_, err := t.run("send-keys", "-t", target, "-l", "\r")
 	return err
 }
@@ -1559,7 +1556,7 @@ func (t *Tmux) sendEnterVerified(target string) error {
 	// Snapshot pane content before submit so we can detect processing.
 	preSnapshot, preErr := t.CapturePane(target, verifyLines)
 
-	if err := t.sendLiteralCR(target); err != nil {
+	if err := sendLiteralCR(t, target); err != nil {
 		return fmt.Errorf("send Enter: %w", err)
 	}
 
@@ -1584,7 +1581,7 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		}
 
 		// Content unchanged — CR may not have been processed. Retry.
-		if err := t.sendLiteralCR(target); err != nil {
+		if err := sendLiteralCR(t, target); err != nil {
 			return fmt.Errorf("send Enter (retry %d): %w", retry+1, err)
 		}
 

--- a/internal/tmux/tmuxtest/helpers.go
+++ b/internal/tmux/tmuxtest/helpers.go
@@ -1,0 +1,65 @@
+// Package tmuxtest holds process-level helpers for tests that wrap a real
+// tmux binary with testdata/tmuxstub.sh.
+package tmuxtest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// RealTmuxOrSkip returns the host tmux path, or skips the test if tmux is missing.
+func RealTmuxOrSkip(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+	return path
+}
+
+// SocketName returns an isolated tmux socket name derived from the test name.
+func SocketName(t *testing.T, prefix string) string {
+	t.Helper()
+	return prefix + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+// StartSession starts a detached tmux session on an isolated socket and kills
+// that server when the test ends.
+func StartSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+// InstallStub copies testdata/tmuxstub.sh to a temp executable named tmux.
+func InstallStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "..", "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}
+
+// ShellQuote wraps path in single quotes for a sh -c command string.
+func ShellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Summary
Make dog dispatch establish one authoritative assignment across the source bead, persisted dog state, startup hook lookup, and session lifecycle before reporting success.

Dispatch now verifies consumer-side state before startup and conditionally rolls back only transaction-owned mutations. Formula and legacy/plugin dispatch remain compatible.

## Related Issue
Fixes #4516

## Changes
- persist explicit bead/formula/plugin work kinds in dog state
- resolve dog hooks across rig databases and reject stale or conflicting ownership
- verify delayed dog assignment before session startup, with exact metadata CAS rollback and formula molecule cleanup
- serialize completion, removal, forced reassignment, and daemon idle reaping against assignment snapshots
- stop and clear the previous dog during forced dog-to-dog handoff
- add regressions for authoritative lookup, ownership, rollback, completion, and lifecycle races

## Testing
- [x] Focused unit/package tests pass in a capped Docker container:
  `go test -vet=off -p=1 ./internal/cmd ./internal/dog ./internal/daemon ./internal/tmux -count=1`
- [ ] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (not applicable; behavior now matches the documented propulsion contract)
- [x] No breaking changes
