### PR TITLE
fix: prevent silent nudge loss on tmux 3.7b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,8 +3,12 @@ name: Windows CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,14 @@ and full-suite parallelism — they all pass when isolated:
   `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
 - `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
   shared agent registry). It passes reliably via `go test ./internal/config/`.
+
+### mattpocock/skills
+
+The update script also installs [`mattpocock/skills`](https://github.com/mattpocock/skills) via the
+vercel `skills` CLI (`npx skills@latest add mattpocock/skills --agent cursor --skill '*' -g -y --copy`),
+which lands them under `~/.agents/skills/`. Because the Cursor Cloud agent discovers global skills from
+`~/.cursor/skills-cursor/` (not `~/.cursor/skills`, which is where the `skills` CLI's cursor preset
+points), the update script then mirrors each skill folder into `~/.cursor/skills-cursor/` so they are
+discoverable next session. This is deliberately global (user-level), not project-level, to avoid leaving
+untracked files in the repo working tree. The skills-refresh step is best-effort (`|| true`); a prior
+copy persists in the VM snapshot if the network fetch fails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,3 +183,44 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
+
+---
+
+## Cursor Cloud specific instructions
+
+Gas Town is a Go CLI (`gt`). The environment build already has: Go (base `go1.22.2`, but
+`go.mod` pins `go 1.26.2`, auto-fetched via `GOTOOLCHAIN=auto`), `libicu-dev` (required for the
+`go-icu-regex` CGo dependency), `golangci-lint` v2.11.4, `bd` (beads), and `dolt` v2.0.7. The
+update script runs `go mod download` to refresh module deps after a pull.
+
+### Build / lint / test / run
+
+- Build: `make build` → produces `gt`, `gt-proxy-server`, `gt-proxy-client` at repo root. First
+  build compiles a large dep tree (~1.5 min). `go run ./cmd/gt …` also works.
+- Lint: `golangci-lint run --timeout=5m` (installed at `~/go/bin`).
+  - GOTCHA: `golangci-lint` refuses to run if it was built with an older Go than `go.mod`'s
+    `1.26.2` ("the Go language version go1.25 ... is lower than the targeted Go version 1.26.2").
+    `go install ...@v2.11.4` picks the tool's own toolchain (1.25). It must be built with
+    `GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4`.
+    The prebuilt binary in the snapshot is already correct.
+- Test (unit): `go test -short ./...`. Full suite is slow (~15-20 min) because many packages spawn
+  real `git`/`tmux` subprocesses.
+- Integration tests are build-tagged and need Dolt: `go test -tags=integration ./internal/cmd/...`.
+  Some use `internal/testutil` helpers that start Dolt Docker containers and skip gracefully when
+  prerequisites are missing.
+- Run the app: `gt install <path>` creates a town HQ and auto-starts a Dolt SQL server; then
+  `gt status`, `bd create/list/update/close` (beads work ledger), `gt rig add`, etc. `gt` must be on
+  `PATH` for hooks/crew workflows (`cp gt ~/go/bin/` or `make install` → `~/.local/bin`).
+
+### Known environment-induced test failures (NOT code bugs)
+
+Under a full `go test ./...` in the cloud VM, these fail purely due to the VM's global git config
+and full-suite parallelism — they all pass when isolated:
+
+- `internal/git` (`TestConfigurePushURL`, `TestGetPushURL_NoPushURL`, `TestClearPushURL`) and
+  `internal/doctor` (`TestBareRepoExistsCheck_*PushURL*`): the cloud VM injects Cursor-managed
+  `url.https://x-access-token:***@github.com/.insteadOf` rewrites into the global git config, so
+  round-tripped remote URLs don't match. Re-run with a clean config to confirm green, e.g.
+  `TMP=$(mktemp); printf '[user]\n\tname=t\n\temail=t@t' >$TMP; GIT_CONFIG_GLOBAL=$TMP go test ./internal/git/ ./internal/doctor/`.
+- `internal/config` `TestBuiltinPresets` can flake under `./...` (a sibling parallel test mutates the
+  shared agent registry). It passes reliably via `go test ./internal/config/`.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,47 @@
+# Coding standards
+
+## Tests
+
+- Strongly prefer integration and end-to-end tests over unit tests when behaviour crosses CLI, process, filesystem, tmux, Git, or Dolt boundaries.
+- Strongly prefer exercising real system behaviour over treating a green test suite as proof that the product works.
+- Mock only third-party services or process boundaries that we cannot control. Do not mock packages or business rules that we own.
+- For command and workflow changes, the default proof is to run the real command against a temporary town or rig and assert exit status, output, and persisted state.
+- Assert results produced by production code. Do not assert values assembled only by test helpers, copied production logic, or mocks configured by the same test.
+- Use `testutil.RequireDoltContainer`, `testutil.StartIsolatedDoltContainer`, or `testutil.RequireTownEnv` when a test needs those resources. Self-contained tests that create their own temporary town do not need an integration guard.
+- Keep concurrency tests deterministic. Synchronize on observable state or explicit test seams instead of sleeps when possible, and run race-sensitive packages with `go test -race ./path/to/package`.
+- Use `make test` as the repository-wide unit-test gate; it includes shell checks before `go test ./...`. Run tagged integration tests for affected command paths and use `make test-e2e-container` for installation or full-workspace behaviour.
+
+## Comments and docs
+
+- Code comments use ASD-STE100 Simplified Technical English: use short direct sentences, one instruction per sentence, and consistent terms.
+- Use established Gas Town domain terms consistently: town, rig, convoy, bead, molecule, wisp, polecat, crew, dog, hook, sling, and refinery. Use "merge request" for Gas Town's refinery queue and "pull request" for GitHub contributions. Do not invent synonyms for existing terms.
+- Do not write comments that only repeat what the code already makes clear. Explain invariants, boundary conditions, compatibility constraints, and non-obvious reasons.
+- Do not put brittle references in comments or docs, such as line numbers, temporary paths, current versions, or "as of today" claims, when those details can change.
+- Update user-facing docs when commands, configuration, output, or operational behaviour changes.
+
+## Common footguns
+
+- Tautological tests that assert a mock was called exactly as the test configured it.
+- Mocks of packages, modules, or services we own.
+- Treating a green suite as proof that a real agent, town, or rig can complete the workflow.
+- Encoding agent judgment in Go: behavioural heuristics and arbitrary decision thresholds belong in agents and formulas. Deterministic protocol rules and safety boundaries can remain in Go.
+- Confusing ephemeral wisps with durable Dolt-backed issues, or assuming every command reads the same Beads database.
+- Swallowing process, tmux, Git, or persistence errors and then reporting success.
+- Using sleeps to hide lifecycle races or relying on goroutine completion order for stable results.
+- Narrating comments, stale README claims, and hard-coded implementation details.
+- Evading complexity or quality gates with denser syntax, hidden branching, or indirection that does not reduce real complexity.
+
+## Go
+
+- Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
+- Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
+- Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.
+- Use existing package boundaries and production seams. Keep Cobra command wiring in `internal/cmd` thin, and put reusable domain behaviour in the relevant `internal` package.
+- Pass `context.Context` through blocking work. Give subprocesses and external operations explicit cancellation or timeouts.
+- Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
+- Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
+- Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
+- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
+- Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -42,6 +42,6 @@
 - Wrap errors with operation and resource context. Preserve causes with `%w`, and do not convert failures into apparent success.
 - Make concurrent output deterministic. Protect shared state, avoid goroutine leaks, and verify concurrency changes with the race detector.
 - Preserve compatibility across documented town, rig, worktree, and configuration layouts unless a migration is part of the change.
-- Run `make build` and `make test` before merge. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour.
+- Run `make build` and `make test` before merging changes that can affect Go behaviour. Run focused package tests during development, tagged integration tests for affected integration paths, and `make test-e2e-container` when changing installation or end-to-end workspace behaviour. Markdown-only changes do not require Go builds or tests.
 - For releases, keep the release tag and `internal/cmd/version.go` version equal; verify tagged commits with `make check-version-tag`.
 - Use a dedicated branch for every pull request, based on the intended upstream branch. Never open a pull request from a fork's `main` branch.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -34,6 +34,8 @@
 ## Go
 
 - Format with `gofmt`; keep `go vet ./...` and `golangci-lint run --timeout=5m` clean.
+- Production Go code changes should report no violations on the `messgo` rulesets `design`, `codesize`, and `unusedcode`.
+- Production Go code changes should report a covered-MSI of 80% or above from `mutago`.
 - Validate trust boundaries manually as well as with linters. Check user-controlled paths, subprocess arguments, SQL identifiers, and external input before use; linter exclusions are not evidence that an operation is safe.
 - Keep the module path `github.com/steveyegge/gastown` and the Go version in `go.mod` honest. Do not use newer language features without deliberately updating the module version.
 - Follow Zero Framework Cognition: Go code transports data, enforces deterministic protocols and safety boundaries, and performs deterministic operations; agents and molecule formulas perform behavioural judgment and reasoning.

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -288,8 +288,10 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 		// this watcher. It exits on: delivery, session death, or timeout.
 		// Must be synchronous (not a goroutine) because gt nudge is a CLI
 		// command — the process exits after return, killing any goroutines.
-		watchAndDeliver(t, townRoot, sessionName)
-		return nil
+		// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
+		// must propagate so the CLI does not print ✓ Nudged after the
+		// watcher has already logged a failed delivery. (GH#4666)
+		return watchAndDeliver(t, townRoot, sessionName)
 
 	default: // NudgeModeImmediate
 		opts := tmux.NudgeOpts{TownRoot: townRoot}
@@ -312,15 +314,17 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 // send-keys input, so we cannot rely on it.
 //
 // This runs synchronously — gt nudge blocks until the watcher exits.
-// Errors are logged to stderr rather than returned since delivery failure
-// after successful queue write is non-fatal (queue persists for next drain).
+// Timeout and "someone else drained the queue" are non-errors: the nudge
+// remains queued. A hard delivery error after drain is returned so callers
+// do not report success; drained nudges are requeued first. (GH#4666)
 //
 // Exit conditions:
 //   - Agent becomes idle: drain queue and deliver formatted content, exit.
 //   - Queue is empty (someone else drained it): exit.
 //   - Session disappears: exit (nothing to deliver to).
 //   - Timeout: exit (queue stays for next input or watcher cycle).
-func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
+//   - Delivery fails: requeue drained nudges and return the error.
+func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 	fmt.Fprintf(os.Stderr, "Watching %s for idle (up to %s)...\n", sessionName, idleWatcherTimeout)
 	deadline := time.Now().Add(idleWatcherTimeout)
 	for time.Now().Before(deadline) {
@@ -328,12 +332,12 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
 
 		// If queue is already empty, someone else drained it.
 		if nudge.QueueLen(townRoot, sessionName) == 0 {
-			return
+			return nil
 		}
 
 		// Check if session still exists — no point watching a dead session.
 		if exists, _ := t.HasSession(sessionName); !exists {
-			return
+			return nil
 		}
 
 		// Use WaitForIdle with a short timeout instead of single-snapshot
@@ -346,17 +350,19 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
 			// empty slice and skip delivery to avoid duplicates.
 			drained, _ := nudge.Drain(townRoot, sessionName)
 			if len(drained) == 0 {
-				return
+				return nil
 			}
 			formatted := nudge.FormatForInjection(drained)
 			if err := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot}); err != nil {
 				fmt.Fprintf(os.Stderr, "idle-watcher: delivery for %s failed: %v\n", sessionName, err)
 				requeueDrainedNudges(townRoot, sessionName, "idle-watcher", drained)
+				return err
 			}
-			return
+			return nil
 		}
 	}
 	// Timeout — nudge stays in queue for next watcher or manual drain.
+	return nil
 }
 
 func requeueDrainedNudges(townRoot, sessionName, source string, drained []nudge.QueuedNudge) {

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -156,18 +156,8 @@ var idleWatcherPollInterval = 1 * time.Second
 // For "queue" mode: writes to the nudge queue for cooperative delivery.
 // For "wait-idle" mode: waits for idle, then delivers or falls back to queue.
 func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
-	// Test hook: when GT_TEST_NUDGE_LOG is set, log the nudge instead of
-	// delivering through real tmux/queue transport. Prevents test-suite
-	// runs from delivering "test" messages to live agents (mayor reported
-	// recurring synthetic nudges traced to nudge_test.go invocations).
-	// Mirrors the pattern in sling_helpers.go's nudgeWitness/nudgeRefinery.
-	if logPath := os.Getenv("GT_TEST_NUDGE_LOG"); logPath != "" {
-		entry := fmt.Sprintf("nudge:%s:%s:%s\n", sessionName, sender, message)
-		if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-			_, _ = f.WriteString(entry)
-			_ = f.Close()
-		}
-		return nil
+	if handled, err := logNudgeIfTest(sessionName, sender, message); handled {
+		return err
 	}
 
 	townRoot, _ := workspace.FindFromCwd()
@@ -179,132 +169,167 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 		mode = NudgeModeQueue
 	}
 
-	// For direct tmux delivery, prefix with sender attribution.
-	// Queue-based delivery stores Sender as a separate field and
-	// FormatForInjection adds the prefix, so we must NOT double-prefix.
-	prefixedMessage := fmt.Sprintf("[from %s] %s", sender, message)
-
 	switch mode {
 	case NudgeModeQueue:
 		if townRoot == "" {
 			return fmt.Errorf("--mode=queue requires a Gas Town workspace")
 		}
-		return nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-			Sender:   sender,
-			Message:  message,
-			Priority: nudgePriorityFlag,
-		})
+		return nudge.Enqueue(townRoot, sessionName, queuedNudge(sender, message))
 
 	case NudgeModeWaitIdle:
-		if townRoot == "" {
-			// wait-idle needs workspace for queue fallback — fail explicitly
-			// rather than silently degrading to immediate (destructive) delivery.
-			return fmt.Errorf("--mode=wait-idle requires a Gas Town workspace")
-		}
-		// Check if the target agent supports prompt-based idle detection.
-		// WaitForIdle uses Claude Code's prompt pattern (❯) and status bar (⏵⏵).
-		// Non-Claude agents (Gemini, Codex, etc.) have no ReadyPromptPrefix,
-		// so WaitForIdle produces false positives — it sees no busy indicator
-		// and matches stale prompt characters in the pane buffer. (GH#gt-5ey3)
-		// Degrade to queue mode for agents without prompt-based detection.
-		if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
-			preset := config.GetAgentPresetByName(agentName)
-			if preset != nil && preset.ReadyPromptPrefix == "" {
-				fmt.Fprintf(os.Stderr, "wait-idle: %s agent %q has no prompt detection, using queue mode\n", sessionName, agentName)
-				if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-					Sender:   sender,
-					Message:  message,
-					Priority: nudgePriorityFlag,
-				}); qErr != nil {
-					formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-						Sender:   sender,
-						Message:  message,
-						Priority: nudgePriorityFlag,
-					}})
-					return t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-				}
-				// Ensure a nudge-poller is running so the queue actually drains.
-				// The poller is normally started by gt crew start, but if the
-				// session was started manually (or the poller crashed), queued
-				// nudges sit undelivered forever. StartPoller is idempotent —
-				// it no-ops if a poller is already alive for this session.
-				if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
-					fmt.Fprintf(os.Stderr, "wait-idle: could not start nudge poller for %s: %v\n", sessionName, pollerErr)
-				}
-				return nil
-			}
-		}
-		// Try to wait for idle
-		err := t.WaitForIdle(sessionName, waitIdleTimeout)
-		if err == nil {
-			// Agent is idle — deliver directly. Format as system-reminder
-			// so the agent processes it as a background notification rather
-			// than a user interruption/correction.
-			formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}})
-			deliverErr := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-			if !errors.Is(deliverErr, tmux.ErrSubmitNotVerified) {
-				return deliverErr
-			}
-			fmt.Fprintf(os.Stderr, "wait-idle: %v; queueing for %s\n", deliverErr, sessionName)
-			if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}); qErr != nil {
-				return fmt.Errorf("queue fallback after unverified submit failed: %v (original: %w)", qErr, deliverErr)
-			}
-			return nil
-		}
-		// Terminal errors (session gone, no server) — propagate, don't queue.
-		// Queueing a nudge for a dead session means it will never be delivered.
-		if errors.Is(err, tmux.ErrSessionNotFound) || errors.Is(err, tmux.ErrNoServer) {
-			return fmt.Errorf("wait-idle: %w", err)
-		}
-		// Timeout (agent busy) — queue instead
-		if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
-			Sender:   sender,
-			Message:  message,
-			Priority: nudgePriorityFlag,
-		}); qErr != nil {
-			// Queue failed — fall back to immediate as last resort.
-			// Better to interrupt than lose the message entirely.
-			fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
-			// Still use FormatForInjection so the agent sees a consistent
-			// <system-reminder> format regardless of delivery path.
-			formatted := nudge.FormatForInjection([]nudge.QueuedNudge{{
-				Sender:   sender,
-				Message:  message,
-				Priority: nudgePriorityFlag,
-			}})
-			return t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
-		}
-		// Run watcher synchronously: polls for idle over a longer window.
-		// The UserPromptSubmit hook drains the queue on agent input, but an
-		// idle agent receives no input — so queued nudges are lost without
-		// this watcher. It exits on: delivery, session death, or timeout.
-		// Must be synchronous (not a goroutine) because gt nudge is a CLI
-		// command — the process exits after return, killing any goroutines.
-		// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
-		// must propagate so the CLI does not print ✓ Nudged after the
-		// watcher has already logged a failed delivery. (GH#4666)
-		return watchAndDeliver(t, townRoot, sessionName)
+		return deliverNudgeWaitIdle(t, townRoot, sessionName, sender, message)
 
 	default: // NudgeModeImmediate
-		opts := tmux.NudgeOpts{TownRoot: townRoot}
-		// Check if the target agent uses Escape as cancel (e.g., Gemini CLI).
-		// For these agents, skip the Escape keystroke to avoid canceling
-		// in-flight generation. (GH#gt-wasn)
-		if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
-			if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
-				opts.SkipEscape = true
-			}
-		}
-		return t.NudgeSessionWithOpts(sessionName, prefixedMessage, opts)
+		return deliverNudgeImmediate(t, townRoot, sessionName, sender, message)
 	}
+}
+
+func logNudgeIfTest(sessionName, sender, message string) (bool, error) {
+	// Test hook: when GT_TEST_NUDGE_LOG is set, log the nudge instead of
+	// delivering through real tmux/queue transport. Prevents test-suite
+	// runs from delivering "test" messages to live agents (mayor reported
+	// recurring synthetic nudges traced to nudge_test.go invocations).
+	// Mirrors the pattern in sling_helpers.go's nudgeWitness/nudgeRefinery.
+	logPath := os.Getenv("GT_TEST_NUDGE_LOG")
+	if logPath == "" {
+		return false, nil
+	}
+	entry := fmt.Sprintf("nudge:%s:%s:%s\n", sessionName, sender, message)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return true, fmt.Errorf("writing test nudge log: %w", err)
+	}
+	_, writeErr := f.WriteString(entry)
+	if closeErr := f.Close(); writeErr != nil {
+		return true, fmt.Errorf("writing test nudge log: %w", writeErr)
+	} else if closeErr != nil {
+		return true, fmt.Errorf("closing test nudge log: %w", closeErr)
+	}
+	return true, nil
+}
+
+func deliverNudgeImmediate(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	// Prefix with sender attribution. Queue-based delivery stores Sender as
+	// a separate field and FormatForInjection adds the prefix, so wait-idle
+	// and queue paths must not double-prefix.
+	prefixedMessage := fmt.Sprintf("[from %s] %s", sender, message)
+	opts := tmux.NudgeOpts{TownRoot: townRoot}
+	// Check if the target agent uses Escape as cancel (e.g., Gemini CLI).
+	// For these agents, skip the Escape keystroke to avoid canceling
+	// in-flight generation. (GH#gt-wasn)
+	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+		if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
+			opts.SkipEscape = true
+		}
+	}
+	return t.NudgeSessionWithOpts(sessionName, prefixedMessage, opts)
+}
+
+func queuedNudge(sender, message string) nudge.QueuedNudge {
+	return nudge.QueuedNudge{
+		Sender:   sender,
+		Message:  message,
+		Priority: nudgePriorityFlag,
+	}
+}
+
+func injectFormatted(t *tmux.Tmux, townRoot, sessionName string, nudges []nudge.QueuedNudge) error {
+	return t.NudgeSessionWithOpts(sessionName, nudge.FormatForInjection(nudges), tmux.NudgeOpts{TownRoot: townRoot})
+}
+
+// deliverNudgeWaitIdle waits for idle, then delivers. On timeout it queues
+// and watches. Queue failure falls back to immediate delivery.
+func deliverNudgeWaitIdle(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	if townRoot == "" {
+		// wait-idle needs workspace for queue fallback — fail explicitly
+		// rather than silently degrading to immediate (destructive) delivery.
+		return fmt.Errorf("--mode=wait-idle requires a Gas Town workspace")
+	}
+	// Check if the target agent supports prompt-based idle detection.
+	// WaitForIdle uses Claude Code's prompt pattern (❯) and status bar (⏵⏵).
+	// Non-Claude agents (Gemini, Codex, etc.) have no ReadyPromptPrefix,
+	// so WaitForIdle produces false positives — it sees no busy indicator
+	// and matches stale prompt characters in the pane buffer. (GH#gt-5ey3)
+	// Degrade to queue mode for agents without prompt-based detection.
+	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+		preset := config.GetAgentPresetByName(agentName)
+		if preset != nil && preset.ReadyPromptPrefix == "" {
+			return queuePromptlessAgent(t, townRoot, sessionName, sender, message, agentName)
+		}
+	}
+	err := t.WaitForIdle(sessionName, waitIdleTimeout)
+	if err == nil {
+		return deliverWaitIdleDirect(t, townRoot, sessionName, sender, message)
+	}
+	// Terminal errors (session gone, no server) — propagate, don't queue.
+	// Queueing a nudge for a dead session means it will never be delivered.
+	if errors.Is(err, tmux.ErrSessionNotFound) || errors.Is(err, tmux.ErrNoServer) {
+		return fmt.Errorf("wait-idle: %w", err)
+	}
+	return queueThenWatch(t, townRoot, sessionName, sender, message)
+}
+
+func queuePromptlessAgent(t *tmux.Tmux, townRoot, sessionName, sender, message, agentName string) error {
+	fmt.Fprintf(os.Stderr, "wait-idle: %s agent %q has no prompt detection, using queue mode\n", sessionName, agentName)
+	item := queuedNudge(sender, message)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		return injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	}
+	// Ensure a nudge-poller is running so the queue actually drains.
+	// The poller is normally started by gt crew start, but if the
+	// session was started manually (or the poller crashed), queued
+	// nudges sit undelivered forever. StartPoller is idempotent —
+	// it no-ops if a poller is already alive for this session.
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
+		fmt.Fprintf(os.Stderr, "wait-idle: could not start nudge poller for %s: %v\n", sessionName, pollerErr)
+	}
+	return nil
+}
+
+func deliverWaitIdleDirect(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	item := queuedNudge(sender, message)
+	deliverErr := injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	if deliverErr == nil {
+		return nil
+	}
+	if errors.Is(deliverErr, tmux.ErrSubmitNotVerified) {
+		fmt.Fprintf(os.Stderr, "wait-idle: %v; queueing for %s\n", deliverErr, sessionName)
+		if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+			return fmt.Errorf("queue fallback after unverified submit failed: %v (original: %w)", qErr, deliverErr)
+		}
+		return nil
+	}
+	// Hard send-keys errors take the same fallback as a wait-idle timeout:
+	// queue first, then immediate if the queue write fails. (GH#4666)
+	fmt.Fprintf(os.Stderr, "wait-idle: delivery for %s failed: %v; queueing\n", sessionName, deliverErr)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
+		if immErr := injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item}); immErr != nil {
+			return fmt.Errorf("wait-idle delivery for session %q: %w (queue failed: %w; immediate fallback: %w)", sessionName, deliverErr, qErr, immErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("wait-idle delivery for session %q: %w", sessionName, deliverErr)
+}
+
+func queueThenWatch(t *tmux.Tmux, townRoot, sessionName, sender, message string) error {
+	item := queuedNudge(sender, message)
+	if qErr := nudge.Enqueue(townRoot, sessionName, item); qErr != nil {
+		// Queue failed — fall back to immediate as last resort.
+		// Better to interrupt than lose the message entirely.
+		fmt.Fprintf(os.Stderr, "Warning: queue fallback failed (%v), delivering immediately\n", qErr)
+		return injectFormatted(t, townRoot, sessionName, []nudge.QueuedNudge{item})
+	}
+	// Run watcher synchronously: polls for idle over a longer window.
+	// The UserPromptSubmit hook drains the queue on agent input, but an
+	// idle agent receives no input — so queued nudges are lost without
+	// this watcher. It exits on: delivery, session death, or timeout.
+	// Must be synchronous (not a goroutine) because gt nudge is a CLI
+	// command — the process exits after return, killing any goroutines.
+	// Hard delivery errors (e.g. tmux send-keys rejecting unknown flags)
+	// must propagate so the CLI does not print ✓ Nudged after the
+	// watcher has already logged a failed delivery. (GH#4666)
+	return watchAndDeliver(t, townRoot, sessionName)
 }
 
 // watchAndDeliver polls a session for idle state over idleWatcherTimeout.
@@ -315,15 +340,18 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 //
 // This runs synchronously — gt nudge blocks until the watcher exits.
 // Timeout and "someone else drained the queue" are non-errors: the nudge
-// remains queued. A hard delivery error after drain is returned so callers
-// do not report success; drained nudges are requeued first. (GH#4666)
+// remains queued. A hard delivery error after drain is returned with
+// operation and session context so callers do not report success. Drained
+// nudges are requeued first; if requeue fails, immediate delivery is the
+// last resort. (GH#4666)
 //
 // Exit conditions:
 //   - Agent becomes idle: drain queue and deliver formatted content, exit.
 //   - Queue is empty (someone else drained it): exit.
 //   - Session disappears: exit (nothing to deliver to).
 //   - Timeout: exit (queue stays for next input or watcher cycle).
-//   - Delivery fails: requeue drained nudges and return the error.
+//   - Delivery fails: requeue drained nudges and return a wrapped error.
+//     If requeue also fails, attempt immediate delivery before returning.
 func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 	fmt.Fprintf(os.Stderr, "Watching %s for idle (up to %s)...\n", sessionName, idleWatcherTimeout)
 	deadline := time.Now().Add(idleWatcherTimeout)
@@ -352,11 +380,9 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) error {
 			if len(drained) == 0 {
 				return nil
 			}
-			formatted := nudge.FormatForInjection(drained)
-			if err := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot}); err != nil {
+			if err := injectFormatted(t, townRoot, sessionName, drained); err != nil {
 				fmt.Fprintf(os.Stderr, "idle-watcher: delivery for %s failed: %v\n", sessionName, err)
-				requeueDrainedNudges(townRoot, sessionName, "idle-watcher", drained)
-				return err
+				return recoverFailedWatcherDelivery(t, townRoot, sessionName, drained, err)
 			}
 			return nil
 		}
@@ -369,6 +395,18 @@ func requeueDrainedNudges(townRoot, sessionName, source string, drained []nudge.
 	if err := nudge.Requeue(townRoot, sessionName, drained); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: requeue for %s failed: %v\n", source, sessionName, err)
 	}
+}
+
+func recoverFailedWatcherDelivery(t *tmux.Tmux, townRoot, sessionName string, drained []nudge.QueuedNudge, deliverErr error) error {
+	if qErr := nudge.Requeue(townRoot, sessionName, drained); qErr != nil {
+		fmt.Fprintf(os.Stderr, "idle-watcher: requeue for %s failed: %v\n", sessionName, qErr)
+		fmt.Fprintf(os.Stderr, "Warning: requeue failed (%v), delivering immediately\n", qErr)
+		if immErr := injectFormatted(t, townRoot, sessionName, drained); immErr != nil {
+			return fmt.Errorf("idle-watcher delivery for session %q: %w (requeue failed: %w; immediate fallback: %w)", sessionName, deliverErr, qErr, immErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("idle-watcher delivery for session %q: %w", sessionName, deliverErr)
 }
 
 // validNudgeModes is the set of allowed --mode values.

--- a/internal/cmd/nudge_idle_watcher_delivery_test.go
+++ b/internal/cmd/nudge_idle_watcher_delivery_test.go
@@ -1,27 +1,132 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/tmux/tmuxtest"
 )
 
 // TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError replays
 // GH#4666: busy-target wait-idle falls through to the idle-watcher, send-keys
-// then fails with the tmux 3.7b "unknown flag -V" error, and gt still reports
-// success. The loop is red while deliverNudge returns nil after that failure.
+// then fails with the tmux 3.7b "unknown flag -V" error. The contract is that
+// deliverNudge returns that failure with operation and session context, and
+// the drained nudge is requeued.
 func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, time.Millisecond)
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
 	}
+	if !strings.Contains(stderrText, "unknown flag -V") {
+		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
+	}
+
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+	if !strings.Contains(deliverErr.Error(), "idle-watcher") {
+		t.Fatalf("delivery error missing operation context: %v", deliverErr)
+	}
+	if !strings.Contains(deliverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", deliverErr)
+	}
+
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
+	}
+}
+
+// TestDeliverNudge_WaitIdle_DirectSendKeysFailure_QueuesAndReturnsError covers
+// the idle-direct path: WaitForIdle succeeds, send-keys fails, and the hard
+// error must queue then return so the message is not lost and gt does not
+// print success.
+func TestDeliverNudge_WaitIdle_DirectSendKeysFailure_QueuesAndReturnsError(t *testing.T) {
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, 5*time.Second)
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "wait-idle: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected wait-idle delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
+	}
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-direct send-keys failure. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+	if !strings.Contains(deliverErr.Error(), "wait-idle") {
+		t.Fatalf("delivery error missing operation context: %v", deliverErr)
+	}
+	if !strings.Contains(deliverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", deliverErr)
+	}
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the nudge (queue empty)")
+	}
+}
+
+// TestRecoverFailedWatcherDelivery_RequeueFailure_ImmediateFallback covers
+// the issue's last-resort fallback: when watcher delivery fails and requeue
+// also fails, attempt immediate delivery so the drained nudge is not lost.
+func TestRecoverFailedWatcherDelivery_RequeueFailure_ImmediateFallback(t *testing.T) {
+	townRoot, sessionName, tm := setupWaitIdleSendKeysFailure(t, time.Millisecond)
+	drained := []nudge.QueuedNudge{{
+		Sender:   "test",
+		Message:  "hello from 4666",
+		Priority: nudge.PriorityNormal,
+	}}
+	queueDir := filepath.Join(townRoot, constants.DirRuntime, "nudge_queue", sessionName)
+	if err := os.MkdirAll(queueDir, 0o755); err != nil {
+		t.Fatalf("mkdir queue dir: %v", err)
+	}
+	if err := os.RemoveAll(queueDir); err != nil {
+		t.Fatalf("remove queue dir: %v", err)
+	}
+	if err := os.WriteFile(queueDir, []byte("not-a-directory"), 0o644); err != nil {
+		t.Fatalf("block requeue: %v", err)
+	}
+
+	var recoverErr error
+	stderrText := captureStderr(t, func() {
+		recoverErr = recoverFailedWatcherDelivery(tm, townRoot, sessionName, drained,
+			fmt.Errorf("tmux send-keys: command send-keys: unknown flag -V"))
+	})
+
+	if !strings.Contains(stderrText, "delivering immediately") {
+		t.Fatalf("expected immediate-delivery fallback after requeue failure, stderr=%q err=%v", stderrText, recoverErr)
+	}
+	if recoverErr == nil {
+		t.Fatalf("send-keys still fails on immediate fallback; must not report success. stderr=%q", stderrText)
+	}
+	if !strings.Contains(recoverErr.Error(), "idle-watcher") {
+		t.Fatalf("delivery error missing operation context: %v", recoverErr)
+	}
+	if !strings.Contains(recoverErr.Error(), sessionName) {
+		t.Fatalf("delivery error missing session resource context: %v", recoverErr)
+	}
+	if !strings.Contains(recoverErr.Error(), "requeue failed") {
+		t.Fatalf("delivery error missing requeue failure: %v", recoverErr)
+	}
+}
+
+func setupWaitIdleSendKeysFailure(t *testing.T, waitIdle time.Duration) (townRoot, sessionName string, tm *tmux.Tmux) {
+	t.Helper()
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	origMode := nudgeModeFlag
 	origPriority := nudgePriorityFlag
@@ -40,79 +145,20 @@ func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testin
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_FAIL_SEND_KEYS", "1")
 
-	townRoot := setupTestTownForConfig(t)
+	townRoot = setupTestTownForConfig(t)
 	t.Chdir(townRoot)
 
-	socket := isolatedTmuxSocketName(t)
-	sessionName := "hq-mayor"
-	startIsolatedTmuxSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
+	socket := tmuxtest.SocketName(t, "gt4666-")
+	sessionName = "hq-mayor"
+	tmuxtest.StartSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
 
-	stub := installTmuxStub(t)
-	tm := tmux.NewTmuxWithSocketAndBinary(socket, stub)
+	stub := tmuxtest.InstallStub(t)
+	tm = tmux.NewTmuxWithSocketAndBinary(socket, stub)
 
 	nudgeModeFlag = NudgeModeWaitIdle
 	nudgePriorityFlag = nudge.PriorityNormal
-	// Force the idle-watcher path: the first WaitForIdle cannot complete two
-	// consecutive polls inside 1ms, so wait-idle queues and watchAndDeliver
-	// is the delivery attempt that hits the send-keys failure.
-	waitIdleTimeout = time.Millisecond
+	waitIdleTimeout = waitIdle
 	idleWatcherTimeout = 5 * time.Second
 	idleWatcherPollInterval = 800 * time.Millisecond
-
-	var deliverErr error
-	stderrText := captureStderr(t, func() {
-		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
-	})
-
-	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
-		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
-	}
-	if !strings.Contains(stderrText, "unknown flag -V") {
-		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
-	}
-
-	// User-facing symptom: gt prints ✓ Nudged and exits 0 because this error
-	// is swallowed. The contract is that a hard send-keys failure is not success.
-	if deliverErr == nil {
-		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
-			stderrText, nudge.QueueLen(townRoot, sessionName))
-	}
-
-	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
-		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
-	}
-}
-
-func isolatedTmuxSocketName(t *testing.T) string {
-	t.Helper()
-	return "gt4666-" + strings.ReplaceAll(t.Name(), "/", "-")
-}
-
-func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
-	t.Helper()
-	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("tmux new-session: %v\n%s", err, out)
-	}
-	t.Cleanup(func() {
-		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
-	})
-}
-
-func installTmuxStub(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src := filepath.Join(filepath.Dir(file), "..", "tmux", "testdata", "tmuxstub.sh")
-	data, err := os.ReadFile(src)
-	if err != nil {
-		t.Fatalf("read tmux stub: %v", err)
-	}
-	dst := filepath.Join(t.TempDir(), "tmux")
-	if err := os.WriteFile(dst, data, 0o755); err != nil {
-		t.Fatalf("write tmux stub: %v", err)
-	}
-	return dst
+	return townRoot, sessionName, tm
 }

--- a/internal/cmd/nudge_idle_watcher_delivery_test.go
+++ b/internal/cmd/nudge_idle_watcher_delivery_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError replays
+// GH#4666: busy-target wait-idle falls through to the idle-watcher, send-keys
+// then fails with the tmux 3.7b "unknown flag -V" error, and gt still reports
+// success. The loop is red while deliverNudge returns nil after that failure.
+func TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	origMode := nudgeModeFlag
+	origPriority := nudgePriorityFlag
+	origWait := waitIdleTimeout
+	origWatch := idleWatcherTimeout
+	origInterval := idleWatcherPollInterval
+	t.Cleanup(func() {
+		nudgeModeFlag = origMode
+		nudgePriorityFlag = origPriority
+		waitIdleTimeout = origWait
+		idleWatcherTimeout = origWatch
+		idleWatcherPollInterval = origInterval
+	})
+
+	t.Setenv("GT_TEST_NUDGE_LOG", "")
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_FAIL_SEND_KEYS", "1")
+
+	townRoot := setupTestTownForConfig(t)
+	t.Chdir(townRoot)
+
+	socket := isolatedTmuxSocketName(t)
+	sessionName := "hq-mayor"
+	startIsolatedTmuxSession(t, realTmux, socket, sessionName, "printf '❯ \\n'; exec cat")
+
+	stub := installTmuxStub(t)
+	tm := tmux.NewTmuxWithSocketAndBinary(socket, stub)
+
+	nudgeModeFlag = NudgeModeWaitIdle
+	nudgePriorityFlag = nudge.PriorityNormal
+	// Force the idle-watcher path: the first WaitForIdle cannot complete two
+	// consecutive polls inside 1ms, so wait-idle queues and watchAndDeliver
+	// is the delivery attempt that hits the send-keys failure.
+	waitIdleTimeout = time.Millisecond
+	idleWatcherTimeout = 5 * time.Second
+	idleWatcherPollInterval = 800 * time.Millisecond
+
+	var deliverErr error
+	stderrText := captureStderr(t, func() {
+		deliverErr = deliverNudge(tm, sessionName, "hello from 4666", "test")
+	})
+
+	if !strings.Contains(stderrText, "idle-watcher: delivery for "+sessionName+" failed") {
+		t.Fatalf("expected idle-watcher delivery failure log, stderr=%q err=%v", stderrText, deliverErr)
+	}
+	if !strings.Contains(stderrText, "unknown flag -V") {
+		t.Fatalf("expected tmux 3.7b unknown-flag symptom, stderr=%q", stderrText)
+	}
+
+	// User-facing symptom: gt prints ✓ Nudged and exits 0 because this error
+	// is swallowed. The contract is that a hard send-keys failure is not success.
+	if deliverErr == nil {
+		t.Fatalf("deliverNudge returned nil after idle-watcher send-keys failure; nudge was reported successful. stderr=%q queueLen=%d",
+			stderrText, nudge.QueueLen(townRoot, sessionName))
+	}
+
+	if got := nudge.QueueLen(townRoot, sessionName); got == 0 {
+		t.Fatalf("hard delivery error dropped the queued nudge (queue empty, only lock may remain)")
+	}
+}
+
+func isolatedTmuxSocketName(t *testing.T) string {
+	t.Helper()
+	return "gt4666-" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+func installTmuxStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "..", "tmux", "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}

--- a/internal/tmux/nudge_tmux37b_test.go
+++ b/internal/tmux/nudge_tmux37b_test.go
@@ -2,12 +2,12 @@ package tmux
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux/tmuxtest"
 )
 
 // TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired replays GH#4666 defect 3:
@@ -15,30 +15,29 @@ import (
 // carriage return (send-keys -l $'\r') does. The stub swallows named Enter
 // the way that tmux does not deliver it; the message must still reach cat.
 func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
-	}
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_NOOP_NAMED_ENTER", "1")
 
-	socket := "gt4666-enter-" + strings.ReplaceAll(t.Name(), "/", "-")
+	socket := tmuxtest.SocketName(t, "gt4666-enter-")
 	session := "nudge-enter"
 	outFile := filepath.Join(t.TempDir(), "submitted.txt")
-	startIsolatedTmuxSession(t, realTmux, socket, session,
-		"printf 'esc to interrupt\\n'; exec cat >"+shellQuote(outFile))
+	tmuxtest.StartSession(t, realTmux, socket, session,
+		"printf 'esc to interrupt\\n'; exec cat >"+tmuxtest.ShellQuote(outFile))
 
-	stub := installTmuxStub(t)
+	stub := tmuxtest.InstallStub(t)
 	tm := NewTmuxWithSocketAndBinary(socket, stub)
 
 	msg := "hello-from-4666"
-	if err := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{}); err != nil {
-		t.Logf("NudgeSessionWithOpts error (may be expected while Enter is a no-op): %v", err)
+	nudgeErr := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{})
+	if nudgeErr != nil {
+		t.Logf("NudgeSessionWithOpts error after literal CR submit: %v", nudgeErr)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
 	var got []byte
+	var err error
 	for time.Now().Before(deadline) {
 		got, err = os.ReadFile(outFile)
 		if err == nil && strings.Contains(string(got), msg) {
@@ -52,32 +51,34 @@ func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
 // TestNudgeSendKeys_DoesNotPassUnknown37bFlags records send-keys argv during a
 // real NudgeSession. tmux 3.7b rejects -V and -o on send-keys (GH#4666 defect 1).
 func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
-	realTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not installed")
-	}
+	realTmux := tmuxtest.RealTmuxOrSkip(t)
 
 	logPath := filepath.Join(t.TempDir(), "tmux.argv")
 	t.Setenv("GT_REAL_TMUX", realTmux)
 	t.Setenv("GT_TMUX_ARGV_LOG", logPath)
 	t.Setenv("GT_TMUX_REJECT_37B_FLAGS", "1")
 
-	socket := "gt4666-flags-" + strings.ReplaceAll(t.Name(), "/", "-")
+	socket := tmuxtest.SocketName(t, "gt4666-flags-")
 	session := "nudge-flags"
-	startIsolatedTmuxSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
+	tmuxtest.StartSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
 
-	stub := installTmuxStub(t)
+	stub := tmuxtest.InstallStub(t)
 	tm := NewTmuxWithSocketAndBinary(socket, stub)
-	_ = tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+	nudgeErr := tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+	if nudgeErr != nil && sendKeysUsedUnknown37bFlag(nudgeErr.Error()) {
+		t.Fatalf("production send-keys used a tmux 3.7b-unknown flag: %v", nudgeErr)
+	}
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
-		t.Fatalf("read argv log: %v", err)
+		t.Fatalf("read argv log: %v (nudgeErr=%v)", err, nudgeErr)
 	}
+	sawSendKeys := false
 	for _, line := range strings.Split(string(data), "\n") {
 		if !strings.Contains(line, "send-keys") {
 			continue
 		}
+		sawSendKeys = true
 		fields := strings.Fields(line)
 		for _, f := range fields {
 			if f == "-V" || f == "-o" {
@@ -85,37 +86,11 @@ func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
 			}
 		}
 	}
+	if !sawSendKeys {
+		t.Fatalf("no send-keys invocation recorded; cannot verify flags. log=%q nudgeErr=%v", data, nudgeErr)
+	}
 }
 
-func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
-	t.Helper()
-	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("tmux new-session: %v\n%s", err, out)
-	}
-	t.Cleanup(func() {
-		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
-	})
-}
-
-func installTmuxStub(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src := filepath.Join(filepath.Dir(file), "testdata", "tmuxstub.sh")
-	data, err := os.ReadFile(src)
-	if err != nil {
-		t.Fatalf("read tmux stub: %v", err)
-	}
-	dst := filepath.Join(t.TempDir(), "tmux")
-	if err := os.WriteFile(dst, data, 0o755); err != nil {
-		t.Fatalf("write tmux stub: %v", err)
-	}
-	return dst
-}
-
-func shellQuote(path string) string {
-	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+func sendKeysUsedUnknown37bFlag(errText string) bool {
+	return strings.Contains(errText, "unknown flag -V") || strings.Contains(errText, "unknown flag -o")
 }

--- a/internal/tmux/nudge_tmux37b_test.go
+++ b/internal/tmux/nudge_tmux37b_test.go
@@ -1,0 +1,121 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired replays GH#4666 defect 3:
+// on tmux 3.7b, named-key Enter/C-m/KPEnter do not submit while a literal
+// carriage return (send-keys -l $'\r') does. The stub swallows named Enter
+// the way that tmux does not deliver it; the message must still reach cat.
+func TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_NOOP_NAMED_ENTER", "1")
+
+	socket := "gt4666-enter-" + strings.ReplaceAll(t.Name(), "/", "-")
+	session := "nudge-enter"
+	outFile := filepath.Join(t.TempDir(), "submitted.txt")
+	startIsolatedTmuxSession(t, realTmux, socket, session,
+		"printf 'esc to interrupt\\n'; exec cat >"+shellQuote(outFile))
+
+	stub := installTmuxStub(t)
+	tm := NewTmuxWithSocketAndBinary(socket, stub)
+
+	msg := "hello-from-4666"
+	if err := tm.NudgeSessionWithOpts(session, msg, NudgeOpts{}); err != nil {
+		t.Logf("NudgeSessionWithOpts error (may be expected while Enter is a no-op): %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) {
+		got, err = os.ReadFile(outFile)
+		if err == nil && strings.Contains(string(got), msg) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("named-key Enter did not submit; literal CR is required. outfile=%q err=%v", string(got), err)
+}
+
+// TestNudgeSendKeys_DoesNotPassUnknown37bFlags records send-keys argv during a
+// real NudgeSession. tmux 3.7b rejects -V and -o on send-keys (GH#4666 defect 1).
+func TestNudgeSendKeys_DoesNotPassUnknown37bFlags(t *testing.T) {
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	logPath := filepath.Join(t.TempDir(), "tmux.argv")
+	t.Setenv("GT_REAL_TMUX", realTmux)
+	t.Setenv("GT_TMUX_ARGV_LOG", logPath)
+	t.Setenv("GT_TMUX_REJECT_37B_FLAGS", "1")
+
+	socket := "gt4666-flags-" + strings.ReplaceAll(t.Name(), "/", "-")
+	session := "nudge-flags"
+	startIsolatedTmuxSession(t, realTmux, socket, session, "printf 'esc to interrupt\\n'; exec cat")
+
+	stub := installTmuxStub(t)
+	tm := NewTmuxWithSocketAndBinary(socket, stub)
+	_ = tm.NudgeSessionWithOpts(session, "flag-probe", NudgeOpts{})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "send-keys") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for _, f := range fields {
+			if f == "-V" || f == "-o" {
+				t.Fatalf("send-keys used tmux 3.7b-unknown flag %s: %s", f, line)
+			}
+		}
+	}
+}
+
+func startIsolatedTmuxSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+func installTmuxStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}
+
+func shellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}

--- a/internal/tmux/testdata/tmuxstub.sh
+++ b/internal/tmux/testdata/tmuxstub.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Test stub that wraps the real tmux binary. Controlled by env:
+#   GT_REAL_TMUX              required; path to the real tmux
+#   GT_TMUX_ARGV_LOG          if set, append each invocation's args
+#   GT_TMUX_FAIL_SEND_KEYS    if 1, every send-keys fails like tmux 3.7b unknown -V
+#   GT_TMUX_REJECT_37B_FLAGS  if 1, send-keys -V / -o are rejected (tmux 3.7b)
+#   GT_TMUX_NOOP_NAMED_ENTER  if 1, named-key Enter/C-m/KPEnter succeed but do nothing
+set -eu
+
+if [ -n "${GT_TMUX_ARGV_LOG:-}" ]; then
+	printf '%s\n' "$*" >>"$GT_TMUX_ARGV_LOG"
+fi
+
+is_send_keys=0
+for arg in "$@"; do
+	if [ "$arg" = "send-keys" ]; then
+		is_send_keys=1
+		break
+	fi
+done
+
+if [ "$is_send_keys" = 1 ]; then
+	if [ "${GT_TMUX_FAIL_SEND_KEYS:-}" = "1" ]; then
+		echo "command send-keys: unknown flag -V" >&2
+		exit 1
+	fi
+	if [ "${GT_TMUX_REJECT_37B_FLAGS:-}" = "1" ]; then
+		for arg in "$@"; do
+			if [ "$arg" = "-V" ]; then
+				echo "command send-keys: unknown flag -V" >&2
+				exit 1
+			fi
+			if [ "$arg" = "-o" ]; then
+				echo "command send-keys: unknown flag -o" >&2
+				exit 1
+			fi
+		done
+	fi
+	if [ "${GT_TMUX_NOOP_NAMED_ENTER:-}" = "1" ]; then
+		literal=0
+		named=0
+		for arg in "$@"; do
+			if [ "$arg" = "-l" ]; then
+				literal=1
+			fi
+			case "$arg" in
+			Enter | C-m | KPEnter)
+				named=1
+				;;
+			esac
+		done
+		if [ "$named" = 1 ] && [ "$literal" = 0 ]; then
+			exit 0
+		fi
+	fi
+fi
+
+if [ -z "${GT_REAL_TMUX:-}" ]; then
+	echo "tmuxstub: GT_REAL_TMUX is unset" >&2
+	exit 127
+fi
+exec "$GT_REAL_TMUX" "$@"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1532,14 +1532,20 @@ func (t *Tmux) dismissRewindMode(target string) {
 	time.Sleep(300 * time.Millisecond)
 }
 
-// sendEnterVerified sends Enter to a tmux target and verifies it was processed
-// by checking that the pane content changes. Under load, tmux may buffer
-// keystrokes, causing Enter to race with text delivery — Enter arrives while
-// tmux is still processing text/Escape and gets treated as part of the text
-// stream rather than a separate submit action.
+// sendLiteralCR submits the current line with a literal carriage return.
+// Named-key Enter/C-m/KPEnter are not delivered on some tmux builds
+// (tmux 3.7b on macOS Homebrew); send-keys -l with CR is. (GH#4666)
+func (t *Tmux) sendLiteralCR(target string) error {
+	_, err := t.run("send-keys", "-t", target, "-l", "\r")
+	return err
+}
+
+// sendEnterVerified sends a submit keystroke to a tmux target and verifies it
+// was processed by checking that the pane content changes. Under load, tmux may
+// buffer keystrokes, causing the submit to race with text delivery.
 //
-// After sending Enter, polls the pane content with exponential backoff. If the
-// content hasn't changed (Enter wasn't processed), retries the Enter keystroke.
+// After sending CR, polls the pane content with exponential backoff. If the
+// content hasn't changed (submit wasn't processed), retries the keystroke.
 // Max 3 retries before returning an error.
 //
 // Falls back to best-effort (no verification) if pane capture fails.
@@ -1550,11 +1556,10 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		verifyLines    = 5 // capture last N lines for comparison
 	)
 
-	// Snapshot pane content before Enter so we can detect processing.
+	// Snapshot pane content before submit so we can detect processing.
 	preSnapshot, preErr := t.CapturePane(target, verifyLines)
 
-	// Send Enter
-	if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+	if err := t.sendLiteralCR(target); err != nil {
 		return fmt.Errorf("send Enter: %w", err)
 	}
 
@@ -1574,12 +1579,12 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		}
 
 		if postSnapshot != preSnapshot {
-			// Content changed — Enter was processed.
+			// Content changed — submit was processed.
 			return nil
 		}
 
-		// Content unchanged — Enter may not have been processed. Retry.
-		if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+		// Content unchanged — CR may not have been processed. Retry.
+		if err := t.sendLiteralCR(target); err != nil {
 			return fmt.Errorf("send Enter (retry %d): %w", retry+1, err)
 		}
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -182,6 +182,7 @@ func BuildCommandContext(ctx context.Context, args ...string) *exec.Cmd {
 // Tmux wraps tmux operations.
 type Tmux struct {
 	socketName string // tmux socket name (-L flag), empty = default socket
+	binary     string // optional tmux executable override; empty means "tmux"
 }
 
 // noTownSocket is a sentinel socket name used when no town socket is configured.
@@ -217,6 +218,19 @@ func NewTmuxWithSocket(socket string) *Tmux {
 	return &Tmux{socketName: socket}
 }
 
+// NewTmuxWithSocketAndBinary is like NewTmuxWithSocket but invokes a specific
+// tmux executable. Tests use this to wrap the host tmux without mutating PATH.
+func NewTmuxWithSocketAndBinary(socket, binary string) *Tmux {
+	return &Tmux{socketName: socket, binary: binary}
+}
+
+func (t *Tmux) tmuxBinary() string {
+	if t != nil && t.binary != "" {
+		return t.binary
+	}
+	return "tmux"
+}
+
 // run executes a tmux command and returns stdout.
 // All commands include -u flag for UTF-8 support regardless of locale settings.
 // See: https://github.com/steveyegge/gastown/issues/1219
@@ -230,7 +244,7 @@ func (t *Tmux) commandContext(ctx context.Context, args ...string) *exec.Cmd {
 		allArgs = append(allArgs, "-L", t.socketName)
 	}
 	allArgs = append(allArgs, args...)
-	cmd := exec.CommandContext(ctx, "tmux", allArgs...)
+	cmd := exec.CommandContext(ctx, t.tmuxBinary(), allArgs...)
 	hideConsoleWindow(cmd)
 	return cmd
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -224,13 +224,6 @@ func NewTmuxWithSocketAndBinary(socket, binary string) *Tmux {
 	return &Tmux{socketName: socket, binary: binary}
 }
 
-func (t *Tmux) tmuxBinary() string {
-	if t != nil && t.binary != "" {
-		return t.binary
-	}
-	return "tmux"
-}
-
 // run executes a tmux command and returns stdout.
 // All commands include -u flag for UTF-8 support regardless of locale settings.
 // See: https://github.com/steveyegge/gastown/issues/1219
@@ -244,7 +237,11 @@ func (t *Tmux) commandContext(ctx context.Context, args ...string) *exec.Cmd {
 		allArgs = append(allArgs, "-L", t.socketName)
 	}
 	allArgs = append(allArgs, args...)
-	cmd := exec.CommandContext(ctx, t.tmuxBinary(), allArgs...)
+	binary := "tmux"
+	if t != nil && t.binary != "" {
+		binary = t.binary
+	}
+	cmd := exec.CommandContext(ctx, binary, allArgs...)
 	hideConsoleWindow(cmd)
 	return cmd
 }
@@ -1535,7 +1532,7 @@ func (t *Tmux) dismissRewindMode(target string) {
 // sendLiteralCR submits the current line with a literal carriage return.
 // Named-key Enter/C-m/KPEnter are not delivered on some tmux builds
 // (tmux 3.7b on macOS Homebrew); send-keys -l with CR is. (GH#4666)
-func (t *Tmux) sendLiteralCR(target string) error {
+func sendLiteralCR(t *Tmux, target string) error {
 	_, err := t.run("send-keys", "-t", target, "-l", "\r")
 	return err
 }
@@ -1559,7 +1556,7 @@ func (t *Tmux) sendEnterVerified(target string) error {
 	// Snapshot pane content before submit so we can detect processing.
 	preSnapshot, preErr := t.CapturePane(target, verifyLines)
 
-	if err := t.sendLiteralCR(target); err != nil {
+	if err := sendLiteralCR(t, target); err != nil {
 		return fmt.Errorf("send Enter: %w", err)
 	}
 
@@ -1584,7 +1581,7 @@ func (t *Tmux) sendEnterVerified(target string) error {
 		}
 
 		// Content unchanged — CR may not have been processed. Retry.
-		if err := t.sendLiteralCR(target); err != nil {
+		if err := sendLiteralCR(t, target); err != nil {
 			return fmt.Errorf("send Enter (retry %d): %w", retry+1, err)
 		}
 

--- a/internal/tmux/tmuxtest/helpers.go
+++ b/internal/tmux/tmuxtest/helpers.go
@@ -1,0 +1,65 @@
+// Package tmuxtest holds process-level helpers for tests that wrap a real
+// tmux binary with testdata/tmuxstub.sh.
+package tmuxtest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// RealTmuxOrSkip returns the host tmux path, or skips the test if tmux is missing.
+func RealTmuxOrSkip(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not installed")
+	}
+	return path
+}
+
+// SocketName returns an isolated tmux socket name derived from the test name.
+func SocketName(t *testing.T, prefix string) string {
+	t.Helper()
+	return prefix + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+// StartSession starts a detached tmux session on an isolated socket and kills
+// that server when the test ends.
+func StartSession(t *testing.T, realTmux, socket, sessionName, shellCmd string) {
+	t.Helper()
+	cmd := exec.Command(realTmux, "-u", "-L", socket, "new-session", "-d", "-s", sessionName, "sh", "-c", shellCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tmux new-session: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command(realTmux, "-L", socket, "kill-server").Run()
+	})
+}
+
+// InstallStub copies testdata/tmuxstub.sh to a temp executable named tmux.
+func InstallStub(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src := filepath.Join(filepath.Dir(file), "..", "testdata", "tmuxstub.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read tmux stub: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "tmux")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write tmux stub: %v", err)
+	}
+	return dst
+}
+
+// ShellQuote wraps path in single quotes for a sh -c command string.
+func ShellQuote(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Summary
Fix silent nudge loss on tmux 3.7b by propagating idle-watcher delivery failures and submitting nudges with a literal carriage return instead of named-key `Enter`.

The reporter's `unknown flag -V` / `-o` path is not emitted by current main, but any hard `send-keys` failure on the watcher path was logged and then incorrectly reported as success.

## Related Issue
Fixes #4666

## Changes
- return `NudgeSession` errors from `watchAndDeliver` after requeuing the drained nudge
- propagate wait-idle watcher errors so `gt nudge` cannot print success after failed delivery
- submit nudges with `send-keys -l` and a literal CR
- add a tmux 3.7b stub seam and regressions for rejected flags, watcher failures, and named-key Enter no-ops

## Testing
- [x] Focused tests pass:
  - `go test -count=1 -timeout 30s ./internal/cmd/ -run TestDeliverNudge_WaitIdle_IdleWatcherSendKeysFailure_ReturnsError`
  - `go test -count=1 -timeout 60s ./internal/tmux/ -run TestNudgeSubmit_NamedEnterNoop_LiteralCRRequired`
  - `TestNudgeSendKeys_DoesNotPassUnknown37bFlags`, idle-watcher empty-queue, and submit-verification tests
  - `go vet ./internal/cmd/ ./internal/tmux/`
- [x] Clean upstream-based head: capped Docker `go test -vet=off -p=1 ./internal/cmd ./internal/tmux -count=1`
- [ ] Full `go test ./...`
- [ ] Manual testing on macOS tmux 3.7b / Claude Code TUI

## Checklist
- [x] Code follows project style
- [x] Documentation updated (not applicable)
- [x] No breaking changes

