### PR TITLE
feat: add native OpenCode server workers

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -47,3 +47,11 @@ jobs:
       - name: Vet
         shell: msys2 {0}
         run: go vet ./...
+
+      - name: Windows filesystem and transport tests
+        shell: msys2 {0}
+        run: go test ./internal/atomicfile ./internal/config ./internal/opencodeserver ./internal/opencodestate ./internal/nudge -count=1
+
+      - name: Windows refinery branch cleanup tests
+        shell: msys2 {0}
+        run: go test ./internal/refinery -run '^(TestHandleMRInfoSuccess_VerifiedHeadLeaseDeletesRemoteBranch|TestDoMergeDirectPreservesSubmittedHeadForPostMergeProof|TestHandleMRInfoSuccess_RemoteLeaseFailurePreservesLocalBranch)$' -count=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Native OpenCode server workers** — Added the opt-in `opencode-server`
+  preset, which starts a loopback-only authenticated OpenCode server per worker,
+  persists Gas Town/OpenCode session mappings, resumes same-work sessions, and
+  delivers queued nudges through OpenCode's HTTP API instead of TUI keystrokes.
+  Lifecycle events serialize async turns, per-session locks reject duplicate
+  workers, and credential state is protected with restricted permissions/ACLs.
+
+### Fixed
+
+- **Windows startup and config reliability** - PowerShell exec wrappers now
+  preserve native arguments exactly, including empty and stop-parsing-like
+  values, and atomic config replacement retries transient sharing contention
+  without introducing an unlink window.
+
 ## [1.2.1] - 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -504,7 +504,13 @@ gt feed                     # Real-time activity feed (TUI)
 gt feed --problems          # Start in problems view (stuck agent detection)
 ```
 
-**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`
+**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `opencode-server`, `copilot`, `pi`, `omp`
+
+`opencode-server` is an opt-in OpenCode transport that keeps tmux as the
+process supervisor but sends prompts and nudges through an authenticated,
+worktree-local OpenCode HTTP server. Use it for workers with
+`gt sling <bead-id> <rig> --agent opencode-server`. Set
+`GT_OPENCODE_MODEL=opencode-go/<model>` to pin an OpenCode Go model.
 
 The `kiro` preset launches `kiro-cli chat --trust-all-tools`, supports Kiro's
 documented `--resume` / `--resume-id` session flags, and does not install Kiro

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -533,6 +533,24 @@ Current agent capabilities at a glance:
 | Auggie | No | `--resume` (flag) | No | No | arg | auggie |
 | AMP | No | `threads continue` (subcmd) | No | No | arg | amp |
 | OpenCode | Yes (plugin JS) | No | `run` subcmd | No | none | opencode, node, bun |
+| OpenCode Server | Yes (plugin JS) | Same work key | Native HTTP worker | No | arg | gt, opencode, node, bun |
+
+### Native OpenCode Server Worker
+
+Gas Town also ships the opt-in `opencode-server` preset. It supervises the
+worker in tmux, but readiness, status, startup prompts, and nudges use
+OpenCode's authenticated HTTP API instead of TUI screen scraping and
+`send-keys`. The current adapter is pinned to OpenCode 1.18.16 or newer 1.x and
+fails closed on unsupported API generations.
+
+```bash
+gt sling <bead-id> <rig> --agent opencode-server
+```
+
+Set `GT_OPENCODE_MODEL=provider/model` and optionally
+`GT_OPENCODE_VARIANT=<variant>` to override OpenCode's configured defaults.
+This transport keeps model prose separate from Gas Town completion evidence;
+beads, commits, tests, CI, and merge state remain authoritative.
 
 ---
 
@@ -703,8 +721,11 @@ Create `~/gt/settings/agents.json` (or add to existing):
 ### Step 2: Test basic launch (5 minutes)
 
 ```bash
-# Set your agent as default for a rig
-gt config set agent your-agent --rig <rigname>
+# Set your agent as the town default
+gt config default-agent your-agent
+
+# For one rig, set "agent": "your-agent" in
+# <town>/<rig>/settings/config.json
 
 # Or test with a one-off override
 gt crew start jack --agent your-agent

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -349,40 +349,62 @@ install a plugin file instead of a settings.json.
 Reference: `internal/hooks/templates/opencode/gastown.js`
 
 ```javascript
-export const GasTown = async ({ $, directory }) => {
-  const role = (process.env.GT_ROLE || "").toLowerCase();
-  const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
+export const GasTown = async ({ directory }) => {
+  const gtBin = process.env.GT_BIN || "gt";
+  const primePromises = new Map();
 
-  const run = async (cmd) => {
-    try {
-      await $`/bin/sh -lc ${cmd}`.cwd(directory);
-    } catch (err) {
-      console.error(`[gastown] ${cmd} failed`, err?.message || err);
-    }
+  const run = async (args, env = {}) => {
+    const child = Bun.spawn({
+      cmd: [gtBin, ...args],
+      cwd: directory,
+      env: { ...process.env, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 10_000,
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    if (code !== 0) throw new Error(stderr || `gt exited with code ${code}`);
+    return stdout;
   };
 
-  const injectContext = async () => {
-    await run("gt prime");
-    if (autonomousRoles.has(role)) {
-      await run("gt mail check --inject");
-    }
+  const prime = (source, sessionID) => {
+    const promise = run(["prime", "--hook"], {
+      GT_HOOK_SOURCE: source,
+      GT_SESSION_ID: sessionID,
+    });
+    primePromises.set(sessionID, promise);
+    return promise;
   };
 
   return {
     event: async ({ event }) => {
-      if (event?.type === "session.created") {
-        await injectContext();
+      const sessionID = event?.properties?.sessionID || event?.properties?.info?.id || "";
+      if (event?.type === "session.created" && !primePromises.has(sessionID)) {
+        prime("startup", sessionID);
       }
-      if (event?.type === "session.compacted") {
-        await injectContext();
-      }
+      if (event?.type === "session.compacted") prime("compact", sessionID);
+      if (event?.type === "session.deleted") primePromises.delete(sessionID);
+    },
+    "experimental.chat.system.transform": async (input, output) => {
+      const sessionID = input?.sessionID || "";
+      const context = await (primePromises.get(sessionID) || prime("startup", sessionID));
+      if (context) output.system.push(context);
     },
   };
 };
 ```
 
-The key commands are the same (`gt prime`, `gt mail check --inject`). The
-delivery mechanism adapts to the agent's plugin API.
+Pass commands as an argv array instead of invoking `/bin/sh`; this keeps the
+plugin portable to Windows and avoids shell interpolation. `gt prime --hook`
+handles startup context and role-appropriate mail injection.
+
+Do not pass an OpenCode `ses_*` ID to `gt costs record --session`; that command
+currently records Claude transcript costs for a Gas Town tmux session. OpenCode
+cost telemetry needs a dedicated adapter.
 
 ### Pattern C: Informational hooks (instructions file)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -461,7 +461,7 @@ gt config agent remove <name>     # Remove custom agent (built-ins protected)
 gt config default-agent [name]    # Get or set town default agent
 ```
 
-**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `opencode-server`, `copilot`
 
 The `kiro` preset launches `kiro-cli chat --trust-all-tools` and uses Kiro's
 documented `--resume` / `--resume-id` session flags. Gas Town does not install
@@ -547,6 +547,28 @@ For OpenCode autonomous mode, set env var in your shell profile:
 ```bash
 export OPENCODE_PERMISSION='{"*":"allow"}'
 ```
+
+**Native OpenCode worker transport**:
+```bash
+# One worker
+gt sling <bead-id> <rig> --agent opencode-server
+
+# Or make it the town default
+gt config default-agent opencode-server
+
+# For one rig, set "agent": "opencode-server" in
+# <town>/<rig>/settings/config.json
+
+# Optional OpenCode Go model selection
+export GT_OPENCODE_MODEL="opencode-go/grok-4.5"
+export GT_OPENCODE_VARIANT="high"
+```
+
+The `opencode-server` preset starts a loopback-only, Basic-authenticated
+OpenCode server per worker and routes Gas Town nudges through the server API.
+Its runtime mapping is stored with credentials under
+`<town>/.runtime/opencode-server/`. The existing `opencode` preset remains the
+interactive TUI integration.
 
 ### Rig Management
 

--- a/docs/superpowers/plans/2026-08-13-opencode-server-worker.md
+++ b/docs/superpowers/plans/2026-08-13-opencode-server-worker.md
@@ -1,0 +1,23 @@
+# OpenCode Server Worker Implementation Plan
+
+1. Add failing tests for the authenticated, directory-scoped OpenCode client,
+   bounded errors, session status, async prompts, and abort.
+2. Add failing tests for crash-safe state mappings and active-server checks.
+3. Add failing process tests for launch arguments, random authentication,
+   health readiness, version gating, early exit, and idempotent shutdown.
+4. Add failing delivery tests proving queued nudges remain queued while busy,
+   are submitted once when idle, and are requeued on HTTP failure.
+5. Implement `internal/opencodeserver` with client, process, state, and worker
+   components.
+6. Add the hidden `gt opencode-worker` entry point and the opt-in
+   `opencode-server` preset.
+7. Route active server-backed sessions to queue delivery and suppress the tmux
+   nudge poller for runtimes that manage their own nudge transport.
+8. Document activation and model overrides; update the changelog.
+9. Run focused tests, the real OpenCode no-model integration smoke test, then
+   the repository test suite and vet.
+10. Harden async delivery with a pre-prompt SSE subscription and an exclusive
+    per-session worker lock; prove stale idle status cannot admit a second turn.
+11. Route sling and nudge traffic outside tmux, stop stale generic pollers,
+    preserve effective agents across lifecycle restarts, and protect Windows
+    credentials with explicit ACLs.

--- a/docs/superpowers/specs/2026-08-13-opencode-server-worker.md
+++ b/docs/superpowers/specs/2026-08-13-opencode-server-worker.md
@@ -1,0 +1,94 @@
+# OpenCode Server Worker Specification
+
+## Objective
+
+Add an opt-in Gas Town worker transport that controls OpenCode through its
+headless HTTP server instead of typing into the OpenCode TUI. Tmux remains the
+process supervisor so existing Gas Town lifecycle and cleanup code continues to
+work.
+
+The existing `opencode` preset remains unchanged. The new preset is named
+`opencode-server`.
+
+## Pinned Contract
+
+This first implementation targets OpenCode 1.18.16 and uses its legacy HTTP
+surface, which is present and verified in that release:
+
+- `GET /global/health`
+- `POST /session`
+- `GET /session/status`
+- `POST /session/:id/prompt_async`
+- `POST /session/:id/abort`
+- `GET /event`
+
+Every instance-scoped request sends `X-OpenCode-Directory` with the worker
+worktree. Every request uses HTTP Basic authentication. The server listens only
+on `127.0.0.1` and receives a random per-process password through
+`OPENCODE_SERVER_PASSWORD`.
+
+The adapter accepts OpenCode 1.x versions at or above 1.18.16. Other major
+versions fail closed until their API is verified.
+
+## Lifecycle
+
+1. Gas Town starts `gt opencode-worker <startup-prompt>` in the worker's tmux
+   pane.
+2. The worker starts `opencode serve` on an available loopback port and waits
+   for a successful health response.
+3. The worker acquires an exclusive per-Gas-Town-session lock, then creates or
+   resumes one OpenCode session scoped to the worktree.
+4. It atomically records the mapping under
+   `<town>/.runtime/opencode-server/` with mode `0600`.
+5. It snapshots the session status, then subscribes to lifecycle events before
+   submitting the startup prompt asynchronously. A turn remains locally in
+   flight until `session.status` reports busy and `session.idle` completes that
+   transition. A `session.error` or idempotently recovered prompt requires two
+   consistent idle snapshots before another prompt is admitted, so an
+   immediately stale idle status cannot clear the turn.
+6. It watches the Gas Town nudge queue. When OpenCode is idle, queued nudges are
+   durably claimed and submitted through `prompt_async`. Claims are removed only
+   after acceptance and released on failure. A stable OpenCode message ID lets a
+   retry recognize an already accepted prompt without submitting it twice.
+7. On shutdown it aborts an active turn and stops the server process tree. The
+   server is also attached to an OS parent-death guard so abrupt tmux teardown
+   cannot leave the transport running. The mapping remains so a restart on the
+   same branch can resume the OpenCode
+   session; a new branch replaces the mapping with a fresh session.
+
+The lock is the ownership signal for structured routing. A healthy server with
+an unlocked mapping is stale and must not receive Gas Town nudges. On Windows,
+the mapping directory, lock, and credential-bearing state file use protected
+ACLs limited to the current user and Local System.
+
+The mapping records the Gas Town session, OpenCode session, branch/work key, worktree, loopback
+URL, server PID, credentials, version, and creation time. Credentials never
+appear in command arguments or logs.
+
+## Configuration
+
+The built-in `opencode-server` preset uses the OpenCode `build` agent and the
+user's configured default model. Operators may override:
+
+- `GT_OPENCODE_COMMAND`: OpenCode executable, default `opencode`
+- `GT_OPENCODE_AGENT`: OpenCode agent, default `build`
+- `GT_OPENCODE_MODEL`: model in `provider/model` form
+- `GT_OPENCODE_VARIANT`: provider-specific model variant
+
+OpenCode plugins remain enabled so the existing Gas Town plugin injects
+`gt prime --hook` into the system prompt.
+
+## Completion Semantics
+
+HTTP `204` from `prompt_async` means accepted, not completed. The worker keeps
+the transport busy until `/session/status` returns idle after the submitted
+turn. Gas Town still decides task completion from beads, commits, tests, CI,
+and merge evidence; model prose is never completion evidence.
+
+## Non-Goals
+
+- Replacing tmux as Gas Town's process supervisor
+- Changing the existing OpenCode TUI preset
+- Generalizing Gas Town's attached-Mayor ACP proxy to all workers
+- Encoding scheduling or completion decisions in the transport
+- Supporting remote or non-loopback OpenCode servers in this first slice

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -81,7 +81,7 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := replaceFile(tmpName, path); err != nil {
 		os.Remove(tmpName)
 		return err
 	}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -212,17 +212,23 @@ func TestWriteFileConcurrent(t *testing.T) {
 
 	const numWriters = 10
 	var wg sync.WaitGroup
+	errs := make([]error, numWriters)
 	wg.Add(numWriters)
 
 	for i := 0; i < numWriters; i++ {
 		go func(n int) {
 			defer wg.Done()
 			data := []byte(string(rune('A' + n)))
-			_ = WriteFile(testFile, data, 0644)
+			errs[n] = WriteFile(testFile, data, 0644)
 		}(i)
 	}
 
 	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d: %v", i, err)
+		}
+	}
 
 	content, err := os.ReadFile(testFile)
 	if err != nil {
@@ -494,15 +500,10 @@ func TestWriteFileConcurrentIntegrity(t *testing.T) {
 
 	wg.Wait()
 
-	anySuccess := false
-	for _, err := range errs {
-		if err == nil {
-			anySuccess = true
-			break
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d: %v", i, err)
 		}
-	}
-	if !anySuccess {
-		t.Fatal("All concurrent writes failed")
 	}
 
 	content, err := os.ReadFile(testFile)

--- a/internal/atomicfile/atomicfile_windows_test.go
+++ b/internal/atomicfile/atomicfile_windows_test.go
@@ -1,0 +1,149 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReplaceFileRetriesSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old")
+	newPath := filepath.Join(dir, "new")
+	if err := os.WriteFile(oldPath, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	attempts := 0
+	err := replaceFileWith(oldPath, newPath, func(oldPath, newPath string) error {
+		attempts++
+		if attempts == 1 {
+			return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: syscall.Errno(32)}
+		}
+		return os.Rename(oldPath, newPath)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("rename attempts = %d, want 2", attempts)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("replacement content = %q", data)
+	}
+}
+
+func TestWriteFileRetriesOpenDestination(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := WriteFile(path, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	openFile, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	writeResult := make(chan error, 1)
+	go func() {
+		close(started)
+		writeResult <- WriteFile(path, []byte("new"), 0644)
+	}()
+	<-started
+
+	// Wait until the writer has created its temp file. If replacement fails
+	// immediately instead of retrying, writeResult reports that error here.
+	attemptDeadline := time.Now().Add(time.Second)
+	completed := false
+	for {
+		select {
+		case err := <-writeResult:
+			if err != nil {
+				t.Fatalf("replacement did not retry sharing contention: %v", err)
+			}
+			completed = true
+		default:
+		}
+		if completed {
+			break
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		attempted := false
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "config.json.tmp.") {
+				attempted = true
+				break
+			}
+		}
+		if attempted {
+			select {
+			case err := <-writeResult:
+				if err != nil {
+					t.Fatalf("replacement did not retry sharing contention: %v", err)
+				}
+				completed = true
+			case <-time.After(50 * time.Millisecond):
+				// The destination is still open, so a sharing failure should be
+				// held inside the retry loop rather than returned to the caller.
+			}
+			break
+		}
+		if time.Now().After(attemptDeadline) {
+			t.Fatal("writer did not attempt atomic replacement")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	oldData, err := io.ReadAll(openFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(oldData) != "old" {
+		t.Fatalf("open handle read %q, want old content", oldData)
+	}
+	if err := openFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !completed {
+		select {
+		case err := <-writeResult:
+			if err != nil {
+				t.Fatalf("replace destination after reader closed: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("replacement did not complete after reader closed")
+		}
+	}
+	newData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(newData) != "new" {
+		t.Fatalf("new handle read %q, want new content", newData)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "config.json" {
+		t.Fatalf("unexpected files after replacement: %v", entries)
+	}
+}

--- a/internal/atomicfile/rename_nonwindows.go
+++ b/internal/atomicfile/rename_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+func replaceFile(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}

--- a/internal/atomicfile/rename_windows.go
+++ b/internal/atomicfile/rename_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Windows readers commonly omit delete sharing, so replacement can fail until
+// their short-lived handles close. Stripes prevent same-path writers from
+// starving one another while bounded retries preserve atomic rename semantics.
+var windowsRenameLocks [64]sync.Mutex
+
+func replaceFile(oldPath, newPath string) error {
+	lock := windowsRenameLock(newPath)
+	lock.Lock()
+	defer lock.Unlock()
+	return replaceFileWith(oldPath, newPath, os.Rename)
+}
+
+func replaceFileWith(oldPath, newPath string, rename func(string, string) error) error {
+	deadline := time.Now().Add(2 * time.Second)
+	delay := time.Millisecond
+	for {
+		err := rename(oldPath, newPath)
+		if err == nil || !windowsRenameContention(err) || time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(delay)
+		if delay < 25*time.Millisecond {
+			delay *= 2
+		}
+	}
+}
+
+func windowsRenameLock(path string) *sync.Mutex {
+	const offset32 = uint32(2166136261)
+	const prime32 = uint32(16777619)
+	hash := offset32
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		hash ^= uint32(c)
+		hash *= prime32
+	}
+	return &windowsRenameLocks[hash%uint32(len(windowsRenameLocks))]
+}
+
+func windowsRenameContention(err error) bool {
+	const (
+		errorSharingViolation syscall.Errno = 32
+		errorLockViolation    syscall.Errno = 33
+	)
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, errorSharingViolation) ||
+		errors.Is(err, errorLockViolation)
+}

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -518,7 +518,15 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	}
 
 	// Ensure runtime settings exist (autonomous role needs mail in SessionStart)
-	runtimeConfig := config.ResolveRoleAgentConfig("deacon", townRoot, deaconDir)
+	var runtimeConfig *config.RuntimeConfig
+	if agentOverride != "" {
+		runtimeConfig, _, err = config.ResolveAgentConfigWithOverride(townRoot, "", agentOverride)
+		if err != nil {
+			return fmt.Errorf("resolving deacon agent %s: %w", agentOverride, err)
+		}
+	} else {
+		runtimeConfig = config.ResolveRoleAgentConfig("deacon", townRoot, "")
+	}
 	if err := runtime.EnsureSettingsForRole(deaconDir, deaconDir, "deacon", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
@@ -548,7 +556,9 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 		TownRoot:         townRoot,
 		RuntimeConfigDir: runtimeConfigDir,
 		Agent:            agentOverride,
+		SessionName:      sessionName,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 
 	// Create session with command and env vars via -e flags so the initial
 	// shell (and subprocesses Claude spawns) inherit them from the start.
@@ -578,15 +588,19 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 
 	time.Sleep(constants.ShutdownNotifyDelay)
 
-	deaconTownRoot, _ := workspace.FindFromCwdOrError()
-	runtimeCfg := config.ResolveRoleAgentConfig("deacon", deaconTownRoot, "")
-	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeCfg)
-	startDeaconNudgePoller(townRoot, sessionName)
+	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeConfig)
+	startDeaconNudgePoller(townRoot, sessionName, runtimeConfig)
 
 	return nil
 }
 
-func startDeaconNudgePoller(townRoot, sessionName string) {
+func startDeaconNudgePoller(townRoot, sessionName string, runtimeConfig *config.RuntimeConfig) {
+	if runtimeConfig != nil && runtimeConfig.ManagesNudgeQueue {
+		if pollerErr := nudge.StopPoller(townRoot, sessionName); pollerErr != nil {
+			style.PrintWarning("could not stop stale nudge poller for %s: %v", sessionName, pollerErr)
+		}
+		return
+	}
 	if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
 		style.PrintWarning("could not start nudge poller for %s: %v", sessionName, pollerErr)
 	}
@@ -900,6 +914,15 @@ func runDeaconHealthCheck(cmd *cobra.Command, args []string) error {
 	}
 	if !exists {
 		fmt.Printf("%s Agent %s session not running\n", style.Dim.Render("○"), agent)
+		return nil
+	}
+	if hasActiveOpenCodeServerSession(townRoot, sessionName) {
+		agentState.RecordPing()
+		agentState.RecordResponse()
+		if err := deacon.SaveHealthCheckState(townRoot, state); err != nil {
+			style.PrintWarning("failed to save health check state: %v", err)
+		}
+		fmt.Printf("%s Agent %s OpenCode transport is healthy (failures reset to 0)\n", style.Bold.Render("✓"), agent)
 		return nil
 	}
 

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -247,8 +247,15 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	buildOpts := buildRestartCommandOpts{}
+	var targetEnvironment map[string]string
+	if targetSession != currentSession {
+		targetEnvironment = handoffSessionEnvironment(townTmux, targetSession)
+		buildOpts.Environment = targetEnvironment
+	}
+
 	// Build the restart command
-	restartCmd, err := buildRestartCommand(targetSession)
+	restartCmd, err := buildRestartCommandWithOpts(targetSession, buildOpts)
 	if err != nil {
 		return err
 	}
@@ -257,7 +264,9 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 	// Remote sessions live on the town socket, so use townTmux for their operations.
 	if targetSession != currentSession {
 		// Update tmux session env before respawn (not during dry-run — see below)
-		updateSessionEnvForHandoff(townTmux, targetSession, "")
+		if targetAgent := targetEnvironment["GT_AGENT"]; !handoffDryRun && targetAgent != "" {
+			updateSessionEnvForHandoff(townTmux, targetSession, targetAgent)
+		}
 		return handoffRemoteSession(townTmux, targetSession, restartCmd)
 	}
 
@@ -786,6 +795,9 @@ type buildRestartCommandOpts struct {
 	// ContinueSession is true. If empty, falls back to a generic
 	// continuation message.
 	ContinuePrompt string
+	// Environment, when non-nil, is the target session's environment. Remote
+	// handoffs must never inherit runtime selection from the caller process.
+	Environment map[string]string
 }
 
 func buildRestartCommand(sessionName string) (string, error) {
@@ -859,8 +871,8 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 	// If so, preserve it across handoff by using the override variant.
 	// Fall back to tmux session environment if process env doesn't have it,
 	// since exec env vars may not propagate through all agent runtimes.
-	currentAgent, agentInEnv := os.LookupEnv("GT_AGENT")
-	if !agentInEnv {
+	currentAgent, agentInEnv := restartEnvironmentValue(opts, "GT_AGENT")
+	if !agentInEnv && opts.Environment == nil {
 		// GT_AGENT not in process env at all — try tmux session environment
 		// as fallback, since exec env vars may not propagate through all runtimes.
 		t := tmux.NewTmux()
@@ -887,12 +899,7 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 	// Note: runtimeCmd starts with the command name (e.g., "claude --settings ..."),
 	// not "exec claude" — the "exec" prefix is added later in the Sprintf.
 	if opts.ContinueSession {
-		// Handle both Unix ("claude ") and Windows ("claude.exe ") binary names
-		if n := strings.Replace(runtimeCmd, "claude.exe ", "claude.exe --continue ", 1); n != runtimeCmd {
-			runtimeCmd = n
-		} else {
-			runtimeCmd = strings.Replace(runtimeCmd, "claude ", "claude --continue ", 1)
-		}
+		runtimeCmd = addClaudeContinueFlag(runtimeCmd)
 	}
 
 	// Build environment variables map — role vars first, then Claude vars.
@@ -929,17 +936,23 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 	// Propagate GT_ROOT so subsequent handoffs can use it as fallback
 	// when cwd-based detection fails (broken state recovery)
 	envMap["GT_ROOT"] = townRoot
+	// Structured runtimes identify their durable transport by the tmux session
+	// name. Preserve it across respawn-pane handoffs.
+	envMap["GT_SESSION"] = sessionName
 
 	// Preserve GT_AGENT across handoff so agent override persists
 	if currentAgent != "" {
 		envMap["GT_AGENT"] = currentAgent
+	}
+	if workKey := resolveOpenCodeWorkKey(workDir, ""); workKey != "" {
+		envMap["GT_BRANCH"] = workKey
 	}
 
 	// Preserve GT_PROCESS_NAMES across handoff for accurate liveness detection.
 	// Without this, custom agents that shadow built-in presets (e.g., custom
 	// "codex" running "opencode") would revert to GT_AGENT-based lookup after
 	// handoff, causing false liveness failures.
-	if processNames := os.Getenv("GT_PROCESS_NAMES"); processNames != "" {
+	if processNames, _ := restartEnvironmentValue(opts, "GT_PROCESS_NAMES"); processNames != "" {
 		envMap["GT_PROCESS_NAMES"] = processNames
 	} else if currentAgent != "" {
 		resolved := config.ResolveProcessNames(currentAgent, "")
@@ -948,8 +961,13 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 
 	// Add Claude-related env vars from current environment
 	for _, name := range claudeEnvVars {
-		if val := os.Getenv(name); val != "" {
+		if val, _ := restartEnvironmentValue(opts, name); val != "" {
 			envMap[name] = val
+		}
+	}
+	for _, name := range config.OpenCodeOverrideEnvVars {
+		if value, ok := restartEnvironmentValue(opts, name); ok {
+			envMap[name] = value
 		}
 	}
 
@@ -991,6 +1009,51 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 
 	envCmd := config.PrependEnv(execPrefix+runtimeCmd, envMap)
 	return cdPrefix + envCmd, nil
+}
+
+func restartEnvironmentValue(opts buildRestartCommandOpts, name string) (string, bool) {
+	if opts.Environment != nil {
+		value, ok := opts.Environment[name]
+		return value, ok
+	}
+	return os.LookupEnv(name)
+}
+
+func handoffSessionEnvironment(t *tmux.Tmux, sessionName string) map[string]string {
+	names := append([]string{"GT_AGENT", "GT_PROCESS_NAMES"}, claudeEnvVars...)
+	names = append(names, config.OpenCodeOverrideEnvVars...)
+	environment := make(map[string]string)
+	for _, name := range names {
+		if value, err := t.GetEnvironment(sessionName, name); err == nil {
+			environment[name] = value
+		}
+	}
+	return environment
+}
+
+func addClaudeContinueFlag(command string) string {
+	lower := strings.ToLower(command)
+	for _, name := range []string{"claude.exe", "claude.cmd", "claude"} {
+		searchFrom := 0
+		for {
+			relative := strings.Index(lower[searchFrom:], name)
+			if relative < 0 {
+				break
+			}
+			start := searchFrom + relative
+			end := start + len(name)
+			beforeOK := start == 0 || strings.ContainsRune(" \\/'\"", rune(command[start-1]))
+			afterOK := end == len(command) || strings.ContainsRune(" '\"", rune(command[end]))
+			if beforeOK && afterOK {
+				if end < len(command) && (command[end] == '\'' || command[end] == '"') {
+					end++
+				}
+				return command[:end] + " --continue" + command[end:]
+			}
+			searchFrom = end
+		}
+	}
+	return command
 }
 
 // updateSessionEnvForHandoff updates the tmux session environment with the
@@ -1100,6 +1163,11 @@ func sessionWorkDir(sessionName, townRoot string) (string, error) {
 		case session.RoleRefinery:
 			return fmt.Sprintf("%s/%s/refinery/rig", townRoot, identity.Rig), nil
 		case session.RolePolecat:
+			parent := filepath.Join(townRoot, identity.Rig, "polecats", identity.Name)
+			nested := filepath.Join(parent, identity.Rig)
+			if info, statErr := os.Stat(nested); statErr == nil && info.IsDir() {
+				return nested, nil
+			}
 			return fmt.Sprintf("%s/%s/polecats/%s", townRoot, identity.Rig, identity.Name), nil
 		case session.RoleDog:
 			return fmt.Sprintf("%s/deacon/dogs/%s", townRoot, identity.Name), nil

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -266,9 +266,126 @@ func TestBuildRestartCommand_MergesAgentPresetEnv(t *testing.T) {
 	}
 }
 
+func TestBuildRestartCommandPreservesGasTownSession(t *testing.T) {
+	setupHandoffTestRegistry(t)
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	crewDir := filepath.Join(rigPath, "crew", "alice")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"gastown"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(crewDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runOpenCodeGit(t, crewDir, "init")
+	runOpenCodeGit(t, crewDir, "config", "user.email", "test@example.com")
+	runOpenCodeGit(t, crewDir, "config", "user.name", "Gas Town Test")
+	if err := os.WriteFile(filepath.Join(crewDir, "README.md"), []byte("test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runOpenCodeGit(t, crewDir, "add", "README.md")
+	runOpenCodeGit(t, crewDir, "commit", "-m", "initial")
+	runOpenCodeGit(t, crewDir, "checkout", "-b", "feature/handoff")
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), config.NewTownSettings()); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), config.NewRigSettings()); err != nil {
+		t.Fatal(err)
+	}
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+	if err := os.Chdir(crewDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GT_ROOT", townRoot)
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+	t.Setenv("GT_AGENT", string(config.AgentOpenCodeServer))
+	t.Setenv("GT_OPENCODE_COMMAND", "custom-opencode")
+	t.Setenv("GT_OPENCODE_AGENT", "review")
+	t.Setenv("GT_OPENCODE_MODEL", "provider/model")
+	t.Setenv("GT_OPENCODE_VARIANT", "high")
+
+	command, err := buildRestartCommand("gt-crew-alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "GT_SESSION") || !strings.Contains(command, "gt-crew-alice") {
+		t.Fatalf("restart command lost Gas Town session: %q", command)
+	}
+	if !strings.Contains(command, "GT_BRANCH") || !strings.Contains(command, "feature/handoff") {
+		t.Fatalf("restart command lost work key: %q", command)
+	}
+	for _, value := range []string{"custom-opencode", "review", "provider/model", "high"} {
+		if !strings.Contains(command, value) {
+			t.Fatalf("restart command lost OpenCode override %q: %q", value, command)
+		}
+	}
+
+	runOpenCodeGit(t, crewDir, "checkout", "--detach")
+	revisionCmd := exec.Command("git", "-C", crewDir, "rev-parse", "HEAD")
+	revisionBytes, err := revisionCmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision := strings.TrimSpace(string(revisionBytes))
+	command, err = buildRestartCommand("gt-crew-alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "GT_BRANCH") || !strings.Contains(command, revision) {
+		t.Fatalf("detached handoff did not use commit SHA %q: %q", revision, command)
+	}
+
+	t.Setenv("GT_AGENT", "claude")
+	t.Setenv("GT_PROCESS_NAMES", "caller-process")
+	t.Setenv("GT_OPENCODE_MODEL", "caller/model")
+	command, err = buildRestartCommandWithOpts("gt-crew-alice", buildRestartCommandOpts{Environment: map[string]string{
+		"GT_AGENT":          string(config.AgentOpenCodeServer),
+		"GT_PROCESS_NAMES":  "target-process",
+		"GT_OPENCODE_MODEL": "target/model",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{string(config.AgentOpenCodeServer), "target-process", "target/model"} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("remote restart lost target value %q: %q", want, command)
+		}
+	}
+	for _, unwanted := range []string{"caller-process", "caller/model"} {
+		if strings.Contains(command, unwanted) {
+			t.Fatalf("remote restart leaked caller value %q: %q", unwanted, command)
+		}
+	}
+}
+
+func TestSessionWorkDirUsesNestedPolecatWorktree(t *testing.T) {
+	setupHandoffTestRegistry(t)
+	townRoot := t.TempDir()
+	want := filepath.Join(townRoot, "gastown", "polecats", "furiosa", "gastown")
+	if err := os.MkdirAll(want, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := sessionWorkDir("gt-furiosa", townRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("sessionWorkDir = %q, want %q", got, want)
+	}
+}
+
 func TestBuildRestartCommand_ClearsBDTargetSelectors(t *testing.T) {
 	setupHandoffTestRegistry(t)
 
+	townRoot := t.TempDir()
 	origCwd, _ := os.Getwd()
 	origGTAgent := os.Getenv("GT_AGENT")
 	origTownRoot := os.Getenv("GT_TOWN_ROOT")
@@ -280,7 +397,6 @@ func TestBuildRestartCommand_ClearsBDTargetSelectors(t *testing.T) {
 		_ = os.Setenv("GT_ROOT", origRoot)
 	})
 
-	townRoot := t.TempDir()
 	rigPath := filepath.Join(townRoot, "gastown")
 	witnessDir := filepath.Join(rigPath, "witness")
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
@@ -339,9 +455,9 @@ func TestBuildRestartCommand_ClearsBDTargetSelectors(t *testing.T) {
 			t.Fatalf("restart command leaked stale bd selector value %q: %q", stale, cmd)
 		}
 	}
-	for _, want := range []string{"GT_DOLT_PORT=1555", "GT_DOLT_HOST=agent-host"} {
-		if !strings.Contains(cmd, want) {
-			t.Fatalf("restart command missing preserved connection env %q: %q", want, cmd)
+	for key, value := range map[string]string{"GT_DOLT_PORT": "1555", "GT_DOLT_HOST": "agent-host"} {
+		if !strings.Contains(cmd, key) || !strings.Contains(cmd, value) {
+			t.Fatalf("restart command missing preserved connection env %s=%s: %q", key, value, cmd)
 		}
 	}
 }

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/mayor"
 	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/opencodeserver"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
@@ -35,6 +37,40 @@ func hasACPSessionByName(townRoot, sessionName string) bool {
 	}
 
 	return false
+}
+
+func hasOpenCodeServerSession(townRoot, sessionName string) bool {
+	if townRoot == "" || sessionName == "" {
+		return false
+	}
+	t := tmux.NewTmux()
+	if agent, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agent != "" {
+		rigPath := ""
+		if rigName, rigErr := t.GetEnvironment(sessionName, "GT_RIG"); rigErr == nil && rigName != "" {
+			rigPath = filepath.Join(townRoot, rigName)
+		}
+		if config.AgentManagesNudgeQueue(townRoot, rigPath, agent) {
+			return true
+		}
+	}
+	return hasActiveOpenCodeServerSession(townRoot, sessionName)
+}
+
+func hasActiveOpenCodeServerSession(townRoot, sessionName string) bool {
+	if townRoot == "" || sessionName == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, active := opencodeserver.ActiveState(ctx, townRoot, sessionName)
+	return active
+}
+
+func nudgeDeliveryMode(townRoot, sessionName, requested string) string {
+	if hasACPSessionByName(townRoot, sessionName) || hasOpenCodeServerSession(townRoot, sessionName) {
+		return NudgeModeQueue
+	}
+	return requested
 }
 
 var (
@@ -171,13 +207,15 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 	}
 
 	townRoot, _ := workspace.FindFromCwd()
+	if townRoot == "" {
+		if envRoot, envErr := t.GetEnvironment(sessionName, "GT_ROOT"); envErr == nil {
+			townRoot = envRoot
+		}
+	}
 
 	// Use the requested mode, but force queue mode for ACP sessions.
 	// ACP agents don't have tmux panes to send-keys to.
-	mode := nudgeModeFlag
-	if hasACPSessionByName(townRoot, sessionName) {
-		mode = NudgeModeQueue
-	}
+	mode := nudgeDeliveryMode(townRoot, sessionName, nudgeModeFlag)
 
 	// For direct tmux delivery, prefix with sender attribution.
 	// Queue-based delivery stores Sender as a separate field and

--- a/internal/cmd/nudge_opencode_test.go
+++ b/internal/cmd/nudge_opencode_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/opencodeserver"
+)
+
+func TestNudgeDeliveryModeUsesQueueForOpenCodeServer(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, _ := r.BasicAuth()
+		if user != "opencode" || pass != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(opencodeserver.Health{Healthy: true, Version: "1.18.16"})
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	sessionName := "gt-rig-worker"
+	if err := opencodeserver.SaveState(townRoot, opencodeserver.State{
+		GasTownSession:  sessionName,
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release, err := opencodeserver.AcquireSessionLock(townRoot, sessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if got := nudgeDeliveryMode(townRoot, sessionName, NudgeModeImmediate); got != NudgeModeQueue {
+		t.Fatalf("nudgeDeliveryMode = %q, want %q", got, NudgeModeQueue)
+	}
+}
+
+func TestInjectStartPromptQueuesForOpenCodeServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(opencodeserver.Health{Healthy: true, Version: "1.18.16"})
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	sessionName := "gt-rig-worker"
+	if err := opencodeserver.SaveState(townRoot, opencodeserver.State{
+		GasTownSession:  sessionName,
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release, err := opencodeserver.AcquireSessionLock(townRoot, sessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if err := injectStartPrompt(townRoot, sessionName+":0.0", "gt-123", "Fix race", "urgent"); err != nil {
+		t.Fatal(err)
+	}
+	queueDir := filepath.Join(townRoot, ".runtime", "nudge_queue", sessionName)
+	entries, err := os.ReadDir(queueDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("queued files = %d, want 1", len(entries))
+	}
+}
+
+func TestResolveSessionFromPaneRejectsEmptyTarget(t *testing.T) {
+	if _, err := resolveSessionFromPane(""); err == nil {
+		t.Fatal("resolveSessionFromPane accepted an empty pane target")
+	}
+}

--- a/internal/cmd/nudge_poller.go
+++ b/internal/cmd/nudge_poller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -69,6 +70,9 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 	if exists, _ := t.HasSession(sessionName); !exists {
 		return fmt.Errorf("session %q not found", sessionName)
 	}
+	if hasOpenCodeServerSession(townRoot, sessionName) {
+		return nil
+	}
 
 	// Resolve nudge options once at startup: if the target agent uses Escape
 	// as cancel (e.g., Gemini CLI), skip the Escape keystroke during delivery
@@ -78,6 +82,13 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 	hasPromptDetection := false
 	if name, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && name != "" {
 		agentName = name
+		rigPath := ""
+		if rigName, rigErr := t.GetEnvironment(sessionName, "GT_RIG"); rigErr == nil && rigName != "" {
+			rigPath = filepath.Join(townRoot, rigName)
+		}
+		if config.AgentManagesNudgeQueue(townRoot, rigPath, agentName) {
+			return nil
+		}
 		if preset := config.GetAgentPresetByName(agentName); preset != nil {
 			hasPromptDetection = preset.ReadyPromptPrefix != ""
 			if preset.EscapeCancelsRequest {
@@ -102,6 +113,9 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 			// Check if session still exists.
 			if exists, _ := t.HasSession(sessionName); !exists {
 				return nil // session gone, exit
+			}
+			if hasOpenCodeServerSession(townRoot, sessionName) {
+				return nil
 			}
 
 			// Check if there are queued nudges.

--- a/internal/cmd/opencode_worker.go
+++ b/internal/cmd/opencode_worker.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	gtgit "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/opencodeserver"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+func init() {
+	rootCmd.AddCommand(openCodeWorkerCmd)
+}
+
+var openCodeWorkerCmd = &cobra.Command{
+	Use:    "opencode-worker [startup-prompt]",
+	Short:  "Run an OpenCode HTTP worker",
+	Hidden: true,
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   runOpenCodeWorker,
+}
+
+func runOpenCodeWorker(cmd *cobra.Command, args []string) error {
+	townRoot := os.Getenv("GT_ROOT")
+	if townRoot == "" {
+		var err error
+		townRoot, err = workspace.FindFromCwdOrError()
+		if err != nil {
+			return fmt.Errorf("finding Gas Town root: %w", err)
+		}
+	}
+	gasTownSession := os.Getenv("GT_SESSION")
+	if gasTownSession == "" {
+		return fmt.Errorf("GT_SESSION is required for an OpenCode server worker")
+	}
+	directory, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("finding OpenCode worker directory: %w", err)
+	}
+
+	startupPrompt := ""
+	if len(args) == 1 {
+		startupPrompt = args[0]
+	}
+	openCodeCommand := strings.TrimSpace(os.Getenv("GT_OPENCODE_COMMAND"))
+	if openCodeCommand == "" {
+		openCodeCommand = "opencode"
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return opencodeserver.RunWorker(ctx, opencodeserver.WorkerOptions{
+		TownRoot:       townRoot,
+		GasTownSession: gasTownSession,
+		Directory:      directory,
+		Command:        openCodeCommand,
+		StartupPrompt:  startupPrompt,
+		Agent:          strings.TrimSpace(os.Getenv("GT_OPENCODE_AGENT")),
+		Model:          strings.TrimSpace(os.Getenv("GT_OPENCODE_MODEL")),
+		Variant:        strings.TrimSpace(os.Getenv("GT_OPENCODE_VARIANT")),
+		WorkKey:        resolveOpenCodeWorkKey(directory, os.Getenv("GT_BRANCH")),
+	})
+}
+
+func resolveOpenCodeWorkKey(directory, configured string) string {
+	if configured = strings.TrimSpace(configured); configured != "" && configured != "HEAD" {
+		return configured
+	}
+	git := gtgit.NewGit(directory)
+	workKey, err := git.WorkKey()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(workKey)
+}

--- a/internal/cmd/opencode_worker_test.go
+++ b/internal/cmd/opencode_worker_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveOpenCodeWorkKey(t *testing.T) {
+	t.Run("configured key wins", func(t *testing.T) {
+		if got := resolveOpenCodeWorkKey(t.TempDir(), " explicit-branch "); got != "explicit-branch" {
+			t.Fatalf("resolveOpenCodeWorkKey = %q, want explicit-branch", got)
+		}
+	})
+
+	t.Run("derives current branch", func(t *testing.T) {
+		dir := t.TempDir()
+		runOpenCodeGit(t, dir, "init")
+		runOpenCodeGit(t, dir, "config", "user.email", "test@example.com")
+		runOpenCodeGit(t, dir, "config", "user.name", "Gas Town Test")
+		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		runOpenCodeGit(t, dir, "add", "README.md")
+		runOpenCodeGit(t, dir, "commit", "-m", "initial")
+		runOpenCodeGit(t, dir, "checkout", "-b", "feature/test")
+
+		if got := resolveOpenCodeWorkKey(dir, ""); got != "feature/test" {
+			t.Fatalf("resolveOpenCodeWorkKey = %q, want feature/test", got)
+		}
+	})
+
+	t.Run("configured HEAD derives detached revision", func(t *testing.T) {
+		dir := t.TempDir()
+		runOpenCodeGit(t, dir, "init")
+		runOpenCodeGit(t, dir, "config", "user.email", "test@example.com")
+		runOpenCodeGit(t, dir, "config", "user.name", "Gas Town Test")
+		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		runOpenCodeGit(t, dir, "add", "README.md")
+		runOpenCodeGit(t, dir, "commit", "-m", "initial")
+		runOpenCodeGit(t, dir, "checkout", "--detach")
+		revisionCommand := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+		revisionBytes, err := revisionCommand.Output()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := resolveOpenCodeWorkKey(dir, "HEAD"), strings.TrimSpace(string(revisionBytes)); got != want {
+			t.Fatalf("resolveOpenCodeWorkKey = %q, want %q", got, want)
+		}
+	})
+}
+
+func runOpenCodeGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,56 +43,58 @@ across distributed teams of AI agents working on shared codebases.`, cmdName)
 // Commands that don't require beads to be installed/checked.
 // These commands should work even when bd is missing or outdated.
 var beadsExemptCommands = map[string]bool{
-	"version":       true,
-	"help":          true,
-	"completion":    true,
-	"crew":          true,
-	"polecat":       true,
-	"witness":       true,
-	"refinery":      true,
-	"status":        true,
-	"status-line":   true,
-	"mail":          true,
-	"hook":          true,
-	"prime":         true,
-	"nudge":         true,
-	"seance":        true,
-	"doctor":        true,
-	"dolt":          true,
-	"handoff":       true,
-	"costs":         true,
-	"feed":          true,
-	"rig":           true,
-	"scheduler":     true,
-	"config":        true,
-	"install":       true,
-	"tap":           true,
-	"dnd":           true,
-	"estop":         true, // E-stop must work when Dolt is down
-	"thaw":          true, // Thaw must work when Dolt is down
-	"signal":        true, // Hook signal handlers must be fast, handle beads internally
-	"metrics":       true, // Metrics reads local JSONL, no beads needed
-	"krc":           true, // KRC doesn't require beads
-	"run-migration": true, // Migration orchestrator handles its own beads checks
-	"health":        true, // Health check doesn't require beads
-	"upgrade":       true, // Post-install migration orchestrator
-	"heartbeat":     true, // Heartbeat state update — must be fast and dependency-free
+	"version":         true,
+	"help":            true,
+	"completion":      true,
+	"crew":            true,
+	"polecat":         true,
+	"witness":         true,
+	"refinery":        true,
+	"status":          true,
+	"status-line":     true,
+	"mail":            true,
+	"hook":            true,
+	"prime":           true,
+	"nudge":           true,
+	"seance":          true,
+	"doctor":          true,
+	"dolt":            true,
+	"handoff":         true,
+	"costs":           true,
+	"feed":            true,
+	"rig":             true,
+	"scheduler":       true,
+	"config":          true,
+	"install":         true,
+	"tap":             true,
+	"dnd":             true,
+	"estop":           true, // E-stop must work when Dolt is down
+	"thaw":            true, // Thaw must work when Dolt is down
+	"signal":          true, // Hook signal handlers must be fast, handle beads internally
+	"metrics":         true, // Metrics reads local JSONL, no beads needed
+	"krc":             true, // KRC doesn't require beads
+	"run-migration":   true, // Migration orchestrator handles its own beads checks
+	"health":          true, // Health check doesn't require beads
+	"upgrade":         true, // Post-install migration orchestrator
+	"heartbeat":       true, // Heartbeat state update — must be fast and dependency-free
+	"opencode-worker": true, // Internal worker transport handles its own prerequisites
 }
 
 // Commands exempt from the town root branch warning.
 // These are commands that help fix the problem or are diagnostic.
 var branchCheckExemptCommands = map[string]bool{
-	"version":     true,
-	"help":        true,
-	"completion":  true,
-	"doctor":      true, // Used to fix the problem
-	"status-line": true, // tmux hot path; never run git freshness checks here
-	"estop":       true, // Emergency stop must always work
-	"thaw":        true, // Thaw must always work
-	"install":     true, // Initial setup
-	"git-init":    true, // Git setup
-	"upgrade":     true, // Post-install migration
-	"scheduler":   true, // Daemon hot path; scheduler handles beads internally
+	"version":         true,
+	"help":            true,
+	"completion":      true,
+	"doctor":          true, // Used to fix the problem
+	"status-line":     true, // tmux hot path; never run git freshness checks here
+	"estop":           true, // Emergency stop must always work
+	"thaw":            true, // Thaw must always work
+	"install":         true, // Initial setup
+	"git-init":        true, // Git setup
+	"upgrade":         true, // Post-install migration
+	"scheduler":       true, // Daemon hot path; scheduler handles beads internally
+	"opencode-worker": true,
 }
 
 // persistentPreRun runs before every command.

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1131,7 +1131,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			}
 		}
 
-		if err := injectStartPrompt(targetPane, beadID, slingSubject, slingArgs); err != nil {
+		if err := injectStartPrompt(townRoot, targetPane, beadID, slingSubject, slingArgs); err != nil {
 			// Graceful fallback for no-tmux mode
 			fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)
 			fmt.Printf("  Agent will discover work via gt prime / bd show\n")

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/formula"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -592,9 +593,22 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 
 	t := tmux.NewTmux()
-	if err := t.NudgePane(targetPane, prompt); err != nil {
+	sessionName, resolveErr := resolveSessionFromPane(targetPane)
+	var nudgeErr error
+	if resolveErr != nil {
+		nudgeErr = resolveErr
+	} else if hasOpenCodeServerSession(townRoot, sessionName) {
+		nudgeErr = nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
+			Sender:   "sling",
+			Message:  prompt,
+			Priority: nudge.PriorityNormal,
+		})
+	} else {
+		nudgeErr = t.NudgePane(targetPane, prompt)
+	}
+	if nudgeErr != nil {
 		// Graceful fallback for no-tmux mode
-		fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)
+		fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), nudgeErr)
 		fmt.Printf("  Agent will discover work via gt prime / bd show\n")
 	} else {
 		fmt.Printf("%s Nudged to start\n", style.Bold.Render("▶"))

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/daemon"
 	"github.com/steveyegge/gastown/internal/formula"
+	"github.com/steveyegge/gastown/internal/nudge"
 	rigpkg "github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
@@ -697,7 +698,7 @@ func storeFieldsInBeadFromTownRoot(townRoot, beadID string, updates beadFieldUpd
 
 // injectStartPrompt sends a prompt to the target pane to start working.
 // Uses the reliable nudge pattern: literal mode + 500ms debounce + separate Enter.
-func injectStartPrompt(pane, beadID, subject, args string) error {
+func injectStartPrompt(townRoot, pane, beadID, subject, args string) error {
 	if pane == "" {
 		return fmt.Errorf("no target pane")
 	}
@@ -724,6 +725,17 @@ func injectStartPrompt(pane, beadID, subject, args string) error {
 
 	// Use the reliable nudge pattern (same as gt nudge / tmux.NudgeSession)
 	t := tmux.NewTmux()
+	sessionName, err := resolveSessionFromPane(pane)
+	if err != nil {
+		return err
+	}
+	if hasOpenCodeServerSession(townRoot, sessionName) {
+		return nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
+			Sender:   "sling",
+			Message:  prompt,
+			Priority: nudge.PriorityNormal,
+		})
+	}
 	return t.NudgePane(pane, prompt)
 }
 
@@ -732,20 +744,32 @@ func injectStartPrompt(pane, beadID, subject, args string) error {
 // - "%9" (pane ID) - need to query tmux for session
 // - "gt-rig-name:0.0" (session:window.pane) - extract session name
 func getSessionFromPane(pane string) string {
+	sessionName, _ := resolveSessionFromPane(pane)
+	return sessionName
+}
+
+func resolveSessionFromPane(pane string) (string, error) {
+	if strings.TrimSpace(pane) == "" {
+		return "", fmt.Errorf("resolving target session: empty pane target")
+	}
 	if strings.HasPrefix(pane, "%") {
 		// Pane ID format - query tmux for the session
 		cmd := tmux.BuildCommand("display-message", "-t", pane, "-p", "#{session_name}")
 		out, err := cmd.Output()
 		if err != nil {
-			return ""
+			return "", fmt.Errorf("resolving target session from pane %s: %w", pane, err)
 		}
-		return strings.TrimSpace(string(out))
+		sessionName := strings.TrimSpace(string(out))
+		if sessionName == "" {
+			return "", fmt.Errorf("resolving target session from pane %s: empty tmux response", pane)
+		}
+		return sessionName, nil
 	}
 	// Session:window.pane format - extract session name
 	if idx := strings.Index(pane, ":"); idx > 0 {
-		return pane[:idx]
+		return pane[:idx], nil
 	}
-	return pane
+	return pane, nil
 }
 
 // ensureAgentReady waits for an agent to be ready before nudging an existing session.

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -37,6 +37,8 @@ const (
 	AgentAmp AgentPreset = "amp"
 	// AgentOpenCode is OpenCode multi-model CLI.
 	AgentOpenCode AgentPreset = "opencode"
+	// AgentOpenCodeServer runs OpenCode through its authenticated HTTP server.
+	AgentOpenCodeServer AgentPreset = "opencode-server"
 	// AgentCopilot is GitHub Copilot CLI.
 	AgentCopilot AgentPreset = "copilot"
 	// AgentPi is Pi Coding Agent (extension-based lifecycle).
@@ -77,6 +79,10 @@ type AgentPresetInfo struct {
 	// Used by tmux.IsAgentRunning to check pane_current_command.
 	// E.g., ["node"] for Claude, ["cursor-agent", "agent"] for Cursor (install script symlinks both names).
 	ProcessNames []string `json:"process_names,omitempty"`
+
+	// ManagesNudgeQueue indicates the runtime consumes Gas Town's nudge queue
+	// through its own structured transport and must not receive a tmux poller.
+	ManagesNudgeQueue bool `json:"manages_nudge_queue,omitempty"`
 
 	// SessionIDEnv is the environment variable for session ID.
 	// Used for resuming sessions across restarts.
@@ -402,6 +408,26 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ACP: &ACPConfig{
 			Command: "acp",
 		},
+	},
+	AgentOpenCodeServer: {
+		Name:    AgentOpenCodeServer,
+		Command: resolveGTPath(),
+		Args:    []string{"opencode-worker"},
+		Env: map[string]string{
+			"OPENCODE_PERMISSION":     `{"*":"allow"}`,
+			"OPENCODE_CONFIG_CONTENT": `{"lsp":true}`,
+		},
+		ProcessNames:        []string{"gt", "opencode", "node", "bun"},
+		ManagesNudgeQueue:   true,
+		SupportsHooks:       true,
+		SupportsForkSession: false,
+		PromptMode:          "arg",
+		ConfigDir:           ".opencode",
+		HooksProvider:       "opencode",
+		HooksDir:            ".opencode/plugins",
+		HooksSettingsFile:   "gastown.js",
+		ReadyDelayMs:        1000,
+		InstructionsFile:    "AGENTS.md",
 	},
 	AgentCopilot: {
 		Name:                AgentCopilot,
@@ -740,10 +766,11 @@ func runtimeConfigFromAgentInfo(preset AgentPreset, info *AgentPresetInfo) *Runt
 	}
 
 	rc := &RuntimeConfig{
-		Provider: string(info.Name),
-		Command:  info.Command,
-		Args:     append([]string(nil), info.Args...),
-		Env:      envCopy,
+		Provider:          string(info.Name),
+		Command:           info.Command,
+		Args:              append([]string(nil), info.Args...),
+		Env:               envCopy,
+		ManagesNudgeQueue: info.ManagesNudgeQueue,
 	}
 
 	if preset == AgentClaude && rc.Command == "claude" {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -32,7 +33,7 @@ func TestBuiltInAgentPresetSummary(t *testing.T) {
 func TestBuiltinPresets(t *testing.T) {
 	t.Parallel()
 	// Ensure all built-in presets are accessible
-	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentOpenCodeServer, AgentCopilot, AgentPi, AgentOmp}
 
 	for _, preset := range presets {
 		info := GetAgentPreset(preset)
@@ -68,9 +69,10 @@ func TestGetAgentPresetByName(t *testing.T) {
 		{"amp", AgentAmp, false},
 		{"aider", "", true},                // Not built-in, can be added via config
 		{"opencode", AgentOpenCode, false}, // Built-in multi-model CLI agent
-		{"copilot", AgentCopilot, false},   // Built-in GitHub Copilot CLI agent
-		{"pi", AgentPi, false},             // Pi Coding Agent
-		{"omp", AgentOmp, false},           // Oh My Pi
+		{"opencode-server", AgentOpenCodeServer, false},
+		{"copilot", AgentCopilot, false}, // Built-in GitHub Copilot CLI agent
+		{"pi", AgentPi, false},           // Pi Coding Agent
+		{"omp", AgentOmp, false},         // Oh My Pi
 		{"unknown", "", true},
 	}
 
@@ -152,9 +154,10 @@ func TestIsKnownPreset(t *testing.T) {
 		{"amp", true},
 		{"aider", false},   // Not built-in, can be added via config
 		{"opencode", true}, // Built-in multi-model CLI agent
-		{"copilot", true},  // Built-in GitHub Copilot CLI agent
-		{"pi", true},       // Pi Coding Agent
-		{"omp", true},      // Oh My Pi
+		{"opencode-server", true},
+		{"copilot", true}, // Built-in GitHub Copilot CLI agent
+		{"pi", true},      // Pi Coding Agent
+		{"omp", true},     // Oh My Pi
 		{"unknown", false},
 		{"chatgpt", false},
 	}
@@ -773,7 +776,7 @@ func TestGetProcessNames(t *testing.T) {
 func TestListAgentPresetsMatchesConstants(t *testing.T) {
 	t.Parallel()
 	// Ensure all AgentPreset constants are returned by ListAgentPresets
-	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentOpenCodeServer, AgentCopilot, AgentPi, AgentOmp}
 	presets := ListAgentPresets()
 
 	// Convert to map for quick lookup
@@ -1215,6 +1218,88 @@ func TestOpenCodeRuntimeConfigFromPreset(t *testing.T) {
 	original := GetAgentPreset(AgentOpenCode)
 	if _, exists := original.Env["MUTATED"]; exists {
 		t.Error("Mutation of RuntimeConfig.Env affected original preset")
+	}
+}
+
+func TestOpenCodeServerAgentPreset(t *testing.T) {
+	t.Parallel()
+	info := GetAgentPreset(AgentOpenCodeServer)
+	if info == nil {
+		t.Fatal("opencode-server preset not found")
+	}
+	if info.Command == "" || len(info.Args) != 1 || info.Args[0] != "opencode-worker" {
+		t.Fatalf("opencode-server command = %q %v", info.Command, info.Args)
+	}
+	if info.PromptMode != "arg" {
+		t.Fatalf("PromptMode = %q, want arg", info.PromptMode)
+	}
+	if info.HooksProvider != "opencode" || !info.SupportsHooks {
+		t.Fatalf("hooks = %q/%v, want opencode/true", info.HooksProvider, info.SupportsHooks)
+	}
+	if info.Env["OPENCODE_PERMISSION"] != `{"*":"allow"}` {
+		t.Fatalf("OPENCODE_PERMISSION = %q", info.Env["OPENCODE_PERMISSION"])
+	}
+	if !info.ManagesNudgeQueue {
+		t.Fatal("opencode-server should manage its own nudge queue")
+	}
+	rc := RuntimeConfigFromPreset(AgentOpenCodeServer)
+	if rc == nil || !rc.ManagesNudgeQueue {
+		t.Fatal("runtime config lost ManagesNudgeQueue")
+	}
+}
+
+func TestRuntimeConfigBuildCommandQuotesCommandPath(t *testing.T) {
+	t.Parallel()
+	rc := &RuntimeConfig{
+		Provider:   "generic",
+		Command:    filepath.Join("path with spaces", "gt"),
+		Args:       []string{"opencode-worker"},
+		PromptMode: "arg",
+	}
+	command := rc.BuildCommandWithPrompt("start work")
+	if !strings.Contains(command, quoteCommandForShell(rc.Command)) {
+		t.Fatalf("command path is not shell-quoted: %q", command)
+	}
+	if runtime.GOOS == "windows" && !strings.HasPrefix(command, "& ") {
+		t.Fatalf("quoted PowerShell command is not invokable: %q", command)
+	}
+}
+
+func TestPowerShellInvocationDoesNotDuplicateCallOperator(t *testing.T) {
+	command := "& 'C:\\Program Files\\Gas Town\\gt.exe' opencode-worker"
+	if got := powerShellInvocation(command); got != command {
+		t.Fatalf("powerShellInvocation = %q, want %q", got, command)
+	}
+	if got := powerShellInvocation("claude --model sonnet"); got != "& claude --model sonnet" {
+		t.Fatalf("powerShellInvocation bare command = %q", got)
+	}
+}
+
+func TestAgentManagesNudgeQueueResolvesCustomAlias(t *testing.T) {
+	townRoot := t.TempDir()
+	settings := NewTownSettings()
+	settings.Agents = map[string]*RuntimeConfig{
+		"server-alias": {Provider: string(AgentOpenCodeServer)},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), settings); err != nil {
+		t.Fatal(err)
+	}
+	if !AgentManagesNudgeQueue(townRoot, "", "server-alias") {
+		t.Fatal("custom OpenCode server alias lost managed-queue metadata")
+	}
+}
+
+func TestAgentManagesNudgeQueueHonorsCustomPresetOverride(t *testing.T) {
+	townRoot := t.TempDir()
+	settings := NewTownSettings()
+	settings.Agents = map[string]*RuntimeConfig{
+		string(AgentOpenCodeServer): {Provider: "generic", Command: "claude"},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), settings); err != nil {
+		t.Fatal(err)
+	}
+	if AgentManagesNudgeQueue(townRoot, "", string(AgentOpenCodeServer)) {
+		t.Fatal("custom runtime inherited managed-queue metadata from shadowed preset")
 	}
 }
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -23,6 +23,15 @@ var IdentityEnvVars = []string{
 	"GT_SESSION", "GT_AGENT", "BD_ACTOR", "GIT_AUTHOR_NAME", "BEADS_AGENT_NAME",
 }
 
+// OpenCodeOverrideEnvVars configure the native OpenCode server worker and must
+// survive tmux startup, daemon restarts, and self-handoffs.
+var OpenCodeOverrideEnvVars = []string{
+	"GT_OPENCODE_COMMAND",
+	"GT_OPENCODE_AGENT",
+	"GT_OPENCODE_MODEL",
+	"GT_OPENCODE_VARIANT",
+}
+
 var bdTargetSelectorEnvVars = []string{
 	"BEADS_DIR",
 	"BEADS_DB",
@@ -194,6 +203,11 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// IsAgentAlive and waitForPolecatReady use the correct process names.
 	if cfg.Agent != "" {
 		env["GT_AGENT"] = cfg.Agent
+	}
+	for _, name := range OpenCodeOverrideEnvVars {
+		if value, ok := os.LookupEnv(name); ok {
+			env[name] = value
+		}
 	}
 
 	// Disable bd's per-repo JSONL auto-backup for all Gas Town agents.

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,22 @@ func TestAgentEnv_Mayor(t *testing.T) {
 	assertEnv(t, env, "NODE_OPTIONS", "")                 // cleared to prevent debugger inheritance
 	assertEnv(t, env, "CLAUDECODE", "")                   // cleared to prevent nested session detection
 	assertNotSet(t, env, "GT_RIG")
+}
+
+func TestAgentEnvPropagatesOpenCodeOverrides(t *testing.T) {
+	want := map[string]string{
+		"GT_OPENCODE_COMMAND": "custom-opencode",
+		"GT_OPENCODE_AGENT":   "review",
+		"GT_OPENCODE_MODEL":   "provider/model",
+		"GT_OPENCODE_VARIANT": "high",
+	}
+	for key, value := range want {
+		t.Setenv(key, value)
+	}
+	env := AgentEnv(AgentEnvConfig{Role: "crew", Rig: "gastown", AgentName: "alice"})
+	for key, value := range want {
+		assertEnv(t, env, key, value)
+	}
 }
 
 func TestAgentEnv_Witness(t *testing.T) {
@@ -463,19 +480,22 @@ func TestShellQuote(t *testing.T) {
 func TestExportPrefix(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		env      map[string]string
-		expected string
+		name        string
+		env         map[string]string
+		wantPOSIX   string
+		wantWindows string
 	}{
 		{
-			name:     "empty",
-			env:      map[string]string{},
-			expected: "",
+			name:        "empty",
+			env:         map[string]string{},
+			wantPOSIX:   "",
+			wantWindows: "",
 		},
 		{
-			name:     "single var",
-			env:      map[string]string{"FOO": "bar"},
-			expected: "export FOO=bar && ",
+			name:        "single var",
+			env:         map[string]string{"FOO": "bar"},
+			wantPOSIX:   "export FOO=bar && ",
+			wantWindows: "$env:FOO='bar'; ",
 		},
 		{
 			name: "multiple vars sorted",
@@ -484,14 +504,16 @@ func TestExportPrefix(t *testing.T) {
 				"AAA": "first",
 				"MMM": "middle",
 			},
-			expected: "export AAA=first MMM=middle ZZZ=last && ",
+			wantPOSIX:   "export AAA=first MMM=middle ZZZ=last && ",
+			wantWindows: "$env:AAA='first'; $env:MMM='middle'; $env:ZZZ='last'; ",
 		},
 		{
 			name: "JSON value is quoted",
 			env: map[string]string{
 				"OPENCODE_PERMISSION": `{"*":"allow"}`,
 			},
-			expected: `export OPENCODE_PERMISSION='{"*":"allow"}' && `,
+			wantPOSIX:   `export OPENCODE_PERMISSION='{"*":"allow"}' && `,
+			wantWindows: `$env:OPENCODE_PERMISSION='{"*":"allow"}'; `,
 		},
 		{
 			name: "mixed simple and complex values",
@@ -500,15 +522,20 @@ func TestExportPrefix(t *testing.T) {
 				"COMPLEX": `{"key":"val"}`,
 				"GT_ROLE": "polecat",
 			},
-			expected: `export COMPLEX='{"key":"val"}' GT_ROLE=polecat SIMPLE=value && `,
+			wantPOSIX:   `export COMPLEX='{"key":"val"}' GT_ROLE=polecat SIMPLE=value && `,
+			wantWindows: `$env:COMPLEX='{"key":"val"}'; $env:GT_ROLE='polecat'; $env:SIMPLE='value'; `,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			want := tt.wantPOSIX
+			if runtime.GOOS == "windows" {
+				want = tt.wantWindows
+			}
 			result := ExportPrefix(tt.env)
-			if result != tt.expected {
-				t.Errorf("ExportPrefix() = %q, want %q", result, tt.expected)
+			if result != want {
+				t.Errorf("ExportPrefix() = %q, want %q", result, want)
 			}
 		})
 	}
@@ -517,40 +544,48 @@ func TestExportPrefix(t *testing.T) {
 func TestBuildStartupCommandWithEnv(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		env      map[string]string
-		agentCmd string
-		prompt   string
-		expected string
+		name        string
+		env         map[string]string
+		agentCmd    string
+		prompt      string
+		wantPOSIX   string
+		wantWindows string
 	}{
 		{
-			name:     "no env no prompt",
-			env:      map[string]string{},
-			agentCmd: "claude",
-			prompt:   "",
-			expected: "claude",
+			name:        "no env no prompt",
+			env:         map[string]string{},
+			agentCmd:    "claude",
+			prompt:      "",
+			wantPOSIX:   "claude",
+			wantWindows: "claude",
 		},
 		{
-			name:     "env no prompt",
-			env:      map[string]string{"GT_ROLE": "polecat"},
-			agentCmd: "claude",
-			prompt:   "",
-			expected: "export GT_ROLE=polecat && claude",
+			name:        "env no prompt",
+			env:         map[string]string{"GT_ROLE": "polecat"},
+			agentCmd:    "claude",
+			prompt:      "",
+			wantPOSIX:   "export GT_ROLE=polecat && claude",
+			wantWindows: "$env:GT_ROLE='polecat'; claude",
 		},
 		{
-			name:     "env with prompt",
-			env:      map[string]string{"GT_ROLE": "polecat"},
-			agentCmd: "claude",
-			prompt:   "gt prime",
-			expected: `export GT_ROLE=polecat && claude "gt prime"`,
+			name:        "env with prompt",
+			env:         map[string]string{"GT_ROLE": "polecat"},
+			agentCmd:    "claude",
+			prompt:      "gt prime",
+			wantPOSIX:   `export GT_ROLE=polecat && claude "gt prime"`,
+			wantWindows: `$env:GT_ROLE='polecat'; claude "gt prime"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			want := tt.wantPOSIX
+			if runtime.GOOS == "windows" {
+				want = tt.wantWindows
+			}
 			result := BuildStartupCommandWithEnv(tt.env, tt.agentCmd, tt.prompt)
-			if result != tt.expected {
-				t.Errorf("BuildStartupCommandWithEnv() = %q, want %q", result, tt.expected)
+			if result != want {
+				t.Errorf("BuildStartupCommandWithEnv() = %q, want %q", result, want)
 			}
 		})
 	}
@@ -1016,6 +1051,9 @@ func TestBuildStartupCommandWithEnv_IncludesNodeOptions(t *testing.T) {
 	}
 	result := BuildStartupCommandWithEnv(env, "claude", "")
 	expected := "export GT_ROLE=polecat NODE_OPTIONS= && claude"
+	if runtime.GOOS == "windows" {
+		expected = "$env:GT_ROLE='polecat'; $env:NODE_OPTIONS=''; claude"
+	}
 	if result != expected {
 		t.Errorf("BuildStartupCommandWithEnv() = %q, want %q", result, expected)
 	}

--- a/internal/config/integration_test.go
+++ b/internal/config/integration_test.go
@@ -58,6 +58,7 @@ func TestRigLevelCustomAgentIntegration(t *testing.T) {
 	// Test 2: Verify BuildPolecatStartupCommand includes the custom agent
 	t.Run("BuildPolecatStartupCommand uses custom agent", func(t *testing.T) {
 		cmd := BuildPolecatStartupCommand(rigName, "test-polecat", rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 
 		if !strings.Contains(cmd, stubAgentPath) {
 			t.Errorf("Expected command to contain stub agent path %q, got: %s", stubAgentPath, cmd)
@@ -68,11 +69,11 @@ func TestRigLevelCustomAgentIntegration(t *testing.T) {
 		}
 
 		// Verify environment variables are set (GT_ROLE is compound format)
-		if !strings.Contains(cmd, "GT_ROLE=testrig/polecats/test-polecat") {
+		if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "testrig/polecats/test-polecat")) {
 			t.Errorf("Expected GT_ROLE=testrig/polecats/test-polecat in command, got: %s", cmd)
 		}
 
-		if !strings.Contains(cmd, "GT_POLECAT=test-polecat") {
+		if !strings.Contains(cmd, startupEnvAssignment("GT_POLECAT", "test-polecat")) {
 			t.Errorf("Expected GT_POLECAT=test-polecat in command, got: %s", cmd)
 		}
 	})

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -82,13 +82,16 @@ func SaveTownConfig(path string, config *TownConfig) error {
 }
 
 // LoadRigsConfig loads and validates a rigs registry file.
-// Retries once on read/parse errors to tolerate the brief window during which a
-// concurrent non-atomic writer could leave the file truncated. With
-// SaveRigsConfig now using atomic write-then-rename this is belt-and-suspenders
-// against older versions that may still be writing the file.
+// Retries transient read/parse errors, including a brief Windows not-found or
+// sharing window during atomic replacement and truncated writes from older
+// Gas Town versions.
 func LoadRigsConfig(path string) (*RigsConfig, error) {
+	return loadRigsConfig(path, os.ReadFile)
+}
+
+func loadRigsConfig(path string, readFile func(string) ([]byte, error)) (*RigsConfig, error) {
 	readAndParse := func() (*RigsConfig, error) {
-		data, err := os.ReadFile(path) //nolint:gosec // G304: path is constructed internally, not from user input
+		data, err := readFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("%w: %s", ErrNotFound, path)
@@ -108,9 +111,16 @@ func LoadRigsConfig(path string) (*RigsConfig, error) {
 		return &config, nil
 	}
 
-	cfg, err := readAndParse()
-	if err != nil && !errors.Is(err, ErrNotFound) {
+	var cfg *RigsConfig
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
 		cfg, err = readAndParse()
+		if err == nil {
+			return cfg, nil
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+		}
 	}
 	return cfg, err
 }
@@ -1866,11 +1876,12 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 
 	// Create result with scalar fields (strings are immutable in Go)
 	result := &RuntimeConfig{
-		Provider:      rc.Provider,
-		Command:       rc.Command,
-		InitialPrompt: rc.InitialPrompt,
-		PromptMode:    rc.PromptMode,
-		ResolvedAgent: rc.ResolvedAgent,
+		Provider:          rc.Provider,
+		Command:           rc.Command,
+		InitialPrompt:     rc.InitialPrompt,
+		PromptMode:        rc.PromptMode,
+		ResolvedAgent:     rc.ResolvedAgent,
+		ManagesNudgeQueue: rc.ManagesNudgeQueue,
 	}
 
 	// Deep copy Args slice to avoid sharing backing array
@@ -1988,6 +1999,9 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 	// Auto-fill PromptMode from preset.
 	if result.PromptMode == "" && preset != nil && preset.PromptMode != "" {
 		result.PromptMode = preset.PromptMode
+	}
+	if preset != nil && preset.ManagesNudgeQueue {
+		result.ManagesNudgeQueue = true
 	}
 
 	// Auto-fill Instructions defaults from preset.
@@ -2137,6 +2151,21 @@ func GetRuntimeCommandWithPromptAndAgentOverride(rigPath, prompt, agentOverride 
 		return "", err
 	}
 	return rc.BuildCommandWithPrompt(prompt), nil
+}
+
+// AgentManagesNudgeQueue resolves built-in and custom agent aliases to decide
+// whether the runtime owns structured queue delivery.
+func AgentManagesNudgeQueue(townRoot, rigPath, agent string) bool {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return false
+	}
+	runtimeConfig, _, err := ResolveAgentConfigWithOverride(townRoot, rigPath, agent)
+	if err == nil && runtimeConfig != nil {
+		return runtimeConfig.ManagesNudgeQueue
+	}
+	preset := GetAgentPresetByName(agent)
+	return preset != nil && preset.ManagesNudgeQueue
 }
 
 // findTownRootFromCwd locates the town root by walking up from cwd.
@@ -2304,16 +2333,7 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 			scriptLines = append(scriptLines, fmt.Sprintf("$env:%s=%s", k, psQuote(resolvedEnv[k])))
 		}
 
-		var agentCmd string
-		if len(rc.ExecWrapper) > 0 {
-			agentCmd = strings.Join(rc.ExecWrapper, " ") + " "
-		}
-		if prompt != "" {
-			agentCmd += "& " + rc.BuildCommandWithPrompt(prompt)
-		} else {
-			agentCmd += "& " + rc.BuildCommand()
-		}
-		scriptLines = append(scriptLines, agentCmd)
+		scriptLines = append(scriptLines, powerShellRuntimeCommand(rc, prompt))
 
 		// Write script to temp file in town's daemon dir
 		townRoot := resolvedEnv["GT_ROOT"]
@@ -2560,16 +2580,7 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 			scriptLines = append(scriptLines, fmt.Sprintf("$env:%s=%s", k, psQuote(resolvedEnv[k])))
 		}
 
-		var agentCmd string
-		if len(rc.ExecWrapper) > 0 {
-			agentCmd = strings.Join(rc.ExecWrapper, " ") + " "
-		}
-		if prompt != "" {
-			agentCmd += "& " + rc.BuildCommandWithPrompt(prompt)
-		} else {
-			agentCmd += "& " + rc.BuildCommand()
-		}
-		scriptLines = append(scriptLines, agentCmd)
+		scriptLines = append(scriptLines, powerShellRuntimeCommand(rc, prompt))
 
 		townRoot := resolvedEnv["GT_ROOT"]
 		if townRoot == "" {
@@ -2613,6 +2624,93 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 	}
 
 	return cmd, nil
+}
+
+func powerShellInvocation(command string) string {
+	if strings.HasPrefix(strings.TrimSpace(command), "& ") {
+		return command
+	}
+	return "& " + command
+}
+
+func powerShellRuntimeCommand(runtimeConfig *RuntimeConfig, prompt string) string {
+	if len(runtimeConfig.ExecWrapper) == 0 {
+		command := runtimeConfig.BuildCommand()
+		if prompt != "" {
+			command = runtimeConfig.BuildCommandWithPrompt(prompt)
+		}
+		return powerShellInvocation(command)
+	}
+
+	argv := append([]string(nil), runtimeConfig.ExecWrapper...)
+	argv = append(argv, runtimeConfig.BuildArgsWithPrompt(prompt)...)
+	escapedArgs := make([]string, 0, len(argv)-1)
+	for _, arg := range argv[1:] {
+		escapedArgs = append(escapedArgs, escapeWindowsArg(arg))
+	}
+	return strings.Join([]string{
+		"$__gtStartInfo=New-Object System.Diagnostics.ProcessStartInfo",
+		"$__gtStartInfo.FileName=" + psQuote(argv[0]),
+		"$__gtStartInfo.Arguments=" + psQuote(strings.Join(escapedArgs, " ")),
+		"$__gtStartInfo.UseShellExecute=$false",
+		"$__gtProcess=[System.Diagnostics.Process]::Start($__gtStartInfo)",
+		"if ($null -eq $__gtProcess) { exit 1 }",
+		"$__gtProcess.WaitForExit()",
+		"exit $__gtProcess.ExitCode",
+	}, "\n")
+}
+
+// escapeWindowsArg follows the quoting rules consumed by CommandLineToArgvW.
+// It is used with ProcessStartInfo.Arguments to bypass WinPS 5.1's lossy native
+// argument binder.
+func escapeWindowsArg(arg string) string {
+	if arg == "" {
+		return `""`
+	}
+	needsBackslash := false
+	hasSpace := false
+	for i := 0; i < len(arg); i++ {
+		switch arg[i] {
+		case '"', '\\':
+			needsBackslash = true
+		case ' ', '\t':
+			hasSpace = true
+		}
+	}
+	if !needsBackslash && !hasSpace {
+		return arg
+	}
+	if !needsBackslash {
+		return `"` + arg + `"`
+	}
+
+	var result strings.Builder
+	if hasSpace {
+		result.WriteByte('"')
+	}
+	slashes := 0
+	for i := 0; i < len(arg); i++ {
+		c := arg[i]
+		switch c {
+		case '\\':
+			slashes++
+		case '"':
+			for ; slashes > 0; slashes-- {
+				result.WriteByte('\\')
+			}
+			result.WriteByte('\\')
+		default:
+			slashes = 0
+		}
+		result.WriteByte(c)
+	}
+	if hasSpace {
+		for ; slashes > 0; slashes-- {
+			result.WriteByte('\\')
+		}
+		result.WriteByte('"')
+	}
+	return result.String()
 }
 
 // BuildStartupCommandFromConfig builds a startup command from a complete AgentEnvConfig.

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -44,13 +44,35 @@ func writeAgentStub(t *testing.T, binDir, name string) {
 	}
 }
 
-// isClaudeCommand checks if a command is claude (either "claude" or a path ending in "/claude").
-// This handles the case where resolveClaudePath returns the full path to the claude binary.
-// Also handles Windows paths with .exe extension.
+// isClaudeCommand accepts either a raw executable path or a shell command line.
 func isClaudeCommand(cmd string) bool {
-	base := filepath.Base(cmd)
-	base = strings.TrimSuffix(base, filepath.Ext(base))
-	return base == "claude"
+	isClaudePath := func(path string) bool {
+		base := filepath.Base(path)
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+		return base == "claude"
+	}
+	if isClaudePath(cmd) {
+		return true
+	}
+
+	cmd = strings.TrimSpace(cmd)
+	cmd = strings.TrimSpace(strings.TrimPrefix(cmd, "& "))
+	if strings.HasPrefix(cmd, "'") {
+		for i := 1; i < len(cmd); i++ {
+			if cmd[i] != '\'' {
+				continue
+			}
+			if i+1 < len(cmd) && cmd[i+1] == '\'' {
+				i++
+				continue
+			}
+			return isClaudePath(strings.ReplaceAll(cmd[1:i], "''", "'"))
+		}
+	}
+	if fields := strings.Fields(cmd); len(fields) > 0 {
+		return isClaudePath(fields[0])
+	}
+	return false
 }
 
 func TestTownConfigRoundTrip(t *testing.T) {
@@ -1054,11 +1076,8 @@ func TestRuntimeConfigBuildCommand(t *testing.T) {
 				}
 			}
 			// Check if command starts with claude (or path to claude)
-			if tt.isClaudeCmd {
-				parts := strings.Fields(got)
-				if len(parts) > 0 && !isClaudeCommand(parts[0]) {
-					t.Errorf("BuildCommand() = %q, command should be claude or path to claude", got)
-				}
+			if tt.isClaudeCmd && !isClaudeCommand(got) {
+				t.Errorf("BuildCommand() = %q, command should be claude or path to claude", got)
 			}
 		})
 	}
@@ -1084,35 +1103,35 @@ func TestRuntimeConfigBuildCommandWithPrompt(t *testing.T) {
 			name:         "with prompt",
 			rc:           DefaultRuntimeConfig(),
 			prompt:       "gt prime",
-			wantContains: []string{"--dangerously-skip-permissions", `"gt prime"`},
+			wantContains: []string{"--dangerously-skip-permissions", quoteForShell("gt prime")},
 			isClaudeCmd:  true,
 		},
 		{
 			name:         "prompt with quotes",
 			rc:           DefaultRuntimeConfig(),
 			prompt:       `Hello "world"`,
-			wantContains: []string{"--dangerously-skip-permissions", `"Hello \"world\""`},
+			wantContains: []string{"--dangerously-skip-permissions", quoteForShell(`Hello "world"`)},
 			isClaudeCmd:  true,
 		},
 		{
 			name:         "config initial prompt used if no override",
 			rc:           &RuntimeConfig{Command: "aider", Args: []string{}, InitialPrompt: "/help"},
 			prompt:       "",
-			wantContains: []string{"aider", `"/help"`},
+			wantContains: []string{"aider", quoteForShell("/help")},
 			isClaudeCmd:  false,
 		},
 		{
 			name:         "override takes precedence over config",
 			rc:           &RuntimeConfig{Command: "aider", Args: []string{}, InitialPrompt: "/help"},
 			prompt:       "custom prompt",
-			wantContains: []string{"aider", `"custom prompt"`},
+			wantContains: []string{"aider", quoteForShell("custom prompt")},
 			isClaudeCmd:  false,
 		},
 		{
 			name:         "copilot uses -i flag for prompt",
 			rc:           &RuntimeConfig{Command: "copilot", Args: []string{"--yolo"}, PromptMode: "arg"},
 			prompt:       "test prompt",
-			wantContains: []string{"copilot", "--yolo", "-i", `"test prompt"`},
+			wantContains: []string{"copilot", "--yolo", "-i", quoteForShell("test prompt")},
 			isClaudeCmd:  false,
 		},
 	}
@@ -1127,11 +1146,8 @@ func TestRuntimeConfigBuildCommandWithPrompt(t *testing.T) {
 				}
 			}
 			// Check if command starts with claude (or path to claude)
-			if tt.isClaudeCmd {
-				parts := strings.Fields(got)
-				if len(parts) > 0 && !isClaudeCommand(parts[0]) {
-					t.Errorf("BuildCommandWithPrompt(%q) = %q, command should be claude or path to claude", tt.prompt, got)
-				}
+			if tt.isClaudeCmd && !isClaudeCommand(got) {
+				t.Errorf("BuildCommandWithPrompt(%q) = %q, command should be claude or path to claude", tt.prompt, got)
 			}
 		})
 	}
@@ -1153,19 +1169,19 @@ func TestBuildAgentStartupCommand(t *testing.T) {
 	// Test without rig config (uses defaults)
 	// New signature: (role, rig, townRoot, rigPath, prompt)
 	cmd := BuildAgentStartupCommand("witness", "gastown", "", "", "")
+	cmd = startupCommandBody(t, cmd)
 
-	// Should contain environment variables (via 'exec env') and claude command
-	if !strings.Contains(cmd, "exec env") {
-		t.Error("expected 'exec env' in command")
-	}
-	if !strings.Contains(cmd, "GT_ROLE=gastown/witness") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "gastown/witness")) {
 		t.Error("expected GT_ROLE=gastown/witness in command")
 	}
-	if !strings.Contains(cmd, "BD_ACTOR=gastown/witness") {
+	if !strings.Contains(cmd, startupEnvAssignment("BD_ACTOR", "gastown/witness")) {
 		t.Error("expected BD_ACTOR in command")
 	}
-	parts := strings.Fields(cmd)
-	if len(parts) < 2 || !isClaudeCommand(parts[len(parts)-2]) || parts[len(parts)-1] != "--dangerously-skip-permissions" {
+	agentCommand := strings.TrimSpace(cmd)
+	if newline := strings.LastIndex(agentCommand, "\n"); newline >= 0 {
+		agentCommand = agentCommand[newline+1:]
+	}
+	if !isClaudeCommand(agentCommand) || !strings.HasSuffix(strings.TrimSpace(agentCommand), "--dangerously-skip-permissions") {
 		t.Error("expected claude command in output")
 	}
 }
@@ -1173,17 +1189,18 @@ func TestBuildAgentStartupCommand(t *testing.T) {
 func TestBuildPolecatStartupCommand(t *testing.T) {
 	t.Parallel()
 	cmd := BuildPolecatStartupCommand("gastown", "toast", "", "")
+	cmd = startupCommandBody(t, cmd)
 
-	if !strings.Contains(cmd, "GT_ROLE=gastown/polecats/toast") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "gastown/polecats/toast")) {
 		t.Error("expected GT_ROLE=gastown/polecats/toast in command")
 	}
-	if !strings.Contains(cmd, "GT_RIG=gastown") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_RIG", "gastown")) {
 		t.Error("expected GT_RIG=gastown in command")
 	}
-	if !strings.Contains(cmd, "GT_POLECAT=toast") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_POLECAT", "toast")) {
 		t.Error("expected GT_POLECAT=toast in command")
 	}
-	if !strings.Contains(cmd, "BD_ACTOR=gastown/polecats/toast") {
+	if !strings.Contains(cmd, startupEnvAssignment("BD_ACTOR", "gastown/polecats/toast")) {
 		t.Error("expected BD_ACTOR in command")
 	}
 }
@@ -1191,17 +1208,18 @@ func TestBuildPolecatStartupCommand(t *testing.T) {
 func TestBuildCrewStartupCommand(t *testing.T) {
 	t.Parallel()
 	cmd := BuildCrewStartupCommand("gastown", "max", "", "")
+	cmd = startupCommandBody(t, cmd)
 
-	if !strings.Contains(cmd, "GT_ROLE=gastown/crew/max") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "gastown/crew/max")) {
 		t.Error("expected GT_ROLE=gastown/crew/max in command")
 	}
-	if !strings.Contains(cmd, "GT_RIG=gastown") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_RIG", "gastown")) {
 		t.Error("expected GT_RIG=gastown in command")
 	}
-	if !strings.Contains(cmd, "GT_CREW=max") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_CREW", "max")) {
 		t.Error("expected GT_CREW=max in command")
 	}
-	if !strings.Contains(cmd, "BD_ACTOR=gastown/crew/max") {
+	if !strings.Contains(cmd, startupEnvAssignment("BD_ACTOR", "gastown/crew/max")) {
 		t.Error("expected BD_ACTOR in command")
 	}
 }
@@ -1366,13 +1384,14 @@ func TestBuildPolecatStartupCommandWithAgentOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildPolecatStartupCommandWithAgentOverride: %v", err)
 	}
-	if !strings.Contains(cmd, "GT_ROLE=testrig/polecats/toast") {
+	cmd = startupCommandBody(t, cmd)
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "testrig/polecats/toast")) {
 		t.Fatalf("expected GT_ROLE export in command: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_RIG=testrig") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_RIG", "testrig")) {
 		t.Fatalf("expected GT_RIG export in command: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_POLECAT=toast") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_POLECAT", "toast")) {
 		t.Fatalf("expected GT_POLECAT export in command: %q", cmd)
 	}
 	if !strings.Contains(cmd, "gemini --approval-mode yolo") {
@@ -1408,10 +1427,11 @@ func TestBuildAgentStartupCommandWithAgentOverride(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildAgentStartupCommandWithAgentOverride: %v", err)
 		}
-		if !strings.Contains(cmd, "GT_ROLE=mayor") {
+		cmd = startupCommandBody(t, cmd)
+		if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "mayor")) {
 			t.Fatalf("expected GT_ROLE export in command: %q", cmd)
 		}
-		if !strings.Contains(cmd, "BD_ACTOR=mayor") {
+		if !strings.Contains(cmd, startupEnvAssignment("BD_ACTOR", "mayor")) {
 			t.Fatalf("expected BD_ACTOR export in command: %q", cmd)
 		}
 		if !strings.Contains(cmd, "gemini --approval-mode yolo") {
@@ -1425,6 +1445,7 @@ func TestBuildAgentStartupCommandWithAgentOverride(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildAgentStartupCommandWithAgentOverride: %v", err)
 		}
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "codex") {
 			t.Fatalf("expected codex command in output: %q", cmd)
 		}
@@ -1449,16 +1470,17 @@ func TestBuildCrewStartupCommandWithAgentOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildCrewStartupCommandWithAgentOverride: %v", err)
 	}
-	if !strings.Contains(cmd, "GT_ROLE=testrig/crew/max") {
+	cmd = startupCommandBody(t, cmd)
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "testrig/crew/max")) {
 		t.Fatalf("expected GT_ROLE export in command: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_RIG=testrig") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_RIG", "testrig")) {
 		t.Fatalf("expected GT_RIG export in command: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_CREW=max") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_CREW", "max")) {
 		t.Fatalf("expected GT_CREW export in command: %q", cmd)
 	}
-	if !strings.Contains(cmd, "BD_ACTOR=testrig/crew/max") {
+	if !strings.Contains(cmd, startupEnvAssignment("BD_ACTOR", "testrig/crew/max")) {
 		t.Fatalf("expected BD_ACTOR export in command: %q", cmd)
 	}
 	if !strings.Contains(cmd, "gemini --approval-mode yolo") {
@@ -1484,6 +1506,7 @@ func TestBuildStartupCommand_UsesRigAgentWhenRigPathProvided(t *testing.T) {
 	}
 
 	cmd := BuildStartupCommand(map[string]string{"GT_ROLE": "witness"}, rigPath, "")
+	cmd = startupCommandBody(t, cmd)
 	if !strings.Contains(cmd, "codex") {
 		t.Fatalf("expected rig agent (codex) in command: %q", cmd)
 	}
@@ -1533,9 +1556,10 @@ func TestBuildStartupCommand_ClearsBDTargetSelectors(t *testing.T) {
 		"GT_DOLT_PORT":               "1444",
 		"GT_DOLT_HOST":               "caller-host",
 	}, rigPath, "")
+	cmd = startupCommandBody(t, cmd)
 
 	for _, key := range bdTargetSelectorEnvVars {
-		if !strings.Contains(cmd, key+"=") {
+		if !strings.Contains(cmd, startupEnvAssignment(key, "")) {
 			t.Fatalf("startup command missing cleared %s assignment: %q", key, cmd)
 		}
 	}
@@ -1544,16 +1568,20 @@ func TestBuildStartupCommand_ClearsBDTargetSelectors(t *testing.T) {
 			t.Fatalf("startup command leaked stale bd selector value %q: %q", stale, cmd)
 		}
 	}
-	for _, want := range []string{
-		"GT_DOLT_PORT=1555",
-		"GT_DOLT_HOST=agent-host",
-		"BEADS_DOLT_PORT=1555",
-		"BEADS_DOLT_SERVER_PORT=1555",
-		"BEADS_DOLT_SERVER_HOST=agent-host",
-		"BEADS_DOLT_AUTO_START=0",
+	for _, want := range []struct {
+		key   string
+		value string
+	}{
+		{"GT_DOLT_PORT", "1555"},
+		{"GT_DOLT_HOST", "agent-host"},
+		{"BEADS_DOLT_PORT", "1555"},
+		{"BEADS_DOLT_SERVER_PORT", "1555"},
+		{"BEADS_DOLT_SERVER_HOST", "agent-host"},
+		{"BEADS_DOLT_AUTO_START", "0"},
 	} {
-		if !strings.Contains(cmd, want) {
-			t.Fatalf("startup command missing preserved connection env %q: %q", want, cmd)
+		expected := startupEnvAssignment(want.key, want.value)
+		if !strings.Contains(cmd, expected) {
+			t.Fatalf("startup command missing preserved connection env %q: %q", expected, cmd)
 		}
 	}
 }
@@ -1597,6 +1625,7 @@ func TestBuildStartupCommand_UsesRoleAgentsFromTownSettings(t *testing.T) {
 
 	t.Run("refinery role gets gemini from role_agents", func(t *testing.T) {
 		cmd := BuildStartupCommand(map[string]string{"GT_ROLE": constants.RoleRefinery}, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "gemini") {
 			t.Fatalf("expected gemini for refinery role, got: %q", cmd)
 		}
@@ -1604,6 +1633,7 @@ func TestBuildStartupCommand_UsesRoleAgentsFromTownSettings(t *testing.T) {
 
 	t.Run("witness role gets codex from role_agents", func(t *testing.T) {
 		cmd := BuildStartupCommand(map[string]string{"GT_ROLE": constants.RoleWitness}, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "codex") {
 			t.Fatalf("expected codex for witness role, got: %q", cmd)
 		}
@@ -1611,6 +1641,7 @@ func TestBuildStartupCommand_UsesRoleAgentsFromTownSettings(t *testing.T) {
 
 	t.Run("crew role falls back to default_agent (not in role_agents)", func(t *testing.T) {
 		cmd := BuildStartupCommand(map[string]string{"GT_ROLE": constants.RoleCrew}, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "claude") {
 			t.Fatalf("expected claude fallback for crew role, got: %q", cmd)
 		}
@@ -1618,6 +1649,7 @@ func TestBuildStartupCommand_UsesRoleAgentsFromTownSettings(t *testing.T) {
 
 	t.Run("no role falls back to default resolution", func(t *testing.T) {
 		cmd := BuildStartupCommand(map[string]string{}, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "claude") {
 			t.Fatalf("expected claude for no role, got: %q", cmd)
 		}
@@ -1650,6 +1682,7 @@ func TestBuildStartupCommand_RigRoleAgentsOverridesTownRoleAgents(t *testing.T) 
 	}
 
 	cmd := BuildStartupCommand(map[string]string{"GT_ROLE": constants.RoleWitness}, rigPath, "")
+	cmd = startupCommandBody(t, cmd)
 	if !strings.Contains(cmd, "codex") {
 		t.Fatalf("expected codex from rig role_agents override, got: %q", cmd)
 	}
@@ -1682,10 +1715,11 @@ func TestBuildAgentStartupCommand_UsesRoleAgents(t *testing.T) {
 
 	// BuildAgentStartupCommand passes role via GT_ROLE env var (compound format)
 	cmd := BuildAgentStartupCommand(constants.RoleRefinery, "testrig", townRoot, rigPath, "")
+	cmd = startupCommandBody(t, cmd)
 	if !strings.Contains(cmd, "codex") {
 		t.Fatalf("expected codex for refinery role, got: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_ROLE=testrig/refinery") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "testrig/refinery")) {
 		t.Fatalf("expected GT_ROLE=testrig/refinery in command: %q", cmd)
 	}
 }
@@ -1714,7 +1748,8 @@ func TestBuildAgentStartupCommand_DogUsesRoleAgents(t *testing.T) {
 	}
 
 	cmd := BuildAgentStartupCommand("dog", "", townRoot, "", "")
-	if !strings.Contains(cmd, "GT_ROLE=dog") {
+	cmd = startupCommandBody(t, cmd)
+	if !strings.Contains(cmd, startupEnvAssignment("GT_ROLE", "dog")) {
 		t.Fatalf("expected GT_ROLE=dog in command, got: %q", cmd)
 	}
 	if !strings.Contains(cmd, "--model haiku") {
@@ -1961,6 +1996,7 @@ func TestBuildStartupCommand_WorkerAgentsViaCrew(t *testing.T) {
 			"GT_CREW": "denali",
 		}
 		cmd := BuildStartupCommand(envVars, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if !strings.Contains(cmd, "codex") {
 			t.Errorf("expected codex for crew worker denali, got: %q", cmd)
 		}
@@ -1972,6 +2008,7 @@ func TestBuildStartupCommand_WorkerAgentsViaCrew(t *testing.T) {
 			"GT_CREW": "glacier",
 		}
 		cmd := BuildStartupCommand(envVars, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if strings.Contains(cmd, "codex") {
 			t.Errorf("expected non-codex for crew worker glacier (not in worker_agents), got: %q", cmd)
 		}
@@ -1982,6 +2019,7 @@ func TestBuildStartupCommand_WorkerAgentsViaCrew(t *testing.T) {
 			"GT_ROLE": constants.RoleCrew,
 		}
 		cmd := BuildStartupCommand(envVars, rigPath, "")
+		cmd = startupCommandBody(t, cmd)
 		if strings.Contains(cmd, "codex") {
 			t.Errorf("expected non-codex when GT_CREW not set, got: %q", cmd)
 		}
@@ -4803,6 +4841,7 @@ func TestBuildStartupCommandWithAgentOverride_PriorityOverRoleAgents(t *testing.
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	if !strings.Contains(cmd, "gemini") {
 		t.Errorf("expected gemini (override) in command, got: %q", cmd)
@@ -4835,9 +4874,10 @@ func TestBuildStartupCommandWithAgentOverride_IncludesGTRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	// Should include GT_ROOT in export
-	expected := "GT_ROOT=" + ShellQuote(townRoot)
+	expected := startupEnvAssignment("GT_ROOT", townRoot)
 	if !strings.Contains(cmd, expected) {
 		t.Errorf("expected %s in command, got: %q", expected, cmd)
 	}
@@ -4846,57 +4886,70 @@ func TestBuildStartupCommandWithAgentOverride_IncludesGTRoot(t *testing.T) {
 func TestQuoteForShell(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name        string
+		input       string
+		wantPOSIX   string
+		wantWindows string
 	}{
 		{
-			name:  "simple string",
-			input: "hello",
-			want:  `"hello"`,
+			name:        "simple string",
+			input:       "hello",
+			wantPOSIX:   `"hello"`,
+			wantWindows: `'hello'`,
 		},
 		{
-			name:  "string with double quote",
-			input: `say "hello"`,
-			want:  `"say \"hello\""`,
+			name:        "string with double quote",
+			input:       `say "hello"`,
+			wantPOSIX:   `"say \"hello\""`,
+			wantWindows: `'say "hello"'`,
 		},
 		{
-			name:  "string with backslash",
-			input: `path\to\file`,
-			want:  `"path\\to\\file"`,
+			name:        "string with backslash",
+			input:       `path\to\file`,
+			wantPOSIX:   `"path\\to\\file"`,
+			wantWindows: `'path\to\file'`,
 		},
 		{
-			name:  "string with backtick",
-			input: "run `cmd`",
-			want:  "\"run \\`cmd\\`\"",
+			name:        "string with backtick",
+			input:       "run `cmd`",
+			wantPOSIX:   "\"run \\`cmd\\`\"",
+			wantWindows: "'run `cmd`'",
 		},
 		{
-			name:  "string with dollar sign",
-			input: "cost is $100",
-			want:  `"cost is \$100"`,
+			name:        "string with dollar sign",
+			input:       "cost is $100",
+			wantPOSIX:   `"cost is \$100"`,
+			wantWindows: `'cost is $100'`,
 		},
 		{
-			name:  "variable expansion prevented",
-			input: "$HOME/path",
-			want:  `"\$HOME/path"`,
+			name:        "variable expansion prevented",
+			input:       "$HOME/path",
+			wantPOSIX:   `"\$HOME/path"`,
+			wantWindows: `'$HOME/path'`,
 		},
 		{
-			name:  "empty string",
-			input: "",
-			want:  `""`,
+			name:        "empty string",
+			input:       "",
+			wantPOSIX:   `""`,
+			wantWindows: `''`,
 		},
 		{
-			name:  "combined special chars",
-			input: "`$HOME`",
-			want:  "\"\\`\\$HOME\\`\"",
+			name:        "combined special chars",
+			input:       "`$HOME`",
+			wantPOSIX:   "\"\\`\\$HOME\\`\"",
+			wantWindows: "'`$HOME`'",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			want := tt.wantPOSIX
+			if runtime.GOOS == "windows" {
+				want = tt.wantWindows
+			}
 			got := quoteForShell(tt.input)
-			if got != tt.want {
-				t.Errorf("quoteForShell(%q) = %q, want %q", tt.input, got, tt.want)
+			if got != want {
+				t.Errorf("quoteForShell(%q) = %q, want %q", tt.input, got, want)
 			}
 		})
 	}
@@ -4925,9 +4978,10 @@ func TestBuildStartupCommandWithAgentOverride_SetsGTAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	// Should include GT_AGENT=gemini in export so handoff can preserve it
-	if !strings.Contains(cmd, "GT_AGENT=gemini") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "gemini")) {
 		t.Errorf("expected GT_AGENT=gemini in command, got: %q", cmd)
 	}
 }
@@ -4955,9 +5009,10 @@ func TestBuildStartupCommandWithAgentOverride_SetsGTProcessNames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	// Should include GT_PROCESS_NAMES with gemini's process names
-	if !strings.Contains(cmd, "GT_PROCESS_NAMES=gemini") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_PROCESS_NAMES", "gemini")) {
 		t.Errorf("expected GT_PROCESS_NAMES=gemini in command, got: %q", cmd)
 	}
 }
@@ -4980,9 +5035,14 @@ func TestBuildStartupCommand_SetsGTProcessNames(t *testing.T) {
 		rigPath,
 		"",
 	)
+	cmd = startupCommandBody(t, cmd)
 
-	// Default agent is claude — GT_PROCESS_NAMES should include node,claude
-	if !strings.Contains(cmd, "GT_PROCESS_NAMES=") {
+	// Default agent startup should publish GT_PROCESS_NAMES for liveness detection.
+	expectedPrefix := "GT_PROCESS_NAMES="
+	if runtime.GOOS == "windows" {
+		expectedPrefix = "$env:GT_PROCESS_NAMES="
+	}
+	if !strings.Contains(cmd, expectedPrefix) {
 		t.Errorf("expected GT_PROCESS_NAMES in command, got: %q", cmd)
 	}
 }
@@ -5019,6 +5079,7 @@ func TestBuildStartupCommandWithAgentOverride_UsesOverrideWhenNoTownRoot(t *test
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	// Should use codex, NOT claude (the default)
 	if !strings.Contains(cmd, "codex") {
@@ -5032,7 +5093,7 @@ func TestBuildStartupCommandWithAgentOverride_UsesOverrideWhenNoTownRoot(t *test
 		t.Errorf("expected command to contain '--dangerously-bypass-approvals-and-sandbox' (codex flag) but got: %q", cmd)
 	}
 	// Should set GT_AGENT=codex
-	if !strings.Contains(cmd, "GT_AGENT=codex") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "codex")) {
 		t.Errorf("expected command to contain 'GT_AGENT=codex' but got: %q", cmd)
 	}
 }
@@ -5060,10 +5121,11 @@ func TestBuildStartupCommandWithAgentOverride_GTAgentFromResolvedAgent(t *testin
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	// GT_AGENT should be set from the resolved agent for liveness detection,
 	// even when no explicit override is used.
-	if !strings.Contains(cmd, "GT_AGENT=") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "claude")) {
 		t.Errorf("expected GT_AGENT in command for liveness detection, got: %q", cmd)
 	}
 }
@@ -5095,9 +5157,10 @@ func TestBuildStartupCommand_RoleAgentsSetGTAgent(t *testing.T) {
 	}
 
 	cmd := BuildPolecatStartupCommand("testrig", "furiosa", rigPath, "do work")
+	cmd = startupCommandBody(t, cmd)
 
 	// GT_AGENT must be set to "opencode" so IsAgentAlive detects the process
-	if !strings.Contains(cmd, "GT_AGENT=opencode") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "opencode")) {
 		t.Errorf("expected GT_AGENT=opencode in command, got: %q", cmd)
 	}
 }
@@ -5126,9 +5189,10 @@ func TestBuildStartupCommand_RoleAgentsCustomAgentSetGTAgent(t *testing.T) {
 	}
 
 	cmd := BuildPolecatStartupCommand("testrig", "furiosa", rigPath, "do work")
+	cmd = startupCommandBody(t, cmd)
 
 	// GT_AGENT must be set to the custom agent name "codex"
-	if !strings.Contains(cmd, "GT_AGENT=codex") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "codex")) {
 		t.Errorf("expected GT_AGENT=codex in command, got: %q", cmd)
 	}
 }
@@ -5162,6 +5226,7 @@ func TestBuildStartupCommand_UsesGTRootFromEnvVars(t *testing.T) {
 		"GT_ROOT": townRoot,
 	}
 	cmd := BuildStartupCommand(envVars, "", "")
+	cmd = startupCommandBody(t, cmd)
 
 	if !strings.Contains(cmd, "--model sonnet") {
 		t.Errorf("expected --model sonnet from role_agents[deacon], got: %q", cmd)
@@ -5195,6 +5260,7 @@ func TestBuildStartupCommandWithAgentOverride_UsesGTRootFromEnvVars(t *testing.T
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	if !strings.Contains(cmd, "--model sonnet") {
 		t.Errorf("expected --model sonnet from role_agents[deacon], got: %q", cmd)
@@ -5613,23 +5679,29 @@ func TestBuildStartupCommand_ExecWrapper(t *testing.T) {
 	}
 
 	cmd := BuildStartupCommand(map[string]string{"GT_ROLE": "polecat"}, rigPath, "hello")
-
-	// Must contain exec wrapper tokens
-	if !strings.Contains(cmd, "exitbox run --profile=gastown-polecat --") {
-		t.Errorf("expected exec wrapper in command, got: %q", cmd)
+	cmd = startupCommandBody(t, cmd)
+	if strings.Contains(cmd, "-- & ") {
+		t.Fatalf("exec wrapper must receive the agent command as arguments, got malformed PowerShell: %q", cmd)
 	}
 
-	// The wrapper + agent command should appear as a contiguous sequence
-	// "exitbox run --profile=gastown-polecat -- claude"
-	if !strings.Contains(cmd, "exitbox run --profile=gastown-polecat -- claude") {
+	wantWrapper := "exitbox run --profile=gastown-polecat -- claude"
+	wrapperMarker := "exitbox run"
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(cmd, "$__gtStartInfo.FileName="+psQuote("exitbox")) {
+			t.Errorf("expected exec wrapper executable in command, got: %q", cmd)
+		}
+		wantWrapper = "run --profile=gastown-polecat -- claude"
+		wrapperMarker = "$__gtStartInfo.FileName=" + psQuote("exitbox")
+	}
+	if !strings.Contains(cmd, wantWrapper) {
 		t.Errorf("expected wrapper immediately before claude command, got: %q", cmd)
 	}
 
-	// Env vars (exec env ...) must appear before the wrapper
-	envIdx := strings.Index(cmd, "exec env")
-	wrapperIdx := strings.Index(cmd, "exitbox run")
+	// Environment setup must appear before the wrapper.
+	envIdx := strings.Index(cmd, startupEnvAssignment("GT_ROLE", "polecat"))
+	wrapperIdx := strings.Index(cmd, wrapperMarker)
 	if envIdx == -1 || wrapperIdx == -1 || envIdx >= wrapperIdx {
-		t.Errorf("expected 'exec env' before wrapper, got: %q", cmd)
+		t.Errorf("expected environment setup before wrapper, got: %q", cmd)
 	}
 }
 
@@ -5655,14 +5727,122 @@ func TestBuildStartupCommandWithAgentOverride_ExecWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
-
-	if !strings.Contains(cmd, "daytona exec furiosa-ws --") {
-		t.Errorf("expected exec wrapper in command, got: %q", cmd)
+	cmd = startupCommandBody(t, cmd)
+	if strings.Contains(cmd, "-- & ") {
+		t.Fatalf("exec wrapper must receive the agent command as arguments, got malformed PowerShell: %q", cmd)
 	}
 
-	// The wrapper + agent command should appear as a contiguous sequence
-	if !strings.Contains(cmd, "daytona exec furiosa-ws -- claude") {
+	wantWrapper := "daytona exec furiosa-ws -- claude"
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(cmd, "$__gtStartInfo.FileName="+psQuote("daytona")) {
+			t.Errorf("expected exec wrapper executable in command, got: %q", cmd)
+		}
+		wantWrapper = "exec furiosa-ws -- claude"
+	}
+	if !strings.Contains(cmd, wantWrapper) {
 		t.Errorf("expected wrapper immediately before claude command, got: %q", cmd)
+	}
+}
+
+func TestPowerShellRuntimeCommandQuotesEveryArgument(t *testing.T) {
+	runtimeConfig := &RuntimeConfig{
+		Provider:   "generic",
+		Command:    `C:\Program Files\Claude's\claude.exe`,
+		Args:       []string{"", "@agent", "--%", "line\rbreak", "two words", "it's"},
+		PromptMode: "arg",
+		ExecWrapper: []string{
+			`C:\Program Files\Wrapper's\wrap.exe`,
+			"",
+			"@wrapper",
+		},
+	}
+	got := powerShellRuntimeCommand(runtimeConfig, "prompt with 'quote'")
+	argv := append([]string(nil), runtimeConfig.ExecWrapper...)
+	argv = append(argv, runtimeConfig.BuildArgsWithPrompt("prompt with 'quote'")...)
+	escapedArgs := make([]string, 0, len(argv)-1)
+	for _, arg := range argv[1:] {
+		escapedArgs = append(escapedArgs, escapeWindowsArg(arg))
+	}
+	want := strings.Join([]string{
+		"$__gtStartInfo=New-Object System.Diagnostics.ProcessStartInfo",
+		"$__gtStartInfo.FileName=" + psQuote(argv[0]),
+		"$__gtStartInfo.Arguments=" + psQuote(strings.Join(escapedArgs, " ")),
+		"$__gtStartInfo.UseShellExecute=$false",
+		"$__gtProcess=[System.Diagnostics.Process]::Start($__gtStartInfo)",
+		"if ($null -eq $__gtProcess) { exit 1 }",
+		"$__gtProcess.WaitForExit()",
+		"exit $__gtProcess.ExitCode",
+	}, "\n")
+	if got != want {
+		t.Fatalf("powerShellRuntimeCommand = %q, want %q", got, want)
+	}
+}
+
+func TestPowerShellRuntimeCommandPreservesNativeArguments(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell native argument regression")
+	}
+	outputPath := filepath.Join(t.TempDir(), "args.json")
+	runtimeConfig := &RuntimeConfig{
+		Provider:   "generic",
+		Command:    "agent.exe",
+		Args:       []string{"", "@agent", "--%", "line\rbreak", "two words", "it's"},
+		PromptMode: "arg",
+		ExecWrapper: []string{
+			os.Args[0],
+			"-test.run=^TestPowerShellNativeArgumentHelper$",
+			"--",
+		},
+	}
+	command := powerShellRuntimeCommand(runtimeConfig, "prompt with 'quote'")
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command)
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_POWERSHELL_NATIVE_ARGUMENT_HELPER=1",
+		"GO_POWERSHELL_NATIVE_ARGUMENT_OUTPUT="+outputPath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("execute PowerShell runtime command: %v\n%s\ncommand: %s", err, output, command)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := append([]string{runtimeConfig.Command}, runtimeConfig.Args...)
+	want = append(want, "prompt with 'quote'")
+	if len(got) != len(want) {
+		t.Fatalf("native arguments = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("native argument %d = %q, want %q; all=%#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestPowerShellNativeArgumentHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_POWERSHELL_NATIVE_ARGUMENT_HELPER") != "1" {
+		return
+	}
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator < 0 {
+		t.Fatal("native argument helper missing separator")
+	}
+	data, err := json.Marshal(os.Args[separator+1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(os.Getenv("GO_POWERSHELL_NATIVE_ARGUMENT_OUTPUT"), data, 0644); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -5719,6 +5899,7 @@ func TestBuildStartupCommandWithAgentOverride_SettingsFlagForClaudeOverride(t *t
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	if !strings.Contains(cmd, "--settings") {
 		t.Errorf("Claude override on polecat role should include --settings, got: %q", cmd)
@@ -5750,6 +5931,7 @@ func TestBuildPolecatStartupCommandWithAgentOverride_IncludesSettingsFlag(t *tes
 	if err != nil {
 		t.Fatalf("BuildPolecatStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	if !strings.Contains(cmd, "--settings") {
 		t.Errorf("polecat with Claude override must get --settings for hooks to fire, got: %q", cmd)
@@ -5782,6 +5964,7 @@ func TestBuildStartupCommandWithAgentOverride_NoSettingsFlagForNonClaude(t *test
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	if strings.Contains(cmd, "--settings") {
 		t.Errorf("non-Claude override (gemini) should NOT get --settings, got: %q", cmd)
@@ -5813,6 +5996,7 @@ func TestBuildStartupCommandWithAgentOverride_NoDoubleSettingsOnNonOverridePath(
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
 	count := strings.Count(cmd, "--settings")
 	if count > 1 {
@@ -5870,11 +6054,16 @@ func TestBuildStartupCommandWithAgentOverrideSetsGTAgentForOpenCode(t *testing.T
 	if err != nil {
 		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
 	}
+	cmd = startupCommandBody(t, cmd)
 
-	if !strings.Contains(cmd, "GT_AGENT=opencode") {
+	if !strings.Contains(cmd, startupEnvAssignment("GT_AGENT", "opencode")) {
 		t.Errorf("expected GT_AGENT=opencode in command, got: %q", cmd)
 	}
-	if !strings.Contains(cmd, "GT_PROCESS_NAMES=opencode") {
+	expectedProcessPrefix := "GT_PROCESS_NAMES=opencode"
+	if runtime.GOOS == "windows" {
+		expectedProcessPrefix = "$env:GT_PROCESS_NAMES='opencode"
+	}
+	if !strings.Contains(cmd, expectedProcessPrefix) {
 		t.Errorf("expected GT_PROCESS_NAMES=opencode in command, got: %q", cmd)
 	}
 	if strings.Contains(cmd, "--settings") {

--- a/internal/config/rigs_atomic_test.go
+++ b/internal/config/rigs_atomic_test.go
@@ -2,10 +2,15 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // TestSaveRigsConfig_AtomicAgainstConcurrentReaders is the regression test for
@@ -37,13 +42,20 @@ func TestSaveRigsConfig_AtomicAgainstConcurrentReaders(t *testing.T) {
 	}
 
 	stop := make(chan struct{})
+	start := make(chan struct{})
+	firstWrite := make(chan struct{}, 1)
 	var wg sync.WaitGroup
+	var successfulWrites atomic.Int64
+	var readerActive atomic.Bool
+	var overlappingWrites atomic.Int64
+	writerErrors := make(chan error, 4)
 
 	// 4 concurrent writers alternating between small and big payloads.
 	for w := 0; w < 4; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			payloads := []*RigsConfig{initial, big}
 			i := 0
 			for {
@@ -53,27 +65,49 @@ func TestSaveRigsConfig_AtomicAgainstConcurrentReaders(t *testing.T) {
 				default:
 				}
 				if err := SaveRigsConfig(path, payloads[i%2]); err != nil {
-					t.Errorf("SaveRigsConfig: %v", err)
+					writerErrors <- err
 					return
+				}
+				successfulWrites.Add(1)
+				if readerActive.Load() {
+					overlappingWrites.Add(1)
+				}
+				select {
+				case firstWrite <- struct{}{}:
+				default:
 				}
 				i++
 			}
 		}()
 	}
+	close(start)
+	select {
+	case <-firstWrite:
+	case <-time.After(3 * time.Second):
+		close(stop)
+		wg.Wait()
+		t.Fatal("no writer completed before reader stress began")
+	}
 
-	// Reader: in 2000 iterations, not a single raw read may yield a truncated
-	// or empty file. (We bypass LoadRigsConfig's retry so the underlying write
-	// semantics are what's under test.)
+	// Reader: in 2000 iterations, not a single successful raw read may yield a
+	// truncated or empty file. Windows can transiently reject an open during
+	// replacement; those errors are counted against the availability floor.
 	var tornReads int
+	var successfulReads int
+	var transientReadErrors int
+	var readErr error
+	readerActive.Store(true)
 	for i := 0; i < 2000; i++ {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			// Transient rename races can cause ENOENT on some platforms; tolerate.
-			if os.IsNotExist(err) {
+			if transientAtomicReadError(err) {
+				transientReadErrors++
 				continue
 			}
-			t.Fatalf("read rigs.json: %v", err)
+			readErr = err
+			break
 		}
+		successfulReads++
 		if len(data) == 0 {
 			tornReads++
 			continue
@@ -82,9 +116,32 @@ func TestSaveRigsConfig_AtomicAgainstConcurrentReaders(t *testing.T) {
 		if err := json.Unmarshal(data, &probe); err != nil {
 			tornReads++
 		}
+		if i%100 == 0 {
+			runtime.Gosched()
+		}
 	}
+	readerActive.Store(false)
 	close(stop)
 	wg.Wait()
+	close(writerErrors)
+	if readErr != nil {
+		t.Fatalf("read rigs.json: %v", readErr)
+	}
+	for err := range writerErrors {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+	if successfulWrites.Load() == 0 {
+		t.Fatal("no concurrent write completed")
+	}
+	if successfulReads == 0 {
+		t.Fatalf("all reads failed transiently (%d sharing errors)", transientReadErrors)
+	}
+	if successfulReads < 200 {
+		t.Fatalf("only %d/2000 reads succeeded (%d sharing errors)", successfulReads, transientReadErrors)
+	}
+	if overlappingWrites.Load() == 0 {
+		t.Fatal("no write completed while the reader stress loop was active")
+	}
 
 	if tornReads > 0 {
 		t.Fatalf("observed %d torn/empty reads — SaveRigsConfig is not atomic", tornReads)
@@ -97,6 +154,42 @@ func TestSaveRigsConfig_AtomicAgainstConcurrentReaders(t *testing.T) {
 	}
 	if len(final.Rigs) != 1 && len(final.Rigs) != 500 {
 		t.Fatalf("final rig count = %d, want 1 or 500", len(final.Rigs))
+	}
+}
+
+func transientAtomicReadError(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	if os.IsNotExist(err) {
+		return true
+	}
+	const (
+		accessDenied     syscall.Errno = 5
+		sharingViolation syscall.Errno = 32
+	)
+	return errors.Is(err, sharingViolation) || errors.Is(err, accessDenied)
+}
+
+func TestLoadRigsConfigRetriesTransientNotFound(t *testing.T) {
+	want := &RigsConfig{Version: 1, Rigs: map[string]RigEntry{"alpha": {}}}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	got, err := loadRigsConfig("rigs.json", func(string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, os.ErrNotExist
+		}
+		return data, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || len(got.Rigs) != 1 {
+		t.Fatalf("loadRigsConfig calls=%d config=%#v", calls, got)
 	}
 }
 

--- a/internal/config/test_main_test.go
+++ b/internal/config/test_main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -51,4 +52,36 @@ func TestMain(m *testing.M) {
 	_ = os.Unsetenv("GT_AGENT_STUB_BIN_DIR")
 	_ = os.RemoveAll(stubDir)
 	os.Exit(code)
+}
+
+func startupCommandBody(t *testing.T, command string) string {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return command
+	}
+
+	if !strings.HasPrefix(command, "& ") {
+		t.Fatalf("startup command is not a PowerShell script invocation: %q", command)
+	}
+	quotedPath := strings.TrimSpace(strings.TrimPrefix(command, "& "))
+	if len(quotedPath) < 2 || quotedPath[0] != '\'' || quotedPath[len(quotedPath)-1] != '\'' {
+		t.Fatalf("startup script path is not single-quoted: %q", command)
+	}
+	scriptPath := strings.ReplaceAll(quotedPath[1:len(quotedPath)-1], "''", "'")
+	if !strings.EqualFold(filepath.Ext(scriptPath), ".ps1") {
+		t.Fatalf("startup command does not invoke a PowerShell script: %q", command)
+	}
+
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read startup script %q: %v", scriptPath, err)
+	}
+	return string(data)
+}
+
+func startupEnvAssignment(key, value string) string {
+	if runtime.GOOS == "windows" {
+		return fmt.Sprintf("$env:%s=%s", key, psQuote(value))
+	}
+	return fmt.Sprintf("%s=%s", key, ShellQuote(value))
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -778,6 +778,10 @@ type RuntimeConfig struct {
 	// Produces: exec env VAR=val ... exitbox run --profile=gastown-polecat -- claude ...
 	ExecWrapper []string `json:"exec_wrapper,omitempty"`
 
+	// ManagesNudgeQueue is copied from the resolved agent preset. It marks
+	// runtimes that deliver queued nudges without the tmux poller.
+	ManagesNudgeQueue bool `json:"-"`
+
 	// ResolvedAgent is the agent name that was resolved during config lookup.
 	// Set by ResolveRoleAgentConfig / resolveAgentConfigInternal so that
 	// BuildStartupCommand can export GT_AGENT for process detection.
@@ -845,7 +849,7 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 func (rc *RuntimeConfig) BuildCommand() string {
 	resolved := normalizeRuntimeConfig(rc)
 
-	cmd := resolved.Command
+	cmd := quoteCommandForShell(resolved.Command)
 	args := resolved.Args
 
 	// Combine command and args, quoting any that contain shell metacharacters
@@ -888,19 +892,16 @@ func (rc *RuntimeConfig) BuildCommandWithPrompt(prompt string) string {
 	// OpenCode requires --prompt flag for initial prompt in interactive mode.
 	// Positional argument causes opencode to exit immediately.
 	// Match both "opencode" and full paths like "/home/user/.opencode/bin/opencode".
-	if resolved.Command == "opencode" || filepath.Base(resolved.Command) == "opencode" {
+	switch runtimeCommandName(resolved.Command) {
+	case "opencode":
 		return base + " --prompt " + quoteForShell(p)
-	}
-
-	// Copilot requires -i flag for initial prompt in interactive mode.
-	if resolved.Command == "copilot" || filepath.Base(resolved.Command) == "copilot" {
+	case "copilot":
+		// Copilot requires -i flag for initial prompt in interactive mode.
 		return base + " -i " + quoteForShell(p)
-	}
-
-	// Gemini requires -i (--prompt-interactive) to auto-execute the prompt
-	// while staying in interactive mode. Positional args populate the input
-	// field but don't execute, and -p runs headless (exits after completion).
-	if resolved.Command == "gemini" || filepath.Base(resolved.Command) == "gemini" {
+	case "gemini":
+		// Gemini requires -i (--prompt-interactive) to auto-execute the prompt
+		// while staying in interactive mode. Positional args populate the input
+		// field but don't execute, and -p runs headless (exits after completion).
 		return base + " -i " + quoteForShell(p)
 	}
 
@@ -919,7 +920,7 @@ func (rc *RuntimeConfig) BuildArgsWithPrompt(prompt string) []string {
 	}
 
 	if p != "" && resolved.PromptMode != "none" {
-		switch resolved.Command {
+		switch runtimeCommandName(resolved.Command) {
 		case "opencode":
 			args = append(args, "--prompt", p)
 		case "copilot", "gemini":
@@ -932,6 +933,11 @@ func (rc *RuntimeConfig) BuildArgsWithPrompt(prompt string) []string {
 	}
 
 	return args
+}
+
+func runtimeCommandName(command string) string {
+	base := filepath.Base(command)
+	return strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
 }
 
 func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
@@ -1106,6 +1112,19 @@ func resolveClaudePath() string {
 	return "claude"
 }
 
+func resolveGTPath() string {
+	if current, err := os.Executable(); err == nil {
+		base := strings.TrimSuffix(filepath.Base(current), filepath.Ext(current))
+		if base == "gt" || base == "gts" {
+			return current
+		}
+	}
+	if path, err := exec.LookPath("gt"); err == nil {
+		return path
+	}
+	return "gt"
+}
+
 func defaultRuntimeArgs(provider string) []string {
 	if preset := GetAgentPresetByName(provider); preset != nil && preset.Args != nil {
 		return append([]string(nil), preset.Args...) // copy to avoid mutation
@@ -1208,6 +1227,16 @@ func quoteForShell(s string) string {
 	escaped = strings.ReplaceAll(escaped, "`", "\\`")
 	escaped = strings.ReplaceAll(escaped, "$", `\$`)
 	return `"` + escaped + `"`
+}
+
+func quoteCommandForShell(s string) string {
+	if runtime.GOOS == "windows" {
+		if ShellQuote(s) == s {
+			return s
+		}
+		return "& " + psQuote(s)
+	}
+	return ShellQuote(s)
 }
 
 // ThemeConfig represents tmux theme settings for a rig.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -9,6 +9,36 @@ import (
 	"time"
 )
 
+func TestBuildPromptRecognizesFullPathProviders(t *testing.T) {
+	tests := []struct {
+		provider string
+		flag     string
+	}{
+		{provider: "opencode", flag: "--prompt"},
+		{provider: "gemini", flag: "-i"},
+		{provider: "copilot", flag: "-i"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			command := filepath.Join("tools", tt.provider+".exe")
+			runtimeConfig := &RuntimeConfig{
+				Provider:   "generic",
+				Command:    command,
+				Args:       []string{},
+				PromptMode: "arg",
+			}
+			args := runtimeConfig.BuildArgsWithPrompt("start here")
+			if len(args) != 3 || args[0] != command || args[1] != tt.flag || args[2] != "start here" {
+				t.Fatalf("BuildArgsWithPrompt = %v", args)
+			}
+			built := runtimeConfig.BuildCommandWithPrompt("start here")
+			if !strings.Contains(built, " "+tt.flag+" ") {
+				t.Fatalf("BuildCommandWithPrompt = %q, missing %s", built, tt.flag)
+			}
+		})
+	}
+}
+
 // --- ParseDurationOrDefault ---
 
 func TestParseDurationOrDefault(t *testing.T) {

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -715,7 +715,15 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	// Ensure runtime settings exist in the shared crew parent directory.
 	// Settings are passed to Claude Code via --settings flag.
 	townRoot := filepath.Dir(m.rig.Path)
-	runtimeConfig := config.ResolveWorkerAgentConfig(name, townRoot, m.rig.Path)
+	var runtimeConfig *config.RuntimeConfig
+	if opts.AgentOverride != "" {
+		runtimeConfig, _, err = config.ResolveAgentConfigWithOverride(townRoot, m.rig.Path, opts.AgentOverride)
+		if err != nil {
+			return fmt.Errorf("resolving agent config for %s: %w", opts.AgentOverride, err)
+		}
+	} else {
+		runtimeConfig = config.ResolveWorkerAgentConfig(name, townRoot, m.rig.Path)
+	}
 	crewSettingsDir := config.RoleSettingsDir("crew", m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(crewSettingsDir, worker.ClonePath, "crew", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
@@ -889,16 +897,23 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 			_ = t.AcceptStartupDialogs(sessionID)
 		}
 
-		// Start background nudge-queue poller for ALL agents (gt-dgf).
+		// Start a background nudge-queue poller unless the runtime owns queue
+		// delivery through a structured transport (for example OpenCode HTTP).
 		// Claude drains its queue via UserPromptSubmit hook, but that hook only
 		// fires when the agent submits a prompt. Idle agents (waiting at prompt
 		// for work) never submit, so queued nudges deadlock: agent waits for
 		// nudge, nudge waits for agent input. The poller breaks this cycle by
 		// polling every 10s and delivering when idle. Drain() is atomic so the
 		// poller and UserPromptSubmit hook coexist safely.
-		if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
-			// Non-fatal — nudges may be delayed but the agent still works.
-			style.PrintWarning("could not start nudge poller for %s: %v", name, pollerErr)
+		if runtimeConfig.ManagesNudgeQueue {
+			if pollerErr := nudge.StopPoller(townRoot, sessionID); pollerErr != nil {
+				style.PrintWarning("could not stop stale nudge poller for %s: %v", name, pollerErr)
+			}
+		} else {
+			if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+				// Non-fatal — nudges may be delayed but the agent still works.
+				style.PrintWarning("could not start nudge poller for %s: %v", name, pollerErr)
+			}
 		}
 	}
 

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	gtgit "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
@@ -196,6 +198,18 @@ func (d *Daemon) executeLifecycleAction(request *LifecycleRequest) error {
 		return nil
 
 	case ActionCycle, ActionRestart:
+		agentOverride := ""
+		runtimeOverrides := make(map[string]string)
+		if running {
+			if agent, envErr := d.tmux.GetEnvironment(sessionName, "GT_AGENT"); envErr == nil {
+				agentOverride = strings.TrimSpace(agent)
+			}
+			for _, name := range config.OpenCodeOverrideEnvVars {
+				if value, envErr := d.tmux.GetEnvironment(sessionName, name); envErr == nil {
+					runtimeOverrides[name] = value
+				}
+			}
+		}
 		if running {
 			// Kill the session first - use KillSessionWithProcesses to prevent orphan processes.
 			if err := d.tmux.KillSessionWithProcesses(sessionName); err != nil {
@@ -208,7 +222,7 @@ func (d *Daemon) executeLifecycleAction(request *LifecycleRequest) error {
 		}
 
 		// Restart the session
-		if err := d.restartSession(sessionName, request.From); err != nil {
+		if err := d.restartSession(sessionName, request.From, agentOverride, runtimeOverrides); err != nil {
 			return fmt.Errorf("restarting session: %w", err)
 		}
 		d.logger.Printf("Restarted session %s", sessionName)
@@ -340,7 +354,7 @@ func (d *Daemon) identityToSession(identity string) string {
 
 // restartSession starts a new session for the given agent.
 // Uses role config if available, falls back to hardcoded defaults.
-func (d *Daemon) restartSession(sessionName, identity string) error {
+func (d *Daemon) restartSession(sessionName, identity, agentOverride string, runtimeOverrides map[string]string) error {
 	// Get role config for this identity
 	roleConfig, parsed, err := d.getRoleConfigForIdentity(identity)
 	if err != nil {
@@ -383,7 +397,10 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	// NewSessionWithCommand (command as initial pane process). This eliminates
 	// the race condition in the old EnsureSessionFresh + SendKeys pattern where
 	// the shell might not be ready to receive keystrokes, producing empty windows.
-	startCmd := d.getStartCommand(roleConfig, parsed)
+	startCmd := d.getStartCommandWithOverrides(roleConfig, parsed, sessionName, agentOverride, runtimeOverrides)
+	if startCmd == "" {
+		return fmt.Errorf("building lifecycle start command for %s", identity)
+	}
 
 	// Build core identity env vars to pass via -e flags. The startup command
 	// already embeds these via PrependEnv, but -e flags provide defense-in-depth:
@@ -391,11 +408,10 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	// global env values (e.g., BD_ACTOR=daemon inherited from the daemon process).
 	// Without this, a polecat session restarted by the daemon could inherit
 	// BD_ACTOR=daemon and have gt done reject it with "you are daemon" (gt-xyr).
-	rigPath := ""
-	if parsed != nil && parsed.RigName != "" {
-		rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
+	rc, err := d.resolveLifecycleRuntime(parsed, agentOverride)
+	if err != nil {
+		return err
 	}
-	rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
 	var sessionIDEnv string
 	if rc.Session != nil {
 		sessionIDEnv = rc.Session.SessionIDEnv
@@ -406,7 +422,17 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 		AgentName:    parsed.AgentName,
 		TownRoot:     d.config.TownRoot,
 		SessionIDEnv: sessionIDEnv,
+		Agent:        agentOverride,
+		SessionName:  sessionName,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, rc)
+	for key, value := range rc.Env {
+		envVars[key] = value
+	}
+	applyRuntimeOverrides(envVars, runtimeOverrides)
+	if workKey, workKeyErr := gtgit.NewGit(workDir).WorkKey(); workKeyErr == nil && workKey != "" {
+		envVars["GT_BRANCH"] = workKey
+	}
 	config.SanitizeAgentEnv(envVars, map[string]string{})
 
 	// Create session with command as initial process (replaces EnsureSessionFresh + SendKeys).
@@ -421,7 +447,7 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	}
 
 	// Set environment variables in tmux session table (for debugging/monitoring tools).
-	d.setSessionEnvironment(sessionName, roleConfig, parsed)
+	d.setSessionEnvironment(sessionName, roleConfig, parsed, rc, agentOverride, runtimeOverrides)
 
 	// Apply theme (non-fatal: theming failure doesn't affect operation)
 	d.applySessionTheme(sessionName, parsed)
@@ -431,6 +457,11 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 		// Non-fatal - Claude might still start
 	}
 	_ = d.tmux.AcceptStartupDialogs(sessionName)
+	if rc.ManagesNudgeQueue {
+		if pollerErr := nudge.StopPoller(d.config.TownRoot, sessionName); pollerErr != nil {
+			d.logger.Printf("Could not stop stale nudge poller for %s: %v", sessionName, pollerErr)
+		}
+	}
 	time.Sleep(constants.ShutdownNotifyDelay)
 
 	return nil
@@ -441,7 +472,20 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 func (d *Daemon) getWorkDir(config *beads.RoleConfig, parsed *ParsedIdentity) string {
 	// If role config has work_dir_pattern, use it
 	if config != nil && config.WorkDirPattern != "" {
-		return beads.ExpandRolePattern(config.WorkDirPattern, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
+		configured := beads.ExpandRolePattern(config.WorkDirPattern, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
+		if parsed.RoleType == constants.RoleDeacon && filepath.Clean(configured) == filepath.Clean(d.config.TownRoot) {
+			return filepath.Join(d.config.TownRoot, "deacon")
+		}
+		if parsed.RoleType == constants.RolePolecat {
+			parent := filepath.Join(d.config.TownRoot, parsed.RigName, "polecats", parsed.AgentName)
+			nested := filepath.Join(parent, parsed.RigName)
+			if filepath.Clean(configured) == filepath.Clean(parent) {
+				if info, err := os.Stat(nested); err == nil && info.IsDir() {
+					return nested
+				}
+			}
+		}
+		return configured
 	}
 
 	// Fallback: use default patterns based on role type
@@ -449,7 +493,7 @@ func (d *Daemon) getWorkDir(config *beads.RoleConfig, parsed *ParsedIdentity) st
 	case constants.RoleMayor:
 		return d.config.TownRoot
 	case constants.RoleDeacon:
-		return d.config.TownRoot
+		return filepath.Join(d.config.TownRoot, "deacon")
 	case constants.RoleWitness:
 		return filepath.Join(d.config.TownRoot, parsed.RigName)
 	case constants.RoleRefinery:
@@ -497,18 +541,29 @@ func isBuiltinClaudeStartCommand(cmd string) bool {
 // getStartCommand determines the startup command for an agent.
 // Uses role config if available, then role-based agent selection, then hardcoded defaults.
 // Includes beacon + role-specific instructions in the CLI prompt.
-func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIdentity) string {
+func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIdentity, restart ...string) string {
+	sessionName := ""
+	agentOverride := ""
+	if len(restart) > 0 {
+		sessionName = restart[0]
+	}
+	if len(restart) > 1 {
+		agentOverride = restart[1]
+	}
+	return d.getStartCommandWithOverrides(roleConfig, parsed, sessionName, agentOverride, nil)
+}
+
+func (d *Daemon) getStartCommandWithOverrides(roleConfig *beads.RoleConfig, parsed *ParsedIdentity, sessionName, agentOverride string, runtimeOverrides map[string]string) string {
+	runtimeConfig, resolveErr := d.resolveLifecycleRuntime(parsed, agentOverride)
+	if resolveErr != nil {
+		return ""
+	}
 	// Role config start_command: only use when the resolved agent is Claude.
 	// Built-in role TOMLs hardcode "exec claude ..." which bypasses the
 	// declarative agent resolution system. Fall through to agent resolution
 	// so non-Claude agents (copilot, codex, etc.) get the correct command.
 	if roleConfig != nil && roleConfig.StartCommand != "" {
-		rigPath := ""
-		if parsed != nil && parsed.RigName != "" {
-			rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
-		}
-		rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
-		if !config.IsResolvedAgentClaude(rc) {
+		if !config.IsResolvedAgentClaude(runtimeConfig) {
 			// Non-Claude agent: skip TOML start_command entirely (GH#2417).
 			// Built-in role TOMLs hardcode "exec claude ..." which is wrong
 			// for non-Claude agents. Fall through to BuildStartupCommandFromConfig
@@ -527,14 +582,6 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 		// Claude agent with built-in start_command: fall through to
 		// BuildStartupCommandFromConfig for proper model flag resolution.
 	}
-
-	rigPath := ""
-	if parsed != nil && parsed.RigName != "" {
-		rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
-	}
-
-	// Use role-based agent resolution for per-role model selection
-	runtimeConfig := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
 
 	// Build recipient for beacon using non-path format to prevent LLMs
 	// from misinterpreting the recipient as a filesystem path.
@@ -564,14 +611,48 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 		AgentName:    parsed.AgentName,
 		TownRoot:     d.config.TownRoot,
 		SessionIDEnv: sessionIDEnv,
+		Agent:        agentOverride,
+		SessionName:  sessionName,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
+	for key, value := range runtimeConfig.Env {
+		envVars[key] = value
+	}
+	for key, value := range runtimeOverrides {
+		envVars[key] = value
+	}
 	config.SanitizeAgentEnv(envVars, map[string]string{})
-	return config.PrependEnv("exec "+runtimeConfig.BuildCommandWithPrompt(prompt), envVars)
+	runtimeCommand := runtimeConfig.BuildCommandWithPrompt(prompt)
+	if runtime.GOOS != "windows" {
+		runtimeCommand = "exec " + runtimeCommand
+	}
+	return config.PrependEnv(runtimeCommand, envVars)
+}
+
+func (d *Daemon) resolveLifecycleRuntime(parsed *ParsedIdentity, agentOverride string) (*config.RuntimeConfig, error) {
+	if parsed == nil {
+		return nil, fmt.Errorf("lifecycle identity is required")
+	}
+	rigPath := ""
+	if parsed != nil && parsed.RigName != "" {
+		rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
+	}
+	if agentOverride != "" {
+		runtimeConfig, _, err := config.ResolveAgentConfigWithOverride(d.config.TownRoot, rigPath, agentOverride)
+		if err != nil {
+			return nil, fmt.Errorf("resolving lifecycle agent %s: %w", agentOverride, err)
+		}
+		return runtimeConfig, nil
+	}
+	if parsed.RoleType == constants.RoleCrew && parsed.AgentName != "" {
+		return config.ResolveWorkerAgentConfig(parsed.AgentName, d.config.TownRoot, rigPath), nil
+	}
+	return config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath), nil
 }
 
 // setSessionEnvironment sets environment variables for the tmux session.
 // Uses centralized AgentEnv for consistency, plus custom env vars from role config if available.
-func (d *Daemon) setSessionEnvironment(sessionName string, roleConfig *beads.RoleConfig, parsed *ParsedIdentity) {
+func (d *Daemon) setSessionEnvironment(sessionName string, roleConfig *beads.RoleConfig, parsed *ParsedIdentity, runtimeConfig *config.RuntimeConfig, agentOverride string, runtimeOverrides map[string]string) {
 	// Resolve CLAUDE_CONFIG_DIR from accounts.json so daemon-restarted sessions
 	// use the correct account. Mirrors the crew startup path (start.go).
 	accountsPath := constants.MayorAccountsPath(d.config.TownRoot)
@@ -588,7 +669,10 @@ func (d *Daemon) setSessionEnvironment(sessionName string, roleConfig *beads.Rol
 		TownRoot:         d.config.TownRoot,
 		RuntimeConfigDir: runtimeConfigDir,
 		SessionName:      sessionName,
+		Agent:            agentOverride,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
+	applyRuntimeOverrides(envVars, runtimeOverrides)
 	for k, v := range envVars {
 		_ = d.tmux.SetEnvironment(sessionName, k, v)
 	}
@@ -609,6 +693,12 @@ func (d *Daemon) setSessionEnvironment(sessionName string, roleConfig *beads.Rol
 			expanded := beads.ExpandRolePattern(v, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
 			_ = d.tmux.SetEnvironment(sessionName, k, expanded)
 		}
+	}
+}
+
+func applyRuntimeOverrides(envVars, runtimeOverrides map[string]string) {
+	for key, value := range runtimeOverrides {
+		envVars[key] = value
 	}
 }
 

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/session"
 )
 
@@ -572,5 +573,83 @@ func TestGetStartCommand_ClaudeAgentFallsThrough(t *testing.T) {
 	// path adds beacon injection and model flags.
 	if startCmd == "exec claude --dangerously-skip-permissions" {
 		t.Errorf("getStartCommand returned literal TOML start_command verbatim — beacon injection was skipped: %q", startCmd)
+	}
+}
+
+func TestGetStartCommandPreservesOpenCodeWorkerSession(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(io.Discard, "", 0),
+	}
+	parsed := &ParsedIdentity{RoleType: constants.RoleCrew, RigName: "gastown", AgentName: "alice"}
+	command := d.getStartCommand(nil, parsed, "gt-crew-alice", string(config.AgentOpenCodeServer))
+
+	if !strings.Contains(command, "opencode-worker") {
+		t.Fatalf("restart command = %q, want OpenCode worker", command)
+	}
+	if !strings.Contains(command, "GT_SESSION") || !strings.Contains(command, "gt-crew-alice") {
+		t.Fatalf("restart command lost GT_SESSION: %q", command)
+	}
+	if !strings.Contains(command, "GT_AGENT") || !strings.Contains(command, string(config.AgentOpenCodeServer)) {
+		t.Fatalf("restart command lost effective agent: %q", command)
+	}
+	if !strings.Contains(command, "OPENCODE_PERMISSION") {
+		t.Fatalf("restart command lost OpenCode runtime environment: %q", command)
+	}
+}
+
+func TestGetWorkDirUsesCanonicalStructuredWorkerDirectories(t *testing.T) {
+	townRoot := t.TempDir()
+	d := &Daemon{config: &Config{TownRoot: townRoot}, logger: log.New(io.Discard, "", 0)}
+
+	nestedPolecat := filepath.Join(townRoot, "gastown", "polecats", "furiosa", "gastown")
+	if err := os.MkdirAll(nestedPolecat, 0755); err != nil {
+		t.Fatal(err)
+	}
+	polecatRole := &beads.RoleConfig{WorkDirPattern: "{town}/{rig}/polecats/{name}"}
+	if got := d.getWorkDir(polecatRole, &ParsedIdentity{RoleType: constants.RolePolecat, RigName: "gastown", AgentName: "furiosa"}); got != nestedPolecat {
+		t.Fatalf("polecat work dir = %q, want %q", got, nestedPolecat)
+	}
+
+	deaconDir := filepath.Join(townRoot, "deacon")
+	deaconRole := &beads.RoleConfig{WorkDirPattern: "{town}"}
+	if got := d.getWorkDir(deaconRole, &ParsedIdentity{RoleType: constants.RoleDeacon}); got != deaconDir {
+		t.Fatalf("deacon work dir = %q, want %q", got, deaconDir)
+	}
+	if got := d.getWorkDir(nil, &ParsedIdentity{RoleType: constants.RoleDeacon}); got != deaconDir {
+		t.Fatalf("fallback deacon work dir = %q, want %q", got, deaconDir)
+	}
+}
+
+func TestGetStartCommandUsesCapturedOpenCodeOverrides(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GT_OPENCODE_MODEL", "daemon/model")
+	d := &Daemon{config: &Config{TownRoot: townRoot}, logger: log.New(io.Discard, "", 0)}
+	parsed := &ParsedIdentity{RoleType: constants.RoleCrew, RigName: "gastown", AgentName: "alice"}
+	command := d.getStartCommandWithOverrides(nil, parsed, "gt-crew-alice", string(config.AgentOpenCodeServer), map[string]string{
+		"GT_OPENCODE_MODEL": "session/model",
+	})
+	if !strings.Contains(command, "session/model") || strings.Contains(command, "daemon/model") {
+		t.Fatalf("restart command did not preserve captured override: %q", command)
+	}
+}
+
+func TestApplyRuntimeOverridesWins(t *testing.T) {
+	envVars := map[string]string{
+		"GT_OPENCODE_MODEL": "daemon/model",
+		"GT_AGENT":          "opencode-server",
+	}
+	applyRuntimeOverrides(envVars, map[string]string{
+		"GT_OPENCODE_MODEL": "session/model",
+	})
+	if envVars["GT_OPENCODE_MODEL"] != "session/model" {
+		t.Fatalf("GT_OPENCODE_MODEL = %q, want captured session override", envVars["GT_OPENCODE_MODEL"])
 	}
 }

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -30,6 +31,7 @@ type tmuxOps interface {
 	NewSessionWithCommandAndEnv(name, workDir, command string, env map[string]string) error
 	SetRemainOnExit(pane string, on bool) error
 	SetEnvironment(session, key, value string) error
+	GetEnvironment(session, key string) (string, error)
 	GetPaneID(session string) (string, error)
 	ConfigureGasTownSession(session string, theme *tmux.Theme, rig, worker, role string) error
 	WaitForCommand(session string, excludeCommands []string, timeout time.Duration) error
@@ -84,6 +86,14 @@ func (m *Manager) startNudgePoller(sessionID string) {
 	}
 }
 
+func (m *Manager) reconcileNudgePoller(sessionID string, runtimeConfig *config.RuntimeConfig) {
+	if runtimeConfig != nil && runtimeConfig.ManagesNudgeQueue {
+		m.stopNudgePoller(sessionID)
+		return
+	}
+	m.startNudgePoller(sessionID)
+}
+
 func (m *Manager) stopNudgePoller(sessionID string) {
 	if m.stopPoller == nil {
 		return
@@ -102,10 +112,23 @@ func (m *Manager) Start(agentOverride string) error {
 
 	// Check if session already exists
 	running, _ := t.HasSession(sessionID)
+	effectiveAgent := strings.TrimSpace(agentOverride)
+	if running {
+		if current, err := t.GetEnvironment(sessionID, "GT_AGENT"); err == nil {
+			if current = strings.TrimSpace(current); current != "" {
+				effectiveAgent = current
+			}
+		}
+	}
+	deaconDir := m.deaconDir()
 	if running {
 		// Session exists - check if agent is actually running (healthy vs zombie)
 		if t.IsAgentAlive(sessionID) {
-			m.startNudgePoller(sessionID)
+			var runtimeConfig *config.RuntimeConfig
+			if effectiveAgent != "" {
+				runtimeConfig, _, _ = config.ResolveAgentConfigWithOverride(m.townRoot, "", effectiveAgent)
+			}
+			m.reconcileNudgePoller(sessionID, runtimeConfig)
 			return ErrAlreadyRunning
 		}
 
@@ -118,15 +141,23 @@ func (m *Manager) Start(agentOverride string) error {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
+	var runtimeConfig *config.RuntimeConfig
+	if effectiveAgent != "" {
+		var err error
+		runtimeConfig, _, err = config.ResolveAgentConfigWithOverride(m.townRoot, "", effectiveAgent)
+		if err != nil {
+			return fmt.Errorf("resolving deacon agent %s: %w", effectiveAgent, err)
+		}
+	} else {
+		runtimeConfig = config.ResolveRoleAgentConfig("deacon", m.townRoot, "")
+	}
 
 	// Ensure deacon directory exists
-	deaconDir := m.deaconDir()
 	if err := os.MkdirAll(deaconDir, 0755); err != nil {
 		return fmt.Errorf("creating deacon directory: %w", err)
 	}
 
 	// Ensure runtime settings exist in deaconDir where session runs.
-	runtimeConfig := config.ResolveRoleAgentConfig("deacon", m.townRoot, deaconDir)
 	if err := runtime.EnsureSettingsForRole(deaconDir, deaconDir, "deacon", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
@@ -142,7 +173,7 @@ func (m *Manager) Start(agentOverride string) error {
 		Prompt:      initialPrompt,
 		Topic:       "patrol",
 		SessionName: sessionID,
-	}, "", initialPrompt, agentOverride)
+	}, "", initialPrompt, effectiveAgent)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)
 	}
@@ -153,7 +184,7 @@ func (m *Manager) Start(agentOverride string) error {
 	envVars := config.AgentEnv(config.AgentEnvConfig{
 		Role:        "deacon",
 		TownRoot:    m.townRoot,
-		Agent:       agentOverride,
+		Agent:       effectiveAgent,
 		SessionName: sessionID,
 	})
 	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
@@ -203,7 +234,7 @@ func (m *Manager) Start(agentOverride string) error {
 
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear.
 	_ = t.AcceptStartupDialogs(sessionID)
-	m.startNudgePoller(sessionID)
+	m.reconcileNudgePoller(sessionID, runtimeConfig)
 
 	time.Sleep(constants.ShutdownNotifyDelay)
 

--- a/internal/deacon/manager_test.go
+++ b/internal/deacon/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -20,6 +21,7 @@ type mockTmux struct {
 	sessionInfo      *tmux.SessionInfo
 	sessionInfoErr   error
 	sendKeysErr      error
+	agentEnvironment string
 
 	// Call tracking
 	killCalls       []string
@@ -51,7 +53,13 @@ func (m *mockTmux) NewSessionWithCommandAndEnv(_, _, _ string, _ map[string]stri
 
 func (m *mockTmux) SetRemainOnExit(_ string, _ bool) error { return nil }
 func (m *mockTmux) SetEnvironment(_, _, _ string) error    { return nil }
-func (m *mockTmux) GetPaneID(_ string) (string, error)     { return "%0", nil }
+func (m *mockTmux) GetEnvironment(_, key string) (string, error) {
+	if key == "GT_AGENT" {
+		return m.agentEnvironment, nil
+	}
+	return "", nil
+}
+func (m *mockTmux) GetPaneID(_ string) (string, error) { return "%0", nil }
 func (m *mockTmux) ConfigureGasTownSession(_ string, _ *tmux.Theme, _, _, _ string) error {
 	return nil
 }
@@ -147,6 +155,40 @@ func TestStart_AlreadyRunningRepairsNudgePoller(t *testing.T) {
 	}
 }
 
+func TestStartAlreadyRunningUsesActualManagedAlias(t *testing.T) {
+	townRoot := t.TempDir()
+	settings := config.NewTownSettings()
+	settings.Agents = map[string]*config.RuntimeConfig{
+		"server-alias": {Provider: string(config.AgentOpenCodeServer)},
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), settings); err != nil {
+		t.Fatal(err)
+	}
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       true,
+		agentEnvironment: "server-alias",
+	}
+	m := newTestManager(townRoot, mock)
+	var starts, stops int
+	m.startPoller = func(_, _ string) (int, error) {
+		starts++
+		return 0, nil
+	}
+	m.stopPoller = func(_, _ string) error {
+		stops++
+		return nil
+	}
+
+	err := m.Start("claude")
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("Start = %v, want ErrAlreadyRunning", err)
+	}
+	if starts != 0 || stops != 1 {
+		t.Fatalf("poller calls = start %d, stop %d; want start 0, stop 1", starts, stops)
+	}
+}
+
 func TestStart_ZombieDetected_KillFails(t *testing.T) {
 	killErr := errors.New("kill failed: session locked")
 	mock := &mockTmux{
@@ -231,6 +273,27 @@ func TestStart_SuccessStartsNudgePoller(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("startPoller calls = %d, want 1", calls)
+	}
+}
+
+func TestStart_ManagedRuntimeStopsNudgePoller(t *testing.T) {
+	mock := &mockTmux{hasSessionResult: false}
+	m := newTestManager(t.TempDir(), mock)
+	var starts, stops int
+	m.startPoller = func(_, _ string) (int, error) {
+		starts++
+		return 123, nil
+	}
+	m.stopPoller = func(_, _ string) error {
+		stops++
+		return nil
+	}
+
+	if err := m.Start(string(config.AgentOpenCodeServer)); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if starts != 0 || stops != 1 {
+		t.Fatalf("poller calls = start %d, stop %d; want start 0, stop 1", starts, stops)
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1327,6 +1327,21 @@ func (g *Git) CurrentBranch() (string, error) {
 	return g.run("rev-parse", "--abbrev-ref", "HEAD")
 }
 
+// WorkKey returns the current branch, or the exact commit SHA when HEAD is
+// detached. It is suitable for durable state that must not conflate detached
+// revisions under the literal branch name "HEAD".
+func (g *Git) WorkKey() (string, error) {
+	branch, err := g.CurrentBranch()
+	if err != nil {
+		return "", err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch != "" && branch != "HEAD" {
+		return branch, nil
+	}
+	return g.Rev("HEAD")
+}
+
 // DefaultBranch returns the default branch name (what HEAD points to).
 // This works for both regular and bare repositories.
 // Returns "main" as fallback if detection fails.

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -84,6 +84,7 @@ func needsUpgrade(content []byte) bool {
 	if bytes.Contains(content, []byte(`Gas Town OpenCode plugin`)) {
 		return bytes.Contains(content, []byte(`captureRun("gt prime")`)) ||
 			bytes.Contains(content, []byte("$`gt prime`")) ||
+			bytes.Contains(content, []byte("return await $`/bin/sh -lc ${cmd}`.cwd(directory).text();")) ||
 			!bytes.Contains(content, []byte(`prime --hook`))
 	}
 	return false

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -242,17 +242,48 @@ func TestOpenCodeTemplateFailureDiagnostics(t *testing.T) {
 	for _, want := range []string{
 		"command: ${cmd}",
 		"exit_code:",
-		"exit code 124",
 		"timeout:",
 		"stdout_tail:",
 		"stderr_tail:",
-		"timeout 10s ${gtCommand()} dolt status 2>&1",
+		"status_timeout_ms: 10000",
 		"dolt_status_tail:",
 		"suggested_recovery:",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("opencode template missing diagnostic field %q", want)
 		}
+	}
+}
+
+func TestOpenCodeTemplateUsesCrossPlatformProcessExecution(t *testing.T) {
+	template, err := templateFS.ReadFile("templates/opencode/gastown.js")
+	if err != nil {
+		t.Fatalf("read opencode template: %v", err)
+	}
+	content := string(template)
+	for _, want := range []string{
+		"Bun.spawn(options)",
+		"cmd: [gtBin, ...args]",
+		"env: { ...process.env, ...env }",
+		"runGT(args, env, commandTimeoutMs)",
+		`["prime", "--hook"]`,
+		"event?.properties?.sessionID",
+		"const primePromises = new Map()",
+		"primePromises.get(sessionID)",
+		"primePromises.delete(eventSessionID(event))",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("opencode template missing cross-platform execution field %q", want)
+		}
+	}
+	if strings.Contains(content, "/bin/sh") {
+		t.Fatal("opencode template must not require a POSIX shell")
+	}
+	if strings.Contains(content, `["costs", "record"`) {
+		t.Fatal("opencode template must not call the Claude-only costs recorder")
+	}
+	if strings.Contains(content, "let didInit") {
+		t.Fatal("opencode template must not share initialization state across sessions")
 	}
 }
 
@@ -263,8 +294,8 @@ func TestOpenCodeTemplateUsesHookPrime(t *testing.T) {
 	}
 	content := string(template)
 	for _, want := range []string{
-		"GT_HOOK_SOURCE=",
-		"GT_SESSION_ID=",
+		"GT_HOOK_SOURCE",
+		"GT_SESSION_ID",
 		"prime --hook",
 		"gt prime --hook",
 	} {
@@ -344,6 +375,39 @@ export const GasTown = async ({ $ }) => {
 	}
 }
 
+func TestInstallForRole_UpgradesOpenCodePOSIXShellWrapper(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := `// Gas Town OpenCode plugin: hooks SessionStart/Compaction via events.
+export const GasTown = async ({ $ }) => {
+  const captureRun = async (cmd) => {
+    return await $` + "`" + `/bin/sh -lc ${cmd}` + "`" + `.cwd(directory).text();
+  };
+}`
+	if err := os.WriteFile(hooksPath, []byte(stale), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false); err != nil {
+		t.Fatalf("InstallForRole: %v", err)
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read upgraded hook: %v", err)
+	}
+	if strings.Contains(string(got), "/bin/sh") {
+		t.Fatal("stale POSIX shell wrapper was not upgraded")
+	}
+	if !strings.Contains(string(got), "Bun.spawn(options)") {
+		t.Fatal("upgraded hook does not use cross-platform process execution")
+	}
+}
+
 func TestOpenCodeTemplateUsesHookModeAndCompoundRoles(t *testing.T) {
 	content, err := resolveAndSubstitute("opencode", "gastown.js", "polecat")
 	if err != nil {
@@ -352,8 +416,8 @@ func TestOpenCodeTemplateUsesHookModeAndCompoundRoles(t *testing.T) {
 	s := string(content)
 	for _, want := range []string{
 		"prime --hook",
-		"GT_HOOK_SOURCE=",
-		"GT_SESSION_ID=",
+		"GT_HOOK_SOURCE",
+		"GT_SESSION_ID",
 		`parts[1] === "polecats"`,
 	} {
 		if !strings.Contains(s, want) {

--- a/internal/hooks/opencode_plugin_test.go
+++ b/internal/hooks/opencode_plugin_test.go
@@ -1,0 +1,150 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	openCodeHookHelperEnv = "GO_WANT_OPENCODE_HOOK_HELPER"
+	openCodeHookHangEnv   = "GO_OPENCODE_HOOK_HELPER_HANG"
+	openCodeHookLogEnv    = "GO_OPENCODE_HOOK_HELPER_LOG"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(openCodeHookHelperEnv) == "1" {
+		os.Exit(runOpenCodeHookHelper())
+	}
+	os.Exit(m.Run())
+}
+
+func runOpenCodeHookHelper() int {
+	args := os.Args[1:]
+	if logPath := os.Getenv(openCodeHookLogEnv); logPath != "" {
+		file, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		_, writeErr := fmt.Fprintf(file, "%s|source=%s|session=%s\n",
+			strings.Join(args, " "), os.Getenv("GT_HOOK_SOURCE"), os.Getenv("GT_SESSION_ID"))
+		closeErr := file.Close()
+		if writeErr != nil || closeErr != nil {
+			fmt.Fprintln(os.Stderr, "writing hook helper log failed")
+			return 2
+		}
+	}
+
+	if len(args) >= 1 && args[0] == "prime" {
+		if os.Getenv(openCodeHookHangEnv) == "1" {
+			time.Sleep(time.Minute)
+		}
+		fmt.Printf("HOOK_CONTEXT source=%s session=%s\n", os.Getenv("GT_HOOK_SOURCE"), os.Getenv("GT_SESSION_ID"))
+	}
+	return 0
+}
+
+func TestOpenCodePluginLifecycleIsSessionScoped(t *testing.T) {
+	bun, err := exec.LookPath("bun")
+	if err != nil {
+		t.Skip("bun is required for the OpenCode plugin behavior test")
+	}
+
+	dir := t.TempDir()
+	pluginPath := filepath.Join(dir, "gastown.js")
+	plugin, err := resolveAndSubstitute("opencode", "gastown.js", "crew")
+	if err != nil {
+		t.Fatalf("resolve OpenCode plugin: %v", err)
+	}
+	if err := os.WriteFile(pluginPath, plugin, 0644); err != nil {
+		t.Fatalf("write OpenCode plugin: %v", err)
+	}
+
+	harnessPath := filepath.Join(dir, "harness.js")
+	if err := os.WriteFile(harnessPath, []byte(openCodePluginHarness), 0644); err != nil {
+		t.Fatalf("write OpenCode plugin harness: %v", err)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	logPath := filepath.Join(dir, "invocations.log")
+
+	cmd := exec.Command(bun, harnessPath, pluginPath, testBinary, logPath, dir)
+	cmd.Env = append(os.Environ(),
+		openCodeHookHelperEnv+"=1",
+		openCodeHookLogEnv+"="+logPath,
+		"GT_ROLE=testrig/crew/alice",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("OpenCode plugin behavior test failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "OpenCode plugin behavior test passed") {
+		t.Fatalf("OpenCode plugin behavior test did not complete:\n%s", output)
+	}
+}
+
+const openCodePluginHarness = `
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+
+const [pluginPath, helperPath, logPath, workDir] = process.argv.slice(2);
+process.env.GT_BIN = helperPath;
+process.env.GO_OPENCODE_HOOK_HELPER_LOG = logPath;
+
+const { GasTown } = await import(pathToFileURL(pluginPath).href);
+const plugin = await GasTown({ directory: workDir });
+
+const create = async (sessionID) => {
+  await plugin.event({ event: { type: "session.created", properties: { sessionID } } });
+};
+const transform = async (sessionID) => {
+  const output = { system: [] };
+  await plugin["experimental.chat.system.transform"]({ sessionID }, output);
+  return output.system;
+};
+
+await create("ses-a");
+await create("ses-b");
+assert.deepEqual(await transform("ses-a"), ["HOOK_CONTEXT source=startup session=ses-a\n"]);
+assert.deepEqual(await transform("ses-b"), ["HOOK_CONTEXT source=startup session=ses-b\n"]);
+assert.deepEqual(await transform("ses-a"), ["HOOK_CONTEXT source=startup session=ses-a\n"]);
+
+await plugin.event({ event: { type: "session.compacted", properties: { sessionID: "ses-b" } } });
+assert.deepEqual(await transform("ses-b"), ["HOOK_CONTEXT source=compact session=ses-b\n"]);
+
+await plugin.event({ event: { type: "session.deleted", properties: { sessionID: "ses-a" } } });
+assert.deepEqual(await transform("ses-a"), ["HOOK_CONTEXT source=startup session=ses-a\n"]);
+
+const invocations = (await Bun.file(logPath).text()).trim().split("\n");
+assert.equal(invocations.filter((line) => line === "prime --hook|source=startup|session=ses-a").length, 2);
+assert.equal(invocations.filter((line) => line === "prime --hook|source=startup|session=ses-b").length, 1);
+assert.equal(invocations.filter((line) => line === "prime --hook|source=compact|session=ses-b").length, 1);
+assert.equal(invocations.some((line) => line.includes("costs record")), false);
+
+const timeoutPluginPath = logPath + ".timeout-plugin.js";
+const source = await Bun.file(pluginPath).text();
+const timeoutSource = source.replace("const commandTimeoutMs = 10_000;", "const commandTimeoutMs = 100;");
+assert.notEqual(timeoutSource, source);
+await Bun.write(timeoutPluginPath, timeoutSource);
+process.env.GO_OPENCODE_HOOK_HELPER_HANG = "1";
+const { GasTown: TimeoutGasTown } = await import(pathToFileURL(timeoutPluginPath).href);
+const timeoutPlugin = await TimeoutGasTown({ directory: workDir });
+await timeoutPlugin.event({ event: { type: "session.created", properties: { sessionID: "ses-timeout" } } });
+const started = performance.now();
+assert.deepEqual(await (async () => {
+  const output = { system: [] };
+  await timeoutPlugin["experimental.chat.system.transform"]({ sessionID: "ses-timeout" }, output);
+  return output.system;
+})(), []);
+delete process.env.GO_OPENCODE_HOOK_HELPER_HANG;
+assert.ok(performance.now() - started < 3000, "hook timeout did not terminate the child promptly");
+
+console.log("OpenCode plugin behavior test passed");
+`

--- a/internal/hooks/templates/opencode/gastown.js
+++ b/internal/hooks/templates/opencode/gastown.js
@@ -1,13 +1,13 @@
 // Gas Town OpenCode plugin: hooks SessionStart/Compaction via events.
 // Injects gt prime context into the system prompt via experimental.chat.system.transform.
-export const GasTown = async ({ $, directory }) => {
+export const GasTown = async ({ directory }) => {
   const role = (process.env.GT_ROLE || "").toLowerCase();
   const gtBin = process.env.GT_BIN || "gt";
-  let didInit = false;
+  const commandTimeoutMs = 10_000;
 
-  // Promise-based context loading ensures the system transform hook can
-  // await the result even if session.created hasn't resolved yet.
-  let primePromise = null;
+  // OpenCode loads one plugin instance per project, so context loading must be
+  // isolated by session even when several sessions share the same server.
+  const primePromises = new Map();
 
   const outputTail = (value, maxChars = 2000) => {
     if (value === undefined || value === null) return "<empty>";
@@ -33,24 +33,53 @@ export const GasTown = async ({ $, directory }) => {
     return null;
   };
 
-  const shellQuote = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
+  const commandLabel = (args) =>
+    [gtBin, ...args].map((value) => JSON.stringify(String(value))).join(" ");
 
-  const gtCommand = () => {
-    if (/^[A-Za-z0-9_./-]+$/.test(gtBin)) return gtBin;
-    return shellQuote(gtBin);
+  const isDoltBackedCommand = (args) =>
+    !(args[0] === "dolt" && args[1] === "status");
+
+  const runGT = async (args, env = {}, timeoutMs = 0) => {
+    const options = {
+      cmd: [gtBin, ...args],
+      cwd: directory,
+      env: { ...process.env, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    };
+    if (timeoutMs > 0) options.timeout = timeoutMs;
+
+    const child = Bun.spawn(options);
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    const timedOut = timeoutMs > 0 && child.signalCode != null;
+    if (code !== 0 || timedOut) {
+      const err = new Error(
+        timedOut
+          ? `${commandLabel(args)} timed out after ${timeoutMs}ms`
+          : `${commandLabel(args)} exited with code ${code}`
+      );
+      err.exitCode = code;
+      err.stdout = stdout;
+      err.stderr = stderr;
+      err.timedOut = timedOut;
+      throw err;
+    }
+    return stdout;
   };
 
-  const isDoltBackedCommand = (cmd) =>
-    /(^|\s)(?:'[^']*\/|[^'\s]*\/)?(?:gt|bd)'?\s/.test(cmd) &&
-    !/(^|\s)(?:'[^']*\/|[^'\s]*\/)?gt'?\s+dolt\s+status(\s|$)/.test(cmd);
-
   const captureDoltStatus = async () => {
-    const statusCmd = `timeout 10s ${gtCommand()} dolt status 2>&1`;
+    const args = ["dolt", "status"];
+    const statusCmd = commandLabel(args);
     try {
-      return await $`/bin/sh -lc ${statusCmd}`.cwd(directory).text();
+      return await runGT(args, {}, 10_000);
     } catch (err) {
       return [
         `status_command: ${statusCmd}`,
+        "status_timeout_ms: 10000",
         `status_error: ${err?.message || err}`,
         `status_stdout_tail: ${outputTail(err?.stdout)}`,
         `status_stderr_tail: ${outputTail(err?.stderr)}`,
@@ -58,11 +87,12 @@ export const GasTown = async ({ $, directory }) => {
     }
   };
 
-  const logFailure = async (cmd, err) => {
+  const logFailure = async (args, err) => {
+    const cmd = commandLabel(args);
     const code = exitCode(err);
     const message = err?.message || String(err);
-    const timeout = code === 124 || /exit code 124|timed?\s*out/i.test(message)
-      ? "yes (exit code 124 / timeout)"
+    const timeout = err?.timedOut || /timed?\s*out/i.test(message)
+      ? "yes"
       : "not indicated";
     const lines = [
       "[gastown] command failed",
@@ -73,7 +103,7 @@ export const GasTown = async ({ $, directory }) => {
       `stdout_tail: ${outputTail(err?.stdout)}`,
       `stderr_tail: ${outputTail(err?.stderr)}`,
     ];
-    if (isDoltBackedCommand(cmd)) {
+    if (isDoltBackedCommand(args)) {
       lines.push(`dolt_status_tail:\n${outputTail(await captureDoltStatus())}`);
       lines.push(
         "suggested_recovery: If Dolt is unhealthy or another gt/bd command is hanging, capture SIGQUIT and `gt dolt status` diagnostics before escalating; otherwise retry after the timeout clears."
@@ -93,59 +123,70 @@ export const GasTown = async ({ $, directory }) => {
     return parts[0];
   };
 
-  const eventSessionID = (event) => event?.properties?.info?.id || event?.sessionID || event?.session?.id || "";
+  const eventSessionID = (event) =>
+    event?.properties?.sessionID || event?.properties?.info?.id || event?.sessionID || event?.session?.id || "";
 
-  const captureRun = async (cmd) => {
+  const captureRun = async (args, env = {}) => {
     try {
-      // .text() captures stdout as a string and suppresses terminal echo.
-      return await $`/bin/sh -lc ${cmd}`.cwd(directory).text();
+      return await runGT(args, env, commandTimeoutMs);
     } catch (err) {
-      await logFailure(cmd, err);
+      await logFailure(args, err);
       return "";
     }
   };
 
   const loadPrime = async (source = "startup", sessionID = "") => {
-    const env = [`GT_HOOK_SOURCE=${shellQuote(source)}`];
+    const env = { GT_HOOK_SOURCE: source };
     if (sessionID) {
-      env.push(`GT_SESSION_ID=${shellQuote(sessionID)}`);
+      env.GT_SESSION_ID = sessionID;
     }
-    let context = await captureRun(`${env.join(" ")} ${gtCommand()} prime --hook`);
+    const context = await captureRun(["prime", "--hook"], env);
     // NOTE: session-started nudge to deacon removed — it interrupted
     // the deacon's await-signal backoff. Deacon wakes on beads activity.
     return context;
   };
 
+  const setPrime = (source, sessionID) => {
+    const promise = loadPrime(source, sessionID);
+    primePromises.set(sessionID, promise);
+    return promise;
+  };
+
+  // Do not call `gt costs record` on session.deleted: it reads Claude
+  // transcripts and OpenCode session IDs are not tmux session names.
   return {
     event: async ({ event }) => {
       if (event?.type === "session.created") {
-        if (didInit) return;
-        didInit = true;
-        // Start loading prime context early; system.transform will await it.
-        primePromise = loadPrime("startup", eventSessionID(event));
+        const sessionID = eventSessionID(event);
+        if (!primePromises.has(sessionID)) {
+          // Start loading prime context early; system.transform will await it.
+          setPrime("startup", sessionID);
+        }
       }
       if (event?.type === "session.compacted") {
         // Reset so next system.transform gets fresh context.
-        primePromise = loadPrime("compact", eventSessionID(event));
+        const sessionID = eventSessionID(event);
+        setPrime("compact", sessionID);
       }
       if (event?.type === "session.deleted") {
-        const sessionID = event.properties?.info?.id;
-        if (sessionID) {
-          await captureRun(`${gtCommand()} costs record --session ${shellQuote(sessionID)}`);
-        }
+        primePromises.delete(eventSessionID(event));
       }
     },
     "experimental.chat.system.transform": async (input, output) => {
+      const sessionID = input?.sessionID || "";
       // If session.created hasn't fired yet, start loading now.
+      let primePromise = primePromises.get(sessionID);
       if (!primePromise) {
-        primePromise = loadPrime("startup");
+        primePromise = setPrime("startup", sessionID);
       }
       const context = await primePromise;
       if (context) {
         output.system.push(context);
       } else {
         // Reset so next transform retries instead of pushing empty forever.
-        primePromise = null;
+        if (primePromises.get(sessionID) === primePromise) {
+          primePromises.delete(sessionID);
+        }
       }
     },
     "experimental.session.compacting": async ({ sessionID }, output) => {

--- a/internal/nudge/poller.go
+++ b/internal/nudge/poller.go
@@ -20,12 +20,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/steveyegge/gastown/internal/constants"
-	"github.com/steveyegge/gastown/internal/util"
 )
 
 // Poller tuning defaults (overridable via flags or tests).
@@ -94,7 +92,7 @@ func buildPollerCommand(gtBin, townRoot, session string) *exec.Cmd {
 	cmd.Dir = townRoot
 	cmd.Stdout = nil // discard
 	cmd.Stderr = nil // discard
-	util.SetDetachedProcessGroup(cmd)
+	cmd.SysProcAttr = detachedProcAttr()
 	return cmd
 }
 
@@ -128,12 +126,17 @@ func StopPoller(townRoot, session string) error {
 		return nil
 	}
 
-	// Send SIGTERM for graceful shutdown.
-	if err := proc.Signal(syscall.SIGTERM); err != nil {
-		_ = os.Remove(pidPath)
-		return fmt.Errorf("sending SIGTERM to poller (pid %d): %w", pid, err)
+	if err := terminateProcess(proc); err != nil && pollerProcessAlive(pid) {
+		return fmt.Errorf("terminating poller (pid %d): %w", pid, err)
 	}
 
+	deadline := time.Now().Add(2 * time.Second)
+	for pollerProcessAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(25 * time.Millisecond)
+	}
+	if pollerProcessAlive(pid) {
+		return fmt.Errorf("poller (pid %d) did not stop", pid)
+	}
 	_ = os.Remove(pidPath)
 	return nil
 }

--- a/internal/nudge/poller_process_windows.go
+++ b/internal/nudge/poller_process_windows.go
@@ -17,6 +17,11 @@ func pollerProcessAlive(pid int) bool {
 	if err != nil {
 		return err == windows.ERROR_ACCESS_DENIED
 	}
-	_ = windows.CloseHandle(handle)
-	return true
+	defer windows.CloseHandle(handle)
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false
+	}
+	const stillActive = 259
+	return exitCode == stillActive
 }

--- a/internal/nudge/poller_test.go
+++ b/internal/nudge/poller_test.go
@@ -7,8 +7,7 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
-
-	"github.com/steveyegge/gastown/internal/util"
+	"time"
 )
 
 func TestPollerPidFile(t *testing.T) {
@@ -170,14 +169,40 @@ func TestBuildPollerCommand_UsesDetachedProcessGroup(t *testing.T) {
 	}
 }
 
-func TestSetProcessGroup_InstallsCancelHook(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("SetProcessGroup is a no-op on Windows")
+func TestStopPollerTerminatesTrackedProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPollerHelperProcess$")
+	cmd.Env = append(os.Environ(), "GO_WANT_POLLER_HELPER=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
 	}
-	cmd := exec.Command("true")
-	util.SetProcessGroup(cmd)
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
 
-	if cmd.Cancel == nil {
-		t.Fatal("SetProcessGroup() should install a cancel hook")
+	townRoot := t.TempDir()
+	session := "gt-gastown-crew-test"
+	if err := os.MkdirAll(pollerPidDir(townRoot), 0755); err != nil {
+		t.Fatal(err)
 	}
+	if err := os.WriteFile(pollerPidFile(townRoot, session), []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := StopPoller(townRoot, session); err != nil {
+		t.Fatalf("StopPoller: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("tracked poller process was not terminated")
+	}
+	if _, err := os.Stat(pollerPidFile(townRoot, session)); !os.IsNotExist(err) {
+		t.Fatal("poller PID file remained after termination")
+	}
+}
+
+func TestPollerHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_POLLER_HELPER") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
 }

--- a/internal/nudge/queue.go
+++ b/internal/nudge/queue.go
@@ -11,8 +11,10 @@ package nudge
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,7 +48,7 @@ const (
 	MaxQueueDepth = 50
 
 	// staleClaimThreshold is how long a .claimed file must be untouched
-	// before Drain considers it orphaned (from a crashed drainer) and removes it.
+	// before Drain considers it orphaned (from a crashed drainer) and restores it.
 	staleClaimThreshold = 5 * time.Minute
 )
 
@@ -141,15 +143,61 @@ func Enqueue(townRoot, session string, nudge QueuedNudge) error {
 // Existing timestamps are preserved so FIFO ordering remains stable relative to
 // one another; only expired nudges are skipped.
 func Requeue(townRoot, session string, nudges []QueuedNudge) error {
+	var requeueErr error
 	for _, n := range nudges {
 		if !n.ExpiresAt.IsZero() && time.Now().After(n.ExpiresAt) {
 			continue
 		}
 		if err := Enqueue(townRoot, session, n); err != nil {
-			return err
+			requeueErr = errors.Join(requeueErr, err)
 		}
 	}
-	return nil
+	return requeueErr
+}
+
+type claimedNudge struct {
+	originalPath string
+	claimPath    string
+}
+
+// ClaimedNudges keeps queue files durably leased until the caller either
+// commits successful delivery or releases them for another attempt.
+type ClaimedNudges struct {
+	Nudges  []QueuedNudge
+	claims  []claimedNudge
+	message string
+}
+
+func (c *ClaimedNudges) MessageID() string {
+	return c.message
+}
+
+func (c *ClaimedNudges) Commit() error {
+	var commitErr error
+	remaining := c.claims[:0]
+	for _, claim := range c.claims {
+		if err := os.Remove(claim.claimPath); err != nil && !os.IsNotExist(err) {
+			commitErr = errors.Join(commitErr, err)
+			remaining = append(remaining, claim)
+		}
+	}
+	c.claims = remaining
+	return commitErr
+}
+
+func (c *ClaimedNudges) Release() error {
+	var releaseErr error
+	remaining := c.claims[:0]
+	for _, claim := range c.claims {
+		if err := os.Rename(claim.claimPath, claim.originalPath); err != nil {
+			if !os.IsNotExist(err) {
+				releaseErr = errors.Join(releaseErr, err)
+				remaining = append(remaining, claim)
+			}
+		}
+	}
+	c.claims = remaining
+	return releaseErr
 }
 
 // Drain reads and removes all queued nudges for a session, returning them
@@ -161,13 +209,23 @@ func Requeue(townRoot, session string, nudges []QueuedNudge) error {
 //
 // Expired nudges (past ExpiresAt) are silently discarded during drain.
 // Orphaned .claimed files from crashed drainers are swept if older than 5 minutes.
-func Drain(townRoot, session string) ([]QueuedNudge, error) {
+func Claim(townRoot, session string) (*ClaimedNudges, error) {
+	return claimNudges(townRoot, session, 0)
+}
+
+// ClaimOne leases the oldest deliverable nudge. A single-file claim gives the
+// HTTP worker a stable idempotency key even when new nudges arrive mid-retry.
+func ClaimOne(townRoot, session string) (*ClaimedNudges, error) {
+	return claimNudges(townRoot, session, 1)
+}
+
+func claimNudges(townRoot, session string, limit int) (*ClaimedNudges, error) {
 	dir := queueDir(townRoot, session)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return &ClaimedNudges{}, nil
 		}
 		return nil, fmt.Errorf("reading nudge queue: %w", err)
 	}
@@ -179,6 +237,7 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 	// it (which would permanently drop the nudge).
 	staleThreshold := nudgeConfig(townRoot).StaleClaimThresholdD()
 	now := time.Now()
+	restoredClaim := false
 	for _, entry := range entries {
 		if !strings.Contains(entry.Name(), ".claimed") {
 			continue
@@ -194,10 +253,16 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 			claimedIdx := strings.Index(name, ".claimed")
 			restoredPath := filepath.Join(dir, name[:claimedIdx])
 			if err := os.Rename(orphanPath, restoredPath); err != nil {
-				// Rename failed — remove as last resort to prevent infinite accumulation
 				fmt.Fprintf(os.Stderr, "Warning: failed to requeue orphaned claim %s: %v\n", entry.Name(), err)
-				_ = os.Remove(orphanPath)
+			} else {
+				restoredClaim = true
 			}
+		}
+	}
+	if restoredClaim {
+		entries, err = os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("rereading nudge queue after restoring claims: %w", err)
 		}
 	}
 
@@ -206,7 +271,8 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 		return entries[i].Name() < entries[j].Name()
 	})
 
-	var nudges []QueuedNudge
+	batch := &ClaimedNudges{}
+	hash := sha256.New()
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
@@ -226,6 +292,11 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 		claimPath := path + ".claimed." + randomSuffix()
 		if err := os.Rename(path, claimPath); err != nil {
 			// Another Drain got it first, or file was already removed
+			continue
+		}
+		claimTime := time.Now()
+		if err := os.Chtimes(claimPath, claimTime, claimTime); err != nil {
+			_ = os.Rename(claimPath, path)
 			continue
 		}
 
@@ -267,15 +338,31 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 			continue
 		}
 
-		nudges = append(nudges, n)
-
-		// Remove the claimed file after successful processing
-		if rmErr := os.Remove(claimPath); rmErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove processed claim %s: %v\n", entry.Name(), rmErr)
+		batch.Nudges = append(batch.Nudges, n)
+		batch.claims = append(batch.claims, claimedNudge{originalPath: path, claimPath: claimPath})
+		_, _ = hash.Write([]byte(entry.Name()))
+		_, _ = hash.Write([]byte{0})
+		if limit > 0 && len(batch.Nudges) >= limit {
+			break
 		}
 	}
 
-	return nudges, nil
+	if len(batch.claims) > 0 {
+		sum := hash.Sum(nil)
+		batch.message = "msg_gt_" + hex.EncodeToString(sum[:16])
+	}
+	return batch, nil
+}
+
+func Drain(townRoot, session string) ([]QueuedNudge, error) {
+	batch, err := Claim(townRoot, session)
+	if err != nil {
+		return nil, err
+	}
+	if err := batch.Commit(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to remove processed nudge claims: %v\n", err)
+	}
+	return batch.Nudges, nil
 }
 
 // Pending returns the count of queued nudges for a session without draining.

--- a/internal/nudge/queue_test.go
+++ b/internal/nudge/queue_test.go
@@ -70,6 +70,142 @@ func TestEnqueueAndDrain(t *testing.T) {
 	}
 }
 
+func TestClaimedNudgesReleaseAndCommit(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-gastown-crew-sean"
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "mayor", Message: "durable"}); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Claim(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Nudges) != 1 || !strings.HasPrefix(first.MessageID(), "msg") {
+		t.Fatalf("claim = %#v, message ID %q", first.Nudges, first.MessageID())
+	}
+	if pending, _ := Pending(townRoot, session); pending != 0 {
+		t.Fatalf("pending while claimed = %d, want 0", pending)
+	}
+	messageID := first.MessageID()
+	if err := first.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if pending, _ := Pending(townRoot, session); pending != 1 {
+		t.Fatalf("pending after release = %d, want 1", pending)
+	}
+
+	second, err := Claim(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.MessageID() != messageID {
+		t.Fatalf("message ID changed across retry: %q != %q", second.MessageID(), messageID)
+	}
+	if err := second.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if pending, _ := Pending(townRoot, session); pending != 0 {
+		t.Fatalf("pending after commit = %d, want 0", pending)
+	}
+}
+
+func TestClaimOneKeepsStableIdentityWhenQueueGrows(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-gastown-crew-sean"
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "mayor", Message: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ClaimOne(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "witness", Message: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	messageID := first.MessageID()
+	if err := first.Release(); err != nil {
+		t.Fatal(err)
+	}
+	retry, err := ClaimOne(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retry.Nudges) != 1 || retry.Nudges[0].Message != "first" || retry.MessageID() != messageID {
+		t.Fatalf("retry claim = %#v, message ID %q; want first/%q", retry.Nudges, retry.MessageID(), messageID)
+	}
+	if err := retry.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if pending, _ := Pending(townRoot, session); pending != 1 {
+		t.Fatalf("pending after first commit = %d, want second nudge", pending)
+	}
+}
+
+func TestClaimOneRefreshesLeaseTimestamp(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-gastown-crew-sean"
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "mayor", Message: "old but active"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(queueDir(townRoot, session))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("queue entries = %d, %v", len(entries), err)
+	}
+	old := time.Now().Add(-2 * staleClaimThreshold)
+	path := filepath.Join(queueDir(townRoot, session), entries[0].Name())
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	active, err := ClaimOne(townRoot, session)
+	if err != nil || len(active.Nudges) != 1 {
+		t.Fatalf("active claim = %#v, %v", active, err)
+	}
+	for i := 0; i < 2; i++ {
+		duplicate, err := ClaimOne(townRoot, session)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(duplicate.Nudges) != 0 {
+			t.Fatalf("claim %d duplicated active lease: %#v", i+1, duplicate.Nudges)
+		}
+	}
+	if err := active.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaimOneRestoresStaleClaimBeforeNewerNudge(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-gastown-crew-sean"
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "mayor", Message: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ClaimOne(townRoot, session)
+	if err != nil || len(first.claims) != 1 {
+		t.Fatalf("first claim = %#v, %v", first, err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{Sender: "witness", Message: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * staleClaimThreshold)
+	if err := os.Chtimes(first.claims[0].claimPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := ClaimOne(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recovered.Nudges) != 1 || recovered.Nudges[0].Message != "first" {
+		t.Fatalf("recovered claim = %#v, want oldest nudge", recovered.Nudges)
+	}
+	if err := recovered.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDrainEmptyQueue(t *testing.T) {
 	townRoot := t.TempDir()
 
@@ -408,41 +544,38 @@ func TestDrainSweepsOrphanedClaims(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// First Drain: requeues the orphaned claim (rename .claimed → .json),
-	// keeps the fresh claim, and returns the valid nudge.
-	// The requeued file isn't in the current ReadDir snapshot, so it's
-	// picked up on the next Drain call.
+	// Drain requeues the orphaned claim (rename .claimed to .json), refreshes
+	// the directory snapshot, and delivers it before the newer valid nudge.
+	// The fresh claim remains leased.
 	nudges, err := Drain(townRoot, session)
 	if err != nil {
 		t.Fatalf("Drain: %v", err)
 	}
-	if len(nudges) != 1 {
-		t.Fatalf("first Drain got %d nudges, want 1", len(nudges))
+	if len(nudges) != 2 {
+		t.Fatalf("Drain got %d nudges, want 2", len(nudges))
 	}
-	if nudges[0].Message != "valid" {
-		t.Errorf("got message %q, want %q", nudges[0].Message, "valid")
+	if nudges[0].Sender != "ghost" || nudges[1].Message != "valid" {
+		t.Errorf("Drain order = %#v, want restored orphan before valid nudge", nudges)
 	}
 
 	// The orphaned .claimed file should have been requeued as .json
 	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
 		t.Error("orphaned .claimed file should no longer exist (requeued to .json)")
 	}
-	// Restored path strips everything from ".claimed" onward
+	// Restored path strips everything from ".claimed" onward, then is
+	// committed after successful delivery.
 	restoredPath := filepath.Join(dir, "100.json")
-	if _, err := os.Stat(restoredPath); os.IsNotExist(err) {
-		t.Error("restored .json file should exist after requeue")
+	if _, err := os.Stat(restoredPath); !os.IsNotExist(err) {
+		t.Error("restored .json file should be committed after delivery")
 	}
 
-	// Second Drain: picks up the requeued orphan
+	// No deliverable nudges remain.
 	nudges2, err := Drain(townRoot, session)
 	if err != nil {
 		t.Fatalf("second Drain: %v", err)
 	}
-	if len(nudges2) != 1 {
-		t.Fatalf("second Drain got %d nudges, want 1 (the requeued orphan)", len(nudges2))
-	}
-	if nudges2[0].Sender != "ghost" {
-		t.Errorf("got sender %q, want %q", nudges2[0].Sender, "ghost")
+	if len(nudges2) != 0 {
+		t.Fatalf("second Drain got %d nudges, want 0", len(nudges2))
 	}
 
 	// The fresh claim should still exist (not old enough to sweep)

--- a/internal/opencodeserver/client.go
+++ b/internal/opencodeserver/client.go
@@ -1,0 +1,317 @@
+package opencodeserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	maxErrorBody    = 16 << 10
+	maxResponseBody = 4 << 20
+)
+
+type Health struct {
+	Healthy bool   `json:"healthy"`
+	Version string `json:"version"`
+}
+
+type Session struct {
+	ID        string `json:"id"`
+	Directory string `json:"directory"`
+	Title     string `json:"title"`
+}
+
+type Status struct {
+	Type    string `json:"type"`
+	Attempt int    `json:"attempt,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func (s Status) Idle() bool {
+	return s.Type == "" || s.Type == "idle"
+}
+
+type CreateSessionOptions struct {
+	Title   string
+	Agent   string
+	Model   string
+	Variant string
+}
+
+type PromptOptions struct {
+	Agent     string
+	Model     string
+	Variant   string
+	MessageID string
+}
+
+type Client struct {
+	baseURL   *url.URL
+	username  string
+	password  string
+	directory string
+	http      *http.Client
+}
+
+type APIError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("OpenCode %s %s returned %s", e.Method, e.Path, e.Status)
+	}
+	return fmt.Sprintf("OpenCode %s %s returned %s: %s", e.Method, e.Path, e.Status, e.Body)
+}
+
+func IsAPIStatus(err error, status int) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == status
+}
+
+func NewClient(baseURL, username, password, directory string, httpClient *http.Client) (*Client, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing OpenCode server URL: %w", err)
+	}
+	if parsed.Scheme != "http" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("OpenCode server URL must be a loopback HTTP origin")
+	}
+	host := parsed.Hostname()
+	ip := net.ParseIP(host)
+	if host != "localhost" && (ip == nil || !ip.IsLoopback()) {
+		return nil, fmt.Errorf("OpenCode server URL must use a loopback host")
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("OpenCode server credentials are required")
+	}
+	if directory == "" {
+		return nil, fmt.Errorf("OpenCode directory is required")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{
+		baseURL:   parsed,
+		username:  username,
+		password:  password,
+		directory: directory,
+		http:      httpClient,
+	}, nil
+}
+
+func (c *Client) Health(ctx context.Context) (Health, error) {
+	var result Health
+	err := c.doJSON(ctx, http.MethodGet, "/global/health", nil, http.StatusOK, &result)
+	return result, err
+}
+
+func (c *Client) CreateSession(ctx context.Context, opts CreateSessionOptions) (Session, error) {
+	body := make(map[string]any)
+	if opts.Title != "" {
+		body["title"] = opts.Title
+	}
+	if opts.Agent != "" {
+		body["agent"] = opts.Agent
+	}
+	if opts.Model != "" {
+		providerID, modelID, ok := strings.Cut(opts.Model, "/")
+		if !ok || providerID == "" || modelID == "" {
+			return Session{}, fmt.Errorf("OpenCode model must use provider/model format")
+		}
+		model := map[string]any{"providerID": providerID, "id": modelID}
+		if opts.Variant != "" {
+			model["variant"] = opts.Variant
+		}
+		body["model"] = model
+	}
+
+	var result Session
+	err := c.doJSON(ctx, http.MethodPost, "/session", body, http.StatusOK, &result)
+	if err == nil && result.ID == "" {
+		return Session{}, fmt.Errorf("OpenCode create session returned an empty ID")
+	}
+	return result, err
+}
+
+func (c *Client) GetSession(ctx context.Context, sessionID string) (Session, error) {
+	if sessionID == "" {
+		return Session{}, fmt.Errorf("OpenCode session ID is required")
+	}
+	var result Session
+	err := c.doJSON(ctx, http.MethodGet, sessionPath(sessionID), nil, http.StatusOK, &result)
+	return result, err
+}
+
+func (c *Client) DeleteSession(ctx context.Context, sessionID string) error {
+	return c.doJSON(ctx, http.MethodDelete, sessionPath(sessionID), nil, http.StatusOK, nil)
+}
+
+func (c *Client) Status(ctx context.Context, sessionID string) (Status, error) {
+	if sessionID == "" {
+		return Status{}, fmt.Errorf("OpenCode session ID is required")
+	}
+	var statuses map[string]Status
+	if err := c.doJSON(ctx, http.MethodGet, "/session/status", nil, http.StatusOK, &statuses); err != nil {
+		return Status{}, err
+	}
+	return statuses[sessionID], nil
+}
+
+func (c *Client) PromptAsync(ctx context.Context, sessionID, prompt string, options ...PromptOptions) error {
+	_, err := c.promptAsync(ctx, sessionID, prompt, options...)
+	return err
+}
+
+// promptAsync reports whether this call submitted a new turn. A false result
+// with no error means the stable message ID was already accepted previously.
+func (c *Client) promptAsync(ctx context.Context, sessionID, prompt string, options ...PromptOptions) (bool, error) {
+	if sessionID == "" {
+		return false, fmt.Errorf("OpenCode session ID is required")
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return false, fmt.Errorf("OpenCode prompt is required")
+	}
+	var opts PromptOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	if opts.MessageID != "" {
+		if !strings.HasPrefix(opts.MessageID, "msg") {
+			return false, fmt.Errorf("OpenCode message ID must start with msg")
+		}
+		exists, err := c.MessageExists(ctx, sessionID, opts.MessageID)
+		if err != nil {
+			return false, fmt.Errorf("checking prior OpenCode prompt delivery: %w", err)
+		}
+		if exists {
+			return false, nil
+		}
+	}
+	body := map[string]any{
+		"parts": []map[string]string{{"type": "text", "text": prompt}},
+	}
+	if opts.MessageID != "" {
+		body["messageID"] = opts.MessageID
+	}
+	if len(options) > 0 {
+		if opts.Agent != "" {
+			body["agent"] = opts.Agent
+		}
+		if opts.Model != "" {
+			providerID, modelID, ok := strings.Cut(opts.Model, "/")
+			if !ok || providerID == "" || modelID == "" {
+				return false, fmt.Errorf("OpenCode model must use provider/model format")
+			}
+			body["model"] = map[string]string{"providerID": providerID, "modelID": modelID}
+		}
+		if opts.Variant != "" {
+			body["variant"] = opts.Variant
+		}
+	}
+	err := c.doJSON(ctx, http.MethodPost, sessionPath(sessionID)+"/prompt_async", body, http.StatusNoContent, nil)
+	if err == nil || opts.MessageID == "" {
+		return err == nil, err
+	}
+	exists, checkErr := c.MessageExists(ctx, sessionID, opts.MessageID)
+	if checkErr == nil && exists {
+		return true, nil
+	}
+	return false, errors.Join(err, checkErr)
+}
+
+func (c *Client) MessageExists(ctx context.Context, sessionID, messageID string) (bool, error) {
+	if sessionID == "" || messageID == "" {
+		return false, fmt.Errorf("OpenCode session and message IDs are required")
+	}
+	err := c.doJSON(ctx, http.MethodGet, sessionPath(sessionID)+"/message/"+url.PathEscape(messageID), nil, http.StatusOK, nil)
+	if IsAPIStatus(err, http.StatusNotFound) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (c *Client) Abort(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("OpenCode session ID is required")
+	}
+	return c.doJSON(ctx, http.MethodPost, sessionPath(sessionID)+"/abort", nil, http.StatusOK, nil)
+}
+
+func sessionPath(sessionID string) string {
+	return "/session/" + url.PathEscape(sessionID)
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, body any, wantStatus int, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encoding OpenCode request: %w", err)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	}
+
+	requestURL := strings.TrimSuffix(c.baseURL.String(), "/") + path
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating OpenCode request: %w", err)
+	}
+	req.SetBasicAuth(c.username, c.password)
+	req.Header.Set("X-OpenCode-Directory", c.directory)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling OpenCode %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != wantStatus {
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody+1))
+		if readErr != nil {
+			return fmt.Errorf("OpenCode %s %s returned %s (reading error body: %v)", method, path, resp.Status, readErr)
+		}
+		truncated := len(data) > maxErrorBody
+		if truncated {
+			data = data[:maxErrorBody]
+		}
+		message := strings.TrimSpace(string(data))
+		if truncated {
+			message += "... (truncated)"
+		}
+		return &APIError{
+			Method:     method,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       message,
+		}
+	}
+
+	if result == nil || resp.StatusCode == http.StatusNoContent {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBody))
+	if err := decoder.Decode(result); err != nil {
+		return fmt.Errorf("decoding OpenCode %s %s response: %w", method, path, err)
+	}
+	return nil
+}

--- a/internal/opencodeserver/client.go
+++ b/internal/opencodeserver/client.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	maxErrorBody    = 16 << 10
-	maxResponseBody = 4 << 20
+	maxErrorBody                 = 16 << 10
+	maxResponseBody              = 4 << 20
+	defaultRequestTimeout        = 15 * time.Second
+	sessionInitializationTimeout = 2 * time.Minute
 )
 
 type Health struct {
@@ -55,11 +57,12 @@ type PromptOptions struct {
 }
 
 type Client struct {
-	baseURL   *url.URL
-	username  string
-	password  string
-	directory string
-	http      *http.Client
+	baseURL     *url.URL
+	username    string
+	password    string
+	directory   string
+	http        *http.Client
+	sessionHTTP *http.Client
 }
 
 type APIError struct {
@@ -102,15 +105,18 @@ func NewClient(baseURL, username, password, directory string, httpClient *http.C
 	if directory == "" {
 		return nil, fmt.Errorf("OpenCode directory is required")
 	}
+	sessionHTTP := httpClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 15 * time.Second}
+		httpClient = &http.Client{Timeout: defaultRequestTimeout}
+		sessionHTTP = &http.Client{Timeout: sessionInitializationTimeout}
 	}
 	return &Client{
-		baseURL:   parsed,
-		username:  username,
-		password:  password,
-		directory: directory,
-		http:      httpClient,
+		baseURL:     parsed,
+		username:    username,
+		password:    password,
+		directory:   directory,
+		http:        httpClient,
+		sessionHTTP: sessionHTTP,
 	}, nil
 }
 
@@ -141,7 +147,7 @@ func (c *Client) CreateSession(ctx context.Context, opts CreateSessionOptions) (
 	}
 
 	var result Session
-	err := c.doJSON(ctx, http.MethodPost, "/session", body, http.StatusOK, &result)
+	err := c.doSessionJSON(ctx, http.MethodPost, "/session", body, http.StatusOK, &result)
 	if err == nil && result.ID == "" {
 		return Session{}, fmt.Errorf("OpenCode create session returned an empty ID")
 	}
@@ -153,7 +159,7 @@ func (c *Client) GetSession(ctx context.Context, sessionID string) (Session, err
 		return Session{}, fmt.Errorf("OpenCode session ID is required")
 	}
 	var result Session
-	err := c.doJSON(ctx, http.MethodGet, sessionPath(sessionID), nil, http.StatusOK, &result)
+	err := c.doSessionJSON(ctx, http.MethodGet, sessionPath(sessionID), nil, http.StatusOK, &result)
 	return result, err
 }
 
@@ -257,6 +263,14 @@ func sessionPath(sessionID string) string {
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, body any, wantStatus int, result any) error {
+	return c.doJSONWithClient(ctx, c.http, method, path, body, wantStatus, result)
+}
+
+func (c *Client) doSessionJSON(ctx context.Context, method, path string, body any, wantStatus int, result any) error {
+	return c.doJSONWithClient(ctx, c.sessionHTTP, method, path, body, wantStatus, result)
+}
+
+func (c *Client) doJSONWithClient(ctx context.Context, httpClient *http.Client, method, path string, body any, wantStatus int, result any) error {
 	var bodyReader io.Reader
 	if body != nil {
 		encoded, err := json.Marshal(body)
@@ -277,7 +291,7 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body any, want
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.http.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("calling OpenCode %s %s: %w", method, path, err)
 	}

--- a/internal/opencodeserver/client_test.go
+++ b/internal/opencodeserver/client_test.go
@@ -3,11 +3,111 @@ package opencodeserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestClientUsesExtendedSessionInitializationTimeout(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("http://127.0.0.1:12345", "opencode", "secret", t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.http.Timeout != defaultRequestTimeout {
+		t.Fatalf("normal request timeout = %v, want %v", client.http.Timeout, defaultRequestTimeout)
+	}
+	if client.sessionHTTP.Timeout != sessionInitializationTimeout {
+		t.Fatalf("session initialization timeout = %v, want %v", client.sessionHTTP.Timeout, sessionInitializationTimeout)
+	}
+
+	custom := &http.Client{Timeout: 250 * time.Millisecond}
+	client, err = NewClient("http://127.0.0.1:12345", "opencode", "secret", t.TempDir(), custom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.http != custom || client.sessionHTTP != custom {
+		t.Fatal("custom HTTP client was not preserved for all request types")
+	}
+}
+
+func TestClientRoutesOnlySessionResolutionThroughInitializationClient(t *testing.T) {
+	t.Parallel()
+
+	normalCalls := 0
+	sessionCalls := 0
+	response := func(request *http.Request, body string) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    request,
+		}
+	}
+	normalHTTP := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		normalCalls++
+		return response(request, `{}`), nil
+	})}
+	sessionHTTP := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		sessionCalls++
+		return response(request, `{"id":"ses_test","directory":"/worktree"}`), nil
+	})}
+	client, err := NewClient("http://127.0.0.1:12345", "opencode", "secret", "/worktree", normalHTTP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.sessionHTTP = sessionHTTP
+
+	if _, err := client.CreateSession(context.Background(), CreateSessionOptions{}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := client.GetSession(context.Background(), "ses_test"); err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if _, err := client.Status(context.Background(), "ses_test"); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if sessionCalls != 2 || normalCalls != 1 {
+		t.Fatalf("session calls = %d, normal calls = %d; want 2/1", sessionCalls, normalCalls)
+	}
+}
+
+func TestSessionInitializationHonorsCallerContext(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+	client, err := NewClient(server.URL, "opencode", "secret", t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = client.CreateSession(ctx, CreateSessionOptions{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CreateSession error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("CreateSession honored HTTP timeout instead of caller context: %v", elapsed)
+	}
+}
 
 func TestClientLifecycleRequests(t *testing.T) {
 	t.Parallel()

--- a/internal/opencodeserver/client_test.go
+++ b/internal/opencodeserver/client_test.go
@@ -1,0 +1,152 @@
+package opencodeserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClientLifecycleRequests(t *testing.T) {
+	t.Parallel()
+
+	const directory = "/worktree"
+	var calls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "opencode" || pass != "secret" {
+			t.Fatalf("BasicAuth = %q/%q/%v, want opencode/secret/true", user, pass, ok)
+		}
+		if r.URL.Path != "/global/health" && r.Header.Get("X-OpenCode-Directory") != directory {
+			t.Fatalf("X-OpenCode-Directory = %q, want %q", r.Header.Get("X-OpenCode-Directory"), directory)
+		}
+		calls = append(calls, r.Method+" "+r.URL.EscapedPath())
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/global/health":
+			_ = json.NewEncoder(w).Encode(Health{Healthy: true, Version: "1.18.16"})
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			if body["title"] != "Gas Town gt-rig-worker" || body["agent"] != "build" {
+				t.Fatalf("create body = %#v", body)
+			}
+			model, _ := body["model"].(map[string]any)
+			if model["providerID"] != "opencode-go" || model["id"] != "grok-4.5" || model["variant"] != "high" {
+				t.Fatalf("model body = %#v", model)
+			}
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_test", Directory: directory})
+		case r.Method == http.MethodGet && r.URL.Path == "/session/status":
+			_ = json.NewEncoder(w).Encode(map[string]Status{"ses_test": {Type: "busy"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/session/ses_test/prompt_async":
+			var body struct {
+				Parts []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"parts"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode prompt body: %v", err)
+			}
+			if len(body.Parts) != 1 || body.Parts[0].Type != "text" || body.Parts[0].Text != "work now" {
+				t.Fatalf("prompt body = %#v", body)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/session/ses_test/abort":
+			_ = json.NewEncoder(w).Encode(true)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "opencode", "secret", directory, server.Client())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := context.Background()
+
+	health, err := client.Health(ctx)
+	if err != nil || !health.Healthy || health.Version != "1.18.16" {
+		t.Fatalf("Health = %#v, %v", health, err)
+	}
+	session, err := client.CreateSession(ctx, CreateSessionOptions{
+		Title:   "Gas Town gt-rig-worker",
+		Agent:   "build",
+		Model:   "opencode-go/grok-4.5",
+		Variant: "high",
+	})
+	if err != nil || session.ID != "ses_test" {
+		t.Fatalf("CreateSession = %#v, %v", session, err)
+	}
+	status, err := client.Status(ctx, session.ID)
+	if err != nil || status.Type != "busy" {
+		t.Fatalf("Status = %#v, %v", status, err)
+	}
+	if err := client.PromptAsync(ctx, session.ID, "work now"); err != nil {
+		t.Fatalf("PromptAsync: %v", err)
+	}
+	if err := client.Abort(ctx, session.ID); err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+
+	want := []string{
+		"GET /global/health",
+		"POST /session",
+		"GET /session/status",
+		"POST /session/ses_test/prompt_async",
+		"POST /session/ses_test/abort",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestClientMissingStatusIsIdle(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := client.Status(context.Background(), "ses_idle")
+	if err != nil || !status.Idle() {
+		t.Fatalf("Status = %#v, %v, want idle", status, err)
+	}
+}
+
+func TestClientRejectsNonLoopbackURL(t *testing.T) {
+	t.Parallel()
+	if _, err := NewClient("https://example.com", "opencode", "secret", t.TempDir(), nil); err == nil {
+		t.Fatal("NewClient accepted non-loopback URL")
+	}
+}
+
+func TestClientBoundsErrorBody(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxErrorBody+1024)))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.PromptAsync(context.Background(), "ses_test", "hello")
+	if err == nil {
+		t.Fatal("PromptAsync succeeded, want error")
+	}
+	if len(err.Error()) > maxErrorBody+256 {
+		t.Fatalf("error length = %d, want bounded", len(err.Error()))
+	}
+}

--- a/internal/opencodeserver/events.go
+++ b/internal/opencodeserver/events.go
@@ -1,0 +1,188 @@
+package opencodeserver
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxEventSize = 1 << 20
+
+type EventProperties struct {
+	SessionID string `json:"sessionID"`
+	Status    Status `json:"status"`
+}
+
+type Event struct {
+	Type       string          `json:"type"`
+	Properties EventProperties `json:"properties"`
+}
+
+func (e Event) SessionID() string {
+	return e.Properties.SessionID
+}
+
+func (e Event) Status() Status {
+	if e.Type == "session.idle" {
+		return Status{Type: "idle"}
+	}
+	return e.Properties.Status
+}
+
+type EventStream struct {
+	body      io.ReadCloser
+	cancel    context.CancelFunc
+	events    chan Event
+	errors    chan error
+	closeOnce sync.Once
+}
+
+func (c *Client) Events(ctx context.Context) (*EventStream, error) {
+	streamCtx, cancel := context.WithCancel(ctx)
+	requestURL := strings.TrimSuffix(c.baseURL.String(), "/") + "/event"
+	req, err := http.NewRequestWithContext(streamCtx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("creating OpenCode event request: %w", err)
+	}
+	req.SetBasicAuth(c.username, c.password)
+	req.Header.Set("X-OpenCode-Directory", c.directory)
+	req.Header.Set("Accept", "text/event-stream")
+
+	// http.Client.Timeout includes reading the response body, so it cannot be
+	// used for a stream that is expected to remain open for the worker lifetime.
+	httpClient := *c.http
+	httpClient.Timeout = 0
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("subscribing to OpenCode events: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody+1))
+		cancel()
+		if readErr != nil {
+			return nil, fmt.Errorf("OpenCode GET /event returned %s (reading error body: %v)", resp.Status, readErr)
+		}
+		if len(data) > maxErrorBody {
+			data = append(data[:maxErrorBody], []byte("... (truncated)")...)
+		}
+		message := strings.TrimSpace(string(data))
+		if message == "" {
+			return nil, fmt.Errorf("OpenCode GET /event returned %s", resp.Status)
+		}
+		return nil, fmt.Errorf("OpenCode GET /event returned %s: %s", resp.Status, message)
+	}
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || mediaType != "text/event-stream" {
+		resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf("OpenCode GET /event returned content type %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+
+	stream := &EventStream{
+		body:   resp.Body,
+		cancel: cancel,
+		events: make(chan Event, 16),
+		errors: make(chan error, 1),
+	}
+	go stream.read(streamCtx)
+	return stream, nil
+}
+
+func (s *EventStream) Events() <-chan Event {
+	return s.events
+}
+
+func (s *EventStream) Errors() <-chan error {
+	return s.errors
+}
+
+func (s *EventStream) Close() error {
+	var closeErr error
+	s.closeOnce.Do(func() {
+		s.cancel()
+		closeErr = s.body.Close()
+	})
+	return closeErr
+}
+
+func (s *EventStream) read(ctx context.Context) {
+	defer close(s.events)
+	defer close(s.errors)
+	defer s.body.Close()
+
+	scanner := bufio.NewScanner(s.body)
+	scanner.Buffer(make([]byte, 64<<10), maxEventSize+64)
+	data := make([]byte, 0, 4096)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if len(data) > 0 && !s.dispatch(ctx, data) {
+				return
+			}
+			data = data[:0]
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, _ := strings.Cut(line, ":")
+		if field != "data" {
+			continue
+		}
+		value = strings.TrimPrefix(value, " ")
+		extra := len(value)
+		if len(data) > 0 {
+			extra++
+		}
+		if len(data)+extra > maxEventSize {
+			s.report(ctx, fmt.Errorf("OpenCode event exceeds %d bytes", maxEventSize))
+			return
+		}
+		if len(data) > 0 {
+			data = append(data, '\n')
+		}
+		data = append(data, value...)
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() == nil {
+			s.report(ctx, fmt.Errorf("reading OpenCode events: %w", err))
+		}
+		return
+	}
+	if len(data) > 0 && !s.dispatch(ctx, data) {
+		return
+	}
+	if ctx.Err() == nil {
+		s.report(ctx, io.ErrUnexpectedEOF)
+	}
+}
+
+func (s *EventStream) dispatch(ctx context.Context, data []byte) bool {
+	var event Event
+	if err := json.Unmarshal(data, &event); err != nil {
+		s.report(ctx, fmt.Errorf("decoding OpenCode event: %w", err))
+		return false
+	}
+	select {
+	case s.events <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (s *EventStream) report(ctx context.Context, err error) {
+	select {
+	case s.errors <- err:
+	case <-ctx.Done():
+	}
+}

--- a/internal/opencodeserver/events_test.go
+++ b/internal/opencodeserver/events_test.go
@@ -1,0 +1,127 @@
+package opencodeserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestEventsParsesSessionLifecycle(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/event" {
+			http.NotFound(w, r)
+			return
+		}
+		user, password, ok := r.BasicAuth()
+		if !ok || user != "opencode" || password != "secret" {
+			t.Fatalf("BasicAuth = %q/%q/%v", user, password, ok)
+		}
+		if r.Header.Get("X-OpenCode-Directory") != "/worktree" {
+			t.Fatalf("directory header = %q", r.Header.Get("X-OpenCode-Directory"))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, ": connected\r\n\r\n")
+		fmt.Fprint(w, "data: {\"type\":\"session.status\",\r\n")
+		fmt.Fprint(w, "data: \"properties\":{\"sessionID\":\"ses_test\",\"status\":{\"type\":\"busy\"}}}\r\n\r\n")
+		fmt.Fprint(w, "data: {\"type\":\"session.idle\",\"properties\":{\"sessionID\":\"ses_test\"}}\r\n\r\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "opencode", "secret", "/worktree", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Events(ctx)
+	if err != nil {
+		cancel()
+		t.Fatalf("Events: %v", err)
+	}
+	defer func() {
+		cancel()
+		stream.Close()
+	}()
+
+	busy := <-stream.Events()
+	if busy.Type != "session.status" || busy.SessionID() != "ses_test" || busy.Status().Type != "busy" {
+		t.Fatalf("busy event = %#v", busy)
+	}
+	idle := <-stream.Events()
+	if idle.Type != "session.idle" || idle.SessionID() != "ses_test" || !idle.Status().Idle() {
+		t.Fatalf("idle event = %#v", idle)
+	}
+}
+
+func TestEventsReportsOversizedEvent(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", string(make([]byte, maxEventSize+1)))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Events(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	select {
+	case err := <-stream.Errors():
+		if err == nil {
+			t.Fatal("event stream returned nil error")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for oversized event error")
+	}
+}
+
+func TestEventsReportsInvalidJSON(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: not-json\n\n")
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Events(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	select {
+	case err := <-stream.Errors():
+		if err == nil {
+			t.Fatal("event stream returned nil error")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for invalid event error")
+	}
+}
+
+func TestEventsRejectsWrongContentType(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	if stream, err := client.Events(context.Background()); err == nil {
+		stream.Close()
+		t.Fatal("Events accepted non-SSE response")
+	}
+}

--- a/internal/opencodeserver/integration_test.go
+++ b/internal/opencodeserver/integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package opencodeserver
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestRealOpenCodeServerLifecycle(t *testing.T) {
+	command := os.Getenv("GT_OPENCODE_TEST_COMMAND")
+	if command == "" {
+		command = "opencode"
+		if runtime.GOOS == "windows" {
+			command = "opencode.cmd"
+		}
+	}
+	resolved, err := exec.LookPath(command)
+	if err != nil {
+		t.Skipf("OpenCode executable not found: %v", err)
+	}
+
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "README.md"), []byte("integration smoke\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	server, err := StartServer(ctx, ServerOptions{Command: resolved, Directory: directory})
+	if err != nil {
+		t.Fatalf("StartServer: %v", err)
+	}
+	defer server.Stop()
+	client, err := server.NewClient(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := client.Events(ctx)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	events.Close()
+	session, err := client.CreateSession(ctx, CreateSessionOptions{Title: "Gas Town integration smoke", Agent: "build"})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	got, err := client.GetSession(ctx, session.ID)
+	if err != nil || got.ID != session.ID {
+		t.Fatalf("GetSession = %#v, %v", got, err)
+	}
+	if err := client.DeleteSession(ctx, session.ID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+}

--- a/internal/opencodeserver/lifecycle.go
+++ b/internal/opencodeserver/lifecycle.go
@@ -1,0 +1,134 @@
+package opencodeserver
+
+import "sync"
+
+type sessionLifecycle struct {
+	mu                      sync.Mutex
+	sessionID               string
+	status                  Status
+	inFlight                bool
+	seenBusy                bool
+	idleConfirmationPending bool
+	idleConfirmationChecks  int
+}
+
+func newSessionLifecycle(sessionID string, status Status) *sessionLifecycle {
+	return &sessionLifecycle{sessionID: sessionID, status: status}
+}
+
+func (l *sessionLifecycle) Ready() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return !l.inFlight && l.status.Idle()
+}
+
+func (l *sessionLifecycle) BeginPrompt() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.inFlight || !l.status.Idle() {
+		return false
+	}
+	l.inFlight = true
+	l.seenBusy = false
+	l.idleConfirmationPending = false
+	l.idleConfirmationChecks = 0
+	l.status = Status{Type: "busy"}
+	return true
+}
+
+func (l *sessionLifecycle) PromptFailed() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.inFlight = false
+	l.seenBusy = false
+	l.idleConfirmationPending = false
+	l.idleConfirmationChecks = 0
+	l.status = Status{Type: "idle"}
+}
+
+// AwaitRecoveredPrompt keeps an idempotently recovered turn in flight until
+// status polling confirms it is either running or already complete.
+func (l *sessionLifecycle) AwaitRecoveredPrompt() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.inFlight {
+		return
+	}
+	l.idleConfirmationPending = true
+	l.idleConfirmationChecks = 0
+}
+
+func (l *sessionLifecycle) Reconcile(status Status) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.inFlight {
+		l.status = status
+		return
+	}
+	if l.idleConfirmationPending {
+		if !status.Idle() {
+			l.status = status
+			l.seenBusy = true
+			l.idleConfirmationPending = false
+			l.idleConfirmationChecks = 0
+			return
+		}
+		l.idleConfirmationChecks++
+		if l.idleConfirmationChecks >= 2 {
+			l.inFlight = false
+			l.seenBusy = false
+			l.idleConfirmationPending = false
+			l.idleConfirmationChecks = 0
+			l.status = status
+		}
+		return
+	}
+	if !status.Idle() {
+		l.status = status
+		l.seenBusy = true
+	}
+}
+
+func (l *sessionLifecycle) Observe(event Event) bool {
+	if event.SessionID() != l.sessionID {
+		return false
+	}
+	if event.Type != "session.status" && event.Type != "session.idle" && event.Type != "session.error" {
+		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if event.Type == "session.error" {
+		if l.inFlight {
+			l.idleConfirmationPending = true
+			l.idleConfirmationChecks = 0
+		}
+		return false
+	}
+	status := event.Status()
+	if !status.Idle() {
+		l.status = status
+		if l.inFlight {
+			l.seenBusy = true
+			l.idleConfirmationPending = false
+			l.idleConfirmationChecks = 0
+		}
+		return false
+	}
+	if l.inFlight && !l.seenBusy {
+		return false
+	}
+	l.inFlight = false
+	l.seenBusy = false
+	l.idleConfirmationPending = false
+	l.idleConfirmationChecks = 0
+	l.status = status
+	return true
+}
+
+func (l *sessionLifecycle) InFlight() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inFlight
+}

--- a/internal/opencodeserver/process.go
+++ b/internal/opencodeserver/process.go
@@ -1,0 +1,321 @@
+package opencodeserver
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+const (
+	defaultStartupTimeout = 30 * time.Second
+	serverUsername        = "opencode"
+)
+
+type ServerOptions struct {
+	Command        string
+	CommandArgs    []string
+	Directory      string
+	StartupTimeout time.Duration
+	Environment    map[string]string
+}
+
+type ServerProcess struct {
+	cmd      *exec.Cmd
+	url      string
+	username string
+	password string
+	version  string
+	cancel   context.CancelFunc
+	done     chan struct{}
+	waitMu   sync.RWMutex
+	waitErr  error
+	stopOnce sync.Once
+	stopErr  error
+	guard    func() error
+}
+
+func StartServer(ctx context.Context, opts ServerOptions) (*ServerProcess, error) {
+	if opts.Command == "" {
+		return nil, fmt.Errorf("OpenCode command is required")
+	}
+	if opts.Directory == "" {
+		return nil, fmt.Errorf("OpenCode directory is required")
+	}
+	if opts.StartupTimeout <= 0 {
+		opts.StartupTimeout = defaultStartupTimeout
+	}
+
+	port, err := availablePort()
+	if err != nil {
+		return nil, err
+	}
+	password, err := randomPassword()
+	if err != nil {
+		return nil, err
+	}
+	baseURL := "http://127.0.0.1:" + strconv.Itoa(port)
+
+	// The worker must abort an active turn before stopping the server. Keep the
+	// child alive when the caller context is canceled; Stop owns termination.
+	childCtx, cancel := context.WithCancel(context.Background())
+	args := append([]string(nil), opts.CommandArgs...)
+	args = append(args, "serve", "--hostname", "127.0.0.1", "--port", strconv.Itoa(port))
+	cmd := exec.CommandContext(childCtx, opts.Command, args...) //nolint:gosec // command is operator-configured
+	cmd.Dir = opts.Directory
+	cmd.Env = mergeEnvironment(os.Environ(), opts.Environment, map[string]string{
+		"OPENCODE_SERVER_USERNAME": serverUsername,
+		"OPENCODE_SERVER_PASSWORD": password,
+	})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	util.SetProcessGroup(cmd)
+	configureServerCommand(cmd)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("starting OpenCode server: %w", err)
+	}
+	guard, err := attachServerProcessGuard(cmd.Process.Pid)
+	if err != nil {
+		_ = terminateProcessTree(cmd.Process.Pid)
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("protecting OpenCode server process tree: %w", err)
+	}
+	server := &ServerProcess{
+		cmd:      cmd,
+		url:      baseURL,
+		username: serverUsername,
+		password: password,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		guard:    guard,
+	}
+	go func() {
+		err := cmd.Wait()
+		server.waitMu.Lock()
+		server.waitErr = err
+		server.waitMu.Unlock()
+		close(server.done)
+	}()
+
+	client, err := NewClient(baseURL, serverUsername, password, opts.Directory, &http.Client{Timeout: time.Second})
+	if err != nil {
+		_ = server.Stop()
+		return nil, err
+	}
+	deadline := time.NewTimer(opts.StartupTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		healthCtx, healthCancel := context.WithTimeout(ctx, time.Second)
+		health, healthErr := client.Health(healthCtx)
+		healthCancel()
+		if healthErr == nil && health.Healthy {
+			if !SupportedVersion(health.Version) {
+				_ = server.Stop()
+				return nil, fmt.Errorf("unsupported OpenCode server version %q; expected 1.18.16 or newer 1.x", health.Version)
+			}
+			server.version = health.Version
+			return server, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			_ = server.Stop()
+			return nil, ctx.Err()
+		case <-server.done:
+			return nil, fmt.Errorf("OpenCode server exited before becoming ready: %v", server.Err())
+		case <-deadline.C:
+			_ = server.Stop()
+			return nil, fmt.Errorf("timed out waiting for OpenCode server readiness")
+		case <-ticker.C:
+		}
+	}
+}
+
+func SupportedVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if strings.HasPrefix(version, "v") {
+		version = strings.TrimPrefix(version, "v")
+	}
+	coreAndPrerelease, build, hasBuild := strings.Cut(version, "+")
+	if hasBuild && !validSemverIdentifiers(build, false) {
+		return false
+	}
+	core, prerelease, hasPrerelease := strings.Cut(coreAndPrerelease, "-")
+	if hasPrerelease && !validSemverIdentifiers(prerelease, true) {
+		return false
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return false
+		}
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major != 1 {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return false
+	}
+	if minor < 18 || (minor == 18 && patch < 16) {
+		return false
+	}
+	return minor > 18 || patch > 16 || !hasPrerelease
+}
+
+func validSemverIdentifiers(value string, rejectNumericLeadingZero bool) bool {
+	if value == "" {
+		return false
+	}
+	for _, identifier := range strings.Split(value, ".") {
+		if identifier == "" {
+			return false
+		}
+		numeric := true
+		for _, char := range identifier {
+			if (char < '0' || char > '9') && (char < 'A' || char > 'Z') && (char < 'a' || char > 'z') && char != '-' {
+				return false
+			}
+			if char < '0' || char > '9' {
+				numeric = false
+			}
+		}
+		if rejectNumericLeadingZero && numeric && len(identifier) > 1 && identifier[0] == '0' {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *ServerProcess) Client(directory string) *Client {
+	client, err := s.NewClient(directory)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func (s *ServerProcess) NewClient(directory string) (*Client, error) {
+	return NewClient(s.url, s.username, s.password, directory, nil)
+}
+
+func (s *ServerProcess) URL() string      { return s.url }
+func (s *ServerProcess) Username() string { return s.username }
+func (s *ServerProcess) Password() string { return s.password }
+func (s *ServerProcess) Version() string  { return s.version }
+func (s *ServerProcess) PID() int {
+	if s.cmd == nil || s.cmd.Process == nil {
+		return 0
+	}
+	return s.cmd.Process.Pid
+}
+func (s *ServerProcess) Done() <-chan struct{} { return s.done }
+
+func (s *ServerProcess) Err() error {
+	s.waitMu.RLock()
+	defer s.waitMu.RUnlock()
+	return s.waitErr
+}
+
+func (s *ServerProcess) Stop() error {
+	s.stopOnce.Do(func() {
+		if s.cmd != nil && s.cmd.Process != nil {
+			s.stopErr = terminateProcessTree(s.cmd.Process.Pid)
+		}
+		if s.guard != nil {
+			s.stopErr = errors.Join(s.stopErr, s.guard())
+		}
+		s.cancel()
+		select {
+		case <-s.done:
+		case <-time.After(5 * time.Second):
+			if s.cmd != nil && s.cmd.Process != nil {
+				if err := s.cmd.Process.Kill(); s.stopErr == nil {
+					s.stopErr = err
+				}
+			}
+			select {
+			case <-s.done:
+			case <-time.After(time.Second):
+			}
+		}
+	})
+	return s.stopErr
+}
+
+func availablePort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("selecting OpenCode server port: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		return 0, fmt.Errorf("releasing OpenCode server port: %w", err)
+	}
+	return port, nil
+}
+
+func randomPassword() (string, error) {
+	var data [32]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", fmt.Errorf("generating OpenCode server password: %w", err)
+	}
+	return hex.EncodeToString(data[:]), nil
+}
+
+func mergeEnvironment(base []string, overlays ...map[string]string) []string {
+	values := make(map[string]string, len(base))
+	keys := make(map[string]string, len(base))
+	canonicalKey := func(key string) string {
+		if runtime.GOOS == "windows" {
+			return strings.ToUpper(key)
+		}
+		return key
+	}
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			canonical := canonicalKey(key)
+			keys[canonical] = key
+			values[canonical] = value
+		}
+	}
+	for _, overlay := range overlays {
+		for key, value := range overlay {
+			canonical := canonicalKey(key)
+			keys[canonical] = key
+			values[canonical] = value
+		}
+	}
+	result := make([]string, 0, len(values))
+	for canonical, value := range values {
+		result = append(result, keys[canonical]+"="+value)
+	}
+	return result
+}

--- a/internal/opencodeserver/process_guard_linux.go
+++ b/internal/opencodeserver/process_guard_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package opencodeserver
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureServerCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+}
+
+func attachServerProcessGuard(pid int) (func() error, error) {
+	return attachUnixParentWatchdog(pid)
+}

--- a/internal/opencodeserver/process_guard_unix.go
+++ b/internal/opencodeserver/process_guard_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows && !linux
+
+package opencodeserver
+
+import "os/exec"
+
+func configureServerCommand(*exec.Cmd) {}
+
+func attachServerProcessGuard(pid int) (func() error, error) {
+	return attachUnixParentWatchdog(pid)
+}

--- a/internal/opencodeserver/process_guard_watchdog_unix.go
+++ b/internal/opencodeserver/process_guard_watchdog_unix.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package opencodeserver
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func attachUnixParentWatchdog(serverPID int) (func() error, error) {
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	const script = `group=$1
+IFS= read -r _ <&3
+kill -TERM -"$group" 2>/dev/null || true
+sleep 1
+kill -KILL -"$group" 2>/dev/null || true`
+	watchdog := exec.Command("sh", "-c", script, "opencode-parent-watchdog", strconv.Itoa(serverPID))
+	watchdog.ExtraFiles = []*os.File{readPipe}
+	watchdog.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := watchdog.Start(); err != nil {
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		return nil, err
+	}
+	_ = readPipe.Close()
+	return func() error {
+		killErr := watchdog.Process.Kill()
+		closeErr := writePipe.Close()
+		waitErr := watchdog.Wait()
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			waitErr = nil
+		}
+		if errors.Is(killErr, os.ErrProcessDone) {
+			killErr = nil
+		}
+		return errors.Join(killErr, closeErr, waitErr)
+	}, nil
+}

--- a/internal/opencodeserver/process_guard_windows.go
+++ b/internal/opencodeserver/process_guard_windows.go
@@ -1,0 +1,135 @@
+//go:build windows
+
+package opencodeserver
+
+import (
+	"errors"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var isProcessInJob = windows.NewLazySystemDLL("kernel32.dll").NewProc("IsProcessInJob")
+
+func configureServerCommand(*exec.Cmd) {}
+
+func attachServerProcessGuard(pid int) (func() error, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	closeJob := func() error { return windows.CloseHandle(job) }
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = closeJob()
+		return nil, err
+	}
+	children, err := snapshotProcessChildren()
+	if err != nil {
+		_ = closeJob()
+		return nil, err
+	}
+	if _, err := assignPIDToJob(job, uint32(pid), false); err != nil {
+		_ = closeJob()
+		return nil, err
+	}
+	if _, err := assignDescendantsToJob(job, uint32(pid), children); err != nil {
+		_ = closeJob()
+		return nil, err
+	}
+	// A child can appear between the initial snapshot and assignment. Once a
+	// sweep finds no unassigned descendants, future children inherit the job.
+	settled := false
+	for range 8 {
+		children, err = snapshotProcessChildren()
+		if err != nil {
+			_ = closeJob()
+			return nil, err
+		}
+		assigned, err := assignDescendantsToJob(job, uint32(pid), children)
+		if err != nil {
+			_ = closeJob()
+			return nil, err
+		}
+		if !assigned {
+			settled = true
+			break
+		}
+	}
+	if !settled {
+		_ = closeJob()
+		return nil, errors.New("OpenCode process tree did not settle while attaching job guard")
+	}
+	return closeJob, nil
+}
+
+func assignDescendantsToJob(job windows.Handle, root uint32, children map[uint32][]uint32) (bool, error) {
+	assignedAny := false
+	visited := make(map[uint32]bool)
+	var assign func(uint32) error
+	assign = func(parent uint32) error {
+		if visited[parent] {
+			return nil
+		}
+		visited[parent] = true
+		for _, child := range children[parent] {
+			assigned, err := assignPIDToJob(job, child, true)
+			if err != nil {
+				return err
+			}
+			assignedAny = assignedAny || assigned
+			if err := assign(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return assignedAny, assign(root)
+}
+
+func assignPIDToJob(job windows.Handle, pid uint32, allowExited bool) (bool, error) {
+	process, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		pid,
+	)
+	if err != nil {
+		if allowExited && errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer windows.CloseHandle(process)
+
+	inJob, err := processIsInJob(process, job)
+	if err != nil {
+		return false, err
+	}
+	if inJob {
+		return false, nil
+	}
+	if err := windows.AssignProcessToJobObject(job, process); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func processIsInJob(process, job windows.Handle) (bool, error) {
+	var result int32
+	ok, _, callErr := isProcessInJob.Call(
+		uintptr(process),
+		uintptr(job),
+		uintptr(unsafe.Pointer(&result)),
+	)
+	if ok == 0 {
+		return false, callErr
+	}
+	return result != 0, nil
+}

--- a/internal/opencodeserver/process_test.go
+++ b/internal/opencodeserver/process_test.go
@@ -1,0 +1,301 @@
+package opencodeserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServerProcessLifecycle(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, err := StartServer(ctx, ServerOptions{
+		Command:        os.Args[0],
+		CommandArgs:    []string{"-test.run=TestOpenCodeServerHelperProcess"},
+		Directory:      t.TempDir(),
+		StartupTimeout: 5 * time.Second,
+		Environment: map[string]string{
+			"GO_WANT_OPENCODE_SERVER_HELPER": "1",
+			"GO_OPENCODE_HELPER_VERSION":     "1.18.16",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartServer: %v", err)
+	}
+	if server.Version() != "1.18.16" {
+		t.Fatalf("Version = %q, want 1.18.16", server.Version())
+	}
+	if _, err := server.Client(t.TempDir()).Health(context.Background()); err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if err := server.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := server.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}
+
+func TestServerRejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := StartServer(ctx, ServerOptions{
+		Command:        os.Args[0],
+		CommandArgs:    []string{"-test.run=TestOpenCodeServerHelperProcess"},
+		Directory:      t.TempDir(),
+		StartupTimeout: 5 * time.Second,
+		Environment: map[string]string{
+			"GO_WANT_OPENCODE_SERVER_HELPER": "1",
+			"GO_OPENCODE_HELPER_VERSION":     "2.0.0",
+		},
+	})
+	if err == nil {
+		t.Fatal("StartServer accepted unsupported major version")
+	}
+}
+
+func TestSupportedVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"1.18.15", false},
+		{"1.18.16", true},
+		{"v1.18.16", true},
+		{"1.18.16-beta.1", false},
+		{"1.18.16+build", true},
+		{"1.18.17-beta.1", true},
+		{"1.19.0", true},
+		{"2.0.0", false},
+		{"dev", false},
+		{"1.18.-", false},
+		{"1.18.+build", false},
+		{"1.18.16-", false},
+		{"1.18.16+", false},
+	}
+	for _, tt := range tests {
+		if got := SupportedVersion(tt.version); got != tt.want {
+			t.Errorf("SupportedVersion(%q) = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestServerParentCancellationAllowsGracefulStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server, err := StartServer(ctx, ServerOptions{
+		Command:        os.Args[0],
+		CommandArgs:    []string{"-test.run=TestOpenCodeServerHelperProcess"},
+		Directory:      t.TempDir(),
+		StartupTimeout: 5 * time.Second,
+		Environment: map[string]string{
+			"GO_WANT_OPENCODE_SERVER_HELPER": "1",
+			"GO_OPENCODE_HELPER_VERSION":     "1.18.16",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartServer: %v", err)
+	}
+	cancel()
+
+	select {
+	case <-server.Done():
+		t.Fatal("parent cancellation killed the server before the worker could abort its active turn")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := server.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestServerStopsWhenParentExits(t *testing.T) {
+	if os.Getenv("GO_WANT_OPENCODE_PARENT_HELPER") == "1" {
+		descendantPIDPath := os.Getenv("GO_OPENCODE_DESCENDANT_PID_PATH")
+		server, err := StartServer(context.Background(), ServerOptions{
+			Command:        os.Args[0],
+			CommandArgs:    []string{"-test.run=^TestOpenCodeServerHelperProcess$"},
+			Directory:      os.TempDir(),
+			StartupTimeout: 5 * time.Second,
+			Environment: map[string]string{
+				"GO_WANT_OPENCODE_SERVER_HELPER":  "1",
+				"GO_OPENCODE_HELPER_VERSION":      "1.18.16",
+				"GO_OPENCODE_HELPER_CHILD":        "1",
+				"GO_OPENCODE_DESCENDANT_PID_PATH": descendantPIDPath,
+			},
+		})
+		if err != nil {
+			os.Exit(2)
+		}
+		pid := server.PID()
+		if data, readErr := os.ReadFile(descendantPIDPath); readErr == nil {
+			pid, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+		}
+		state := State{URL: server.URL(), Username: server.Username(), Password: server.Password(), PID: pid, Directory: os.TempDir()}
+		data, _ := json.Marshal(state)
+		if err := os.WriteFile(os.Getenv("GO_OPENCODE_PARENT_STATE"), data, 0600); err != nil {
+			os.Exit(3)
+		}
+		os.Exit(0)
+	}
+
+	statePath := filepath.Join(t.TempDir(), "server.json")
+	descendantPIDPath := filepath.Join(t.TempDir(), "descendant.pid")
+	parent := exec.Command(os.Args[0], "-test.run=^TestServerStopsWhenParentExits$")
+	parent.Env = append(os.Environ(),
+		"GO_WANT_OPENCODE_PARENT_HELPER=1",
+		"GO_OPENCODE_PARENT_STATE="+statePath,
+		"GO_OPENCODE_DESCENDANT_PID_PATH="+descendantPIDPath,
+	)
+	if output, err := parent.CombinedOutput(); err != nil {
+		t.Fatalf("parent helper: %v\n%s", err, output)
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = terminateProcessTree(state.PID) })
+	client, err := NewClient(state.URL, state.Username, state.Password, state.Directory, &http.Client{Timeout: 100 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		healthCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		_, healthErr := client.Health(healthCtx)
+		cancel()
+		if healthErr != nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("OpenCode server survived its worker parent")
+}
+
+func TestServerProcessUsesRandomCredentials(t *testing.T) {
+	t.Parallel()
+	start := func() *ServerProcess {
+		server, err := StartServer(context.Background(), ServerOptions{
+			Command:        os.Args[0],
+			CommandArgs:    []string{"-test.run=TestOpenCodeServerHelperProcess"},
+			Directory:      t.TempDir(),
+			StartupTimeout: 5 * time.Second,
+			Environment: map[string]string{
+				"GO_WANT_OPENCODE_SERVER_HELPER": "1",
+				"GO_OPENCODE_HELPER_VERSION":     "1.18.16",
+			},
+		})
+		if err != nil {
+			t.Fatalf("StartServer: %v", err)
+		}
+		return server
+	}
+	first := start()
+	defer first.Stop()
+	second := start()
+	defer second.Stop()
+	if first.Password() == "" || first.Password() == second.Password() {
+		t.Fatal("server credentials were empty or reused")
+	}
+}
+
+func TestMergeEnvironmentOverridesKeys(t *testing.T) {
+	base := []string{"PATH=old", "KEEP=value"}
+	overlayKey := "PATH"
+	if runtime.GOOS == "windows" {
+		overlayKey = "Path"
+	}
+	merged := mergeEnvironment(base, map[string]string{overlayKey: "new"})
+	var pathValues int
+	for _, entry := range merged {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PATH") {
+			pathValues++
+			if value != "new" {
+				t.Fatalf("PATH = %q, want new", value)
+			}
+		}
+	}
+	if pathValues != 1 {
+		t.Fatalf("PATH entries = %d, want 1: %v", pathValues, merged)
+	}
+}
+
+func TestOpenCodeServerHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_OPENCODE_SERVER_HELPER") != "1" {
+		return
+	}
+	if os.Getenv("GO_OPENCODE_HELPER_CHILD") == "1" {
+		child := exec.Command(os.Args[0], os.Args[1:]...)
+		child.Env = append(os.Environ(), "GO_OPENCODE_HELPER_CHILD=0")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(5)
+		}
+		_ = child.Wait()
+		os.Exit(0)
+	}
+	if path := os.Getenv("GO_OPENCODE_DESCENDANT_PID_PATH"); path != "" {
+		if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
+			os.Exit(6)
+		}
+	}
+	port := 0
+	hasServe := false
+	hostname := ""
+	for i, arg := range os.Args {
+		if arg == "serve" {
+			hasServe = true
+		}
+		if arg == "--port" && i+1 < len(os.Args) {
+			port, _ = strconv.Atoi(os.Args[i+1])
+		}
+		if arg == "--hostname" && i+1 < len(os.Args) {
+			hostname = os.Args[i+1]
+		}
+	}
+	if !hasServe || port == 0 || hostname != "127.0.0.1" {
+		fmt.Fprintln(os.Stderr, "missing secure serve arguments")
+		os.Exit(2)
+	}
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(3)
+	}
+	version := os.Getenv("GO_OPENCODE_HELPER_VERSION")
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, _ := r.BasicAuth()
+		if user != os.Getenv("OPENCODE_SERVER_USERNAME") || pass != os.Getenv("OPENCODE_SERVER_PASSWORD") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path != "/global/health" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Health{Healthy: true, Version: version})
+	})}
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		os.Exit(4)
+	}
+	os.Exit(0)
+}

--- a/internal/opencodeserver/process_unix.go
+++ b/internal/opencodeserver/process_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package opencodeserver
+
+import "syscall"
+
+func terminateProcessTree(pid int) error {
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+	if err == syscall.ESRCH {
+		return nil
+	}
+	return err
+}

--- a/internal/opencodeserver/process_windows.go
+++ b/internal/opencodeserver/process_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package opencodeserver
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func terminateProcessTree(pid int) error {
+	children, err := snapshotProcessChildren()
+	if err != nil {
+		return err
+	}
+
+	var killErr error
+	var kill func(uint32)
+	kill = func(parent uint32) {
+		for _, child := range children[parent] {
+			kill(child)
+			killErr = errors.Join(killErr, terminatePID(child))
+		}
+	}
+	kill(uint32(pid))
+	killErr = errors.Join(killErr, terminatePID(uint32(pid)))
+	return killErr
+}
+
+func snapshotProcessChildren() (map[uint32][]uint32, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(snapshot)
+
+	children := make(map[uint32][]uint32)
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return nil, err
+	}
+	for {
+		children[entry.ParentProcessID] = append(children[entry.ParentProcessID], entry.ProcessID)
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, syscall.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, err
+		}
+	}
+	return children, nil
+}
+
+func terminatePID(pid uint32) error {
+	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return nil
+		}
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	var exitCode uint32
+	const stillActive = 259
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err == nil && exitCode != stillActive {
+		return nil
+	}
+	return windows.TerminateProcess(handle, 1)
+}

--- a/internal/opencodeserver/state.go
+++ b/internal/opencodeserver/state.go
@@ -1,0 +1,37 @@
+package opencodeserver
+
+import (
+	"context"
+
+	"github.com/steveyegge/gastown/internal/opencodestate"
+)
+
+type State = opencodestate.State
+
+func StatePath(townRoot, gasTownSession string) string {
+	return opencodestate.Path(townRoot, gasTownSession)
+}
+
+func SaveState(townRoot string, state State) error {
+	return opencodestate.Save(townRoot, state)
+}
+
+func LoadState(townRoot, gasTownSession string) (State, error) {
+	return opencodestate.Load(townRoot, gasTownSession)
+}
+
+func RemoveState(townRoot, gasTownSession, openCodeSession string) error {
+	return opencodestate.Remove(townRoot, gasTownSession, openCodeSession)
+}
+
+func ActiveState(ctx context.Context, townRoot, gasTownSession string) (State, bool) {
+	return opencodestate.Active(ctx, townRoot, gasTownSession)
+}
+
+func AcquireSessionLock(townRoot, gasTownSession string) (func(), error) {
+	return opencodestate.AcquireSessionLock(townRoot, gasTownSession)
+}
+
+func SessionLockHeld(townRoot, gasTownSession string) (bool, error) {
+	return opencodestate.SessionLockHeld(townRoot, gasTownSession)
+}

--- a/internal/opencodeserver/state_test.go
+++ b/internal/opencodeserver/state_test.go
@@ -1,0 +1,152 @@
+package opencodeserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestStateRoundTripAndActiveCheck(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, _ := r.BasicAuth()
+		if user != "opencode" || pass != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"healthy":true,"version":"1.18.16"}`))
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	want := State{
+		GasTownSession:  "gt-rig/polecats/worker",
+		OpenCodeSession: "ses_test",
+		Directory:       "/worktree",
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+		PID:             123,
+		Version:         "1.18.16",
+		CreatedAt:       time.Now().UTC().Truncate(time.Second),
+	}
+	if err := SaveState(townRoot, want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	got, err := LoadState(townRoot, want.GasTownSession)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.OpenCodeSession != want.OpenCodeSession || got.Password != want.Password || got.GasTownSession != want.GasTownSession {
+		t.Fatalf("LoadState = %#v, want %#v", got, want)
+	}
+	info, err := os.Stat(StatePath(townRoot, want.GasTownSession))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0077 != 0 {
+		t.Fatalf("state permissions = %o, want no group/other access", info.Mode().Perm())
+	}
+
+	release, err := AcquireSessionLock(townRoot, want.GasTownSession)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	active, ok := ActiveState(context.Background(), townRoot, want.GasTownSession)
+	if !ok || active.OpenCodeSession != want.OpenCodeSession {
+		t.Fatalf("ActiveState = %#v, %v", active, ok)
+	}
+
+	if err := RemoveState(townRoot, want.GasTownSession, "different_session"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadState(townRoot, want.GasTownSession); err != nil {
+		t.Fatalf("mismatched RemoveState removed mapping: %v", err)
+	}
+	if err := RemoveState(townRoot, want.GasTownSession, want.OpenCodeSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadState(townRoot, want.GasTownSession); !os.IsNotExist(err) {
+		t.Fatalf("LoadState after remove = %v, want not exists", err)
+	}
+}
+
+func TestActiveStateRejectsHealthyServerWithoutWorkerLock(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"healthy":true,"version":"1.18.16"}`))
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	state := State{
+		GasTownSession:  "gt-rig-worker",
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}
+	if err := SaveState(townRoot, state); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ActiveState(context.Background(), townRoot, state.GasTownSession); ok {
+		t.Fatal("ActiveState reported server without worker ownership as active")
+	}
+}
+
+func TestActiveStateRejectsStaleServer(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	state := State{
+		GasTownSession:  "gt-rig-worker",
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             "http://127.0.0.1:1",
+		Username:        "opencode",
+		Password:        "secret",
+	}
+	if err := SaveState(townRoot, state); err != nil {
+		t.Fatal(err)
+	}
+	release, err := AcquireSessionLock(townRoot, state.GasTownSession)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, ok := ActiveState(ctx, townRoot, state.GasTownSession); ok {
+		t.Fatal("ActiveState reported stale server as active")
+	}
+}
+
+func TestActiveStateRejectsNonLoopbackURL(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	state := State{
+		GasTownSession:  "gt-rig-worker",
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             "http://example.com",
+		Username:        "opencode",
+		Password:        "secret",
+	}
+	if err := SaveState(townRoot, state); err != nil {
+		t.Fatal(err)
+	}
+	release, err := AcquireSessionLock(townRoot, state.GasTownSession)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if _, ok := ActiveState(context.Background(), townRoot, state.GasTownSession); ok {
+		t.Fatal("ActiveState accepted a non-loopback server URL")
+	}
+}

--- a/internal/opencodeserver/worker.go
+++ b/internal/opencodeserver/worker.go
@@ -218,12 +218,20 @@ func resolveWorkerSession(ctx context.Context, client *Client, opts WorkerOption
 }
 
 func sameDirectory(left, right string) bool {
-	left = filepath.Clean(left)
-	right = filepath.Clean(right)
+	left = canonicalDirectory(left)
+	right = canonicalDirectory(right)
 	if runtime.GOOS == "windows" {
 		return strings.EqualFold(left, right)
 	}
 	return left == right
+}
+
+func canonicalDirectory(path string) string {
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return path
 }
 
 func deliverQueuedNudges(ctx context.Context, client *Client, townRoot, gasTownSession, openCodeSession string, promptOpts ...PromptOptions) (bool, error) {

--- a/internal/opencodeserver/worker.go
+++ b/internal/opencodeserver/worker.go
@@ -1,0 +1,278 @@
+package opencodeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/nudge"
+)
+
+type WorkerOptions struct {
+	TownRoot       string
+	GasTownSession string
+	Directory      string
+	Command        string
+	StartupPrompt  string
+	Agent          string
+	Model          string
+	Variant        string
+	WorkKey        string
+	PollInterval   time.Duration
+	StartupTimeout time.Duration
+}
+
+func RunWorker(ctx context.Context, opts WorkerOptions) (runErr error) {
+	if opts.TownRoot == "" || opts.GasTownSession == "" || opts.Directory == "" {
+		return fmt.Errorf("town root, Gas Town session, and directory are required")
+	}
+	if opts.Command == "" {
+		opts.Command = "opencode"
+	}
+	if opts.Agent == "" {
+		opts.Agent = "build"
+	}
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = time.Second
+	}
+	server, err := StartServer(ctx, ServerOptions{
+		Command:        opts.Command,
+		Directory:      opts.Directory,
+		StartupTimeout: opts.StartupTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	var releaseLock func()
+	defer func() {
+		if stopErr := server.Stop(); stopErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("stopping OpenCode server: %w", stopErr))
+		}
+		if releaseLock != nil {
+			releaseLock()
+		}
+	}()
+
+	releaseLock, err = AcquireSessionLock(opts.TownRoot, opts.GasTownSession)
+	if err != nil {
+		return err
+	}
+	if err := nudge.StopPoller(opts.TownRoot, opts.GasTownSession); err != nil {
+		return fmt.Errorf("stopping stale nudge poller: %w", err)
+	}
+
+	client, err := server.NewClient(opts.Directory)
+	if err != nil {
+		return err
+	}
+	session, err := resolveWorkerSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	state := State{
+		GasTownSession:  opts.GasTownSession,
+		OpenCodeSession: session.ID,
+		WorkKey:         opts.WorkKey,
+		Directory:       opts.Directory,
+		Agent:           opts.Agent,
+		Model:           opts.Model,
+		Variant:         opts.Variant,
+		URL:             server.URL(),
+		Username:        server.Username(),
+		Password:        server.Password(),
+		PID:             server.PID(),
+		Version:         server.Version(),
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := SaveState(opts.TownRoot, state); err != nil {
+		return err
+	}
+
+	watcher, err := nudge.WatcherForSession(opts.TownRoot, opts.GasTownSession)
+	if err != nil {
+		return fmt.Errorf("starting OpenCode nudge watcher: %w", err)
+	}
+	defer watcher.Close()
+	status, err := client.Status(ctx, session.ID)
+	if err != nil {
+		return fmt.Errorf("checking initial OpenCode status: %w", err)
+	}
+	lifecycle := newSessionLifecycle(session.ID, status)
+	defer func() {
+		if !lifecycle.InFlight() {
+			return
+		}
+		abortCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		abortErr := client.Abort(abortCtx, session.ID)
+		cancel()
+		if abortErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("aborting active OpenCode turn: %w", abortErr))
+		}
+	}()
+	// Snapshot status before subscribing so the stream cannot contain a prior
+	// turn's buffered busy/idle pair. The stream still opens before any prompt.
+	eventStream, err := client.Events(ctx)
+	if err != nil {
+		return fmt.Errorf("subscribing to OpenCode lifecycle events: %w", err)
+	}
+	defer eventStream.Close()
+
+	if strings.TrimSpace(opts.StartupPrompt) != "" {
+		if !lifecycle.BeginPrompt() {
+			return fmt.Errorf("OpenCode session %s is busy before startup prompt", session.ID)
+		}
+		if err := client.PromptAsync(ctx, session.ID, opts.StartupPrompt, PromptOptions{Agent: opts.Agent, Model: opts.Model, Variant: opts.Variant}); err != nil {
+			lifecycle.PromptFailed()
+			return fmt.Errorf("submitting OpenCode startup prompt: %w", err)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "OpenCode server worker ready (session %s, OpenCode %s)\n", session.ID, server.Version())
+
+	ticker := time.NewTicker(opts.PollInterval)
+	defer ticker.Stop()
+	events := eventStream.Events()
+	eventErrors := eventStream.Errors()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-server.Done():
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("OpenCode server stopped: %v", server.Err())
+		case event, ok := <-events:
+			if !ok {
+				if ctx.Err() != nil {
+					return nil
+				}
+				if eventErrors != nil {
+					select {
+					case streamErr, errorOpen := <-eventErrors:
+						if errorOpen && streamErr != nil {
+							return fmt.Errorf("OpenCode event stream failed: %w", streamErr)
+						}
+					default:
+					}
+				}
+				return fmt.Errorf("OpenCode event stream closed")
+			}
+			if lifecycle.Observe(event) {
+				if _, err := deliverQueuedNudgesWithLifecycle(ctx, client, lifecycle, opts.TownRoot, opts.GasTownSession, session.ID, PromptOptions{Agent: opts.Agent, Model: opts.Model, Variant: opts.Variant}); err != nil {
+					fmt.Fprintf(os.Stderr, "OpenCode nudge delivery failed: %v\n", err)
+				}
+			}
+		case streamErr, ok := <-eventErrors:
+			if !ok {
+				eventErrors = nil
+				continue
+			}
+			if streamErr != nil && ctx.Err() == nil {
+				return fmt.Errorf("OpenCode event stream failed: %w", streamErr)
+			}
+		case <-watcher.Events():
+			if _, err := deliverQueuedNudgesWithLifecycle(ctx, client, lifecycle, opts.TownRoot, opts.GasTownSession, session.ID, PromptOptions{Agent: opts.Agent, Model: opts.Model, Variant: opts.Variant}); err != nil {
+				fmt.Fprintf(os.Stderr, "OpenCode nudge delivery failed: %v\n", err)
+			}
+		case <-ticker.C:
+			if _, err := deliverQueuedNudgesWithLifecycle(ctx, client, lifecycle, opts.TownRoot, opts.GasTownSession, session.ID, PromptOptions{Agent: opts.Agent, Model: opts.Model, Variant: opts.Variant}); err != nil {
+				fmt.Fprintf(os.Stderr, "OpenCode nudge delivery failed: %v\n", err)
+			}
+		}
+	}
+}
+
+func resolveWorkerSession(ctx context.Context, client *Client, opts WorkerOptions) (Session, error) {
+	prior, loadErr := LoadState(opts.TownRoot, opts.GasTownSession)
+	if loadErr != nil && !os.IsNotExist(loadErr) {
+		return Session{}, fmt.Errorf("loading prior OpenCode worker state: %w", loadErr)
+	}
+	if loadErr == nil && opts.WorkKey != "" && sameDirectory(prior.Directory, opts.Directory) && prior.WorkKey == opts.WorkKey {
+		session, getErr := client.GetSession(ctx, prior.OpenCodeSession)
+		if getErr == nil {
+			if session.Directory != "" && !sameDirectory(session.Directory, opts.Directory) {
+				return Session{}, fmt.Errorf("OpenCode session %s directory mismatch: got %q, want %q", session.ID, session.Directory, opts.Directory)
+			}
+			return session, nil
+		}
+		if !IsAPIStatus(getErr, http.StatusNotFound) {
+			return Session{}, fmt.Errorf("looking up prior OpenCode session %s: %w", prior.OpenCodeSession, getErr)
+		}
+	}
+	session, err := client.CreateSession(ctx, CreateSessionOptions{
+		Title:   "Gas Town " + opts.GasTownSession,
+		Agent:   opts.Agent,
+		Model:   opts.Model,
+		Variant: opts.Variant,
+	})
+	if err != nil {
+		return Session{}, fmt.Errorf("creating OpenCode worker session: %w", err)
+	}
+	return session, nil
+}
+
+func sameDirectory(left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func deliverQueuedNudges(ctx context.Context, client *Client, townRoot, gasTownSession, openCodeSession string, promptOpts ...PromptOptions) (bool, error) {
+	lifecycle := newSessionLifecycle(openCodeSession, Status{})
+	return deliverQueuedNudgesWithLifecycle(ctx, client, lifecycle, townRoot, gasTownSession, openCodeSession, promptOpts...)
+}
+
+func deliverQueuedNudgesWithLifecycle(ctx context.Context, client *Client, lifecycle *sessionLifecycle, townRoot, gasTownSession, openCodeSession string, promptOpts ...PromptOptions) (bool, error) {
+	status, err := client.Status(ctx, openCodeSession)
+	if err != nil {
+		return false, fmt.Errorf("checking OpenCode status: %w", err)
+	}
+	lifecycle.Reconcile(status)
+	if !lifecycle.Ready() {
+		return false, nil
+	}
+	claimed, err := nudge.ClaimOne(townRoot, gasTownSession)
+	if err != nil {
+		return false, fmt.Errorf("claiming nudges: %w", err)
+	}
+	drained := claimed.Nudges
+	if len(drained) == 0 {
+		return false, nil
+	}
+	if !lifecycle.BeginPrompt() {
+		if err := claimed.Release(); err != nil {
+			return false, fmt.Errorf("OpenCode session became busy; releasing nudge claim failed: %w", err)
+		}
+		return false, nil
+	}
+	prompt := nudge.FormatForInjection(drained)
+	var options PromptOptions
+	if len(promptOpts) > 0 {
+		options = promptOpts[0]
+	}
+	options.MessageID = claimed.MessageID()
+	submitted, err := client.promptAsync(ctx, openCodeSession, prompt, options)
+	if err != nil {
+		lifecycle.PromptFailed()
+		if releaseErr := claimed.Release(); releaseErr != nil {
+			return false, fmt.Errorf("submitting OpenCode nudge: %v; releasing claim failed: %w", err, releaseErr)
+		}
+		return false, fmt.Errorf("submitting OpenCode nudge: %w", err)
+	}
+	if !submitted {
+		lifecycle.AwaitRecoveredPrompt()
+	}
+	if err := claimed.Commit(); err != nil {
+		return true, fmt.Errorf("OpenCode nudge accepted but clearing queue claim failed: %w", err)
+	}
+	return true, nil
+}

--- a/internal/opencodeserver/worker_test.go
+++ b/internal/opencodeserver/worker_test.go
@@ -1,0 +1,455 @@
+package opencodeserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/nudge"
+)
+
+func TestLifecycleErrorCompletesInFlightPrompt(t *testing.T) {
+	lifecycle := newSessionLifecycle("ses_test", Status{Type: "idle"})
+	if !lifecycle.BeginPrompt() {
+		t.Fatal("BeginPrompt rejected an idle session")
+	}
+	if lifecycle.Observe(Event{Type: "session.error", Properties: EventProperties{SessionID: "ses_test"}}) {
+		t.Fatal("session.error admitted another prompt before status reconciliation")
+	}
+	lifecycle.Reconcile(Status{Type: "idle"})
+	if lifecycle.Ready() {
+		t.Fatal("one idle snapshot cleared an errored prompt too early")
+	}
+	lifecycle.Reconcile(Status{Type: "idle"})
+	if !lifecycle.Ready() {
+		t.Fatal("lifecycle remained wedged after confirmed idle status")
+	}
+}
+
+func TestLifecycleIgnoresStaleErrorWhenNewPromptBecomesBusy(t *testing.T) {
+	lifecycle := newSessionLifecycle("ses_test", Status{Type: "idle"})
+	if !lifecycle.BeginPrompt() {
+		t.Fatal("BeginPrompt rejected an idle session")
+	}
+	lifecycle.Observe(Event{Type: "session.error", Properties: EventProperties{SessionID: "ses_test"}})
+	lifecycle.Reconcile(Status{Type: "busy"})
+	lifecycle.Observe(Event{Type: "session.idle", Properties: EventProperties{SessionID: "ses_test"}})
+	if !lifecycle.Ready() {
+		t.Fatal("busy-to-idle transition did not complete after a stale error")
+	}
+}
+
+func TestDeliverQueuedNudgesWhenIdle(t *testing.T) {
+	t.Parallel()
+	var prompt string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session/status":
+			_, _ = w.Write([]byte(`{}`))
+		case "/session/ses_test/prompt_async":
+			var body struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			prompt = body.Parts[0].Text
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	for _, message := range []string{"first"} {
+		if err := nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: message}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	delivered, err := deliverQueuedNudges(context.Background(), client, townRoot, gtSession, "ses_test")
+	if err != nil || !delivered {
+		t.Fatalf("deliverQueuedNudges = %v, %v", delivered, err)
+	}
+	if !strings.Contains(prompt, "first") || !strings.Contains(prompt, "mayor") {
+		t.Fatalf("prompt = %q", prompt)
+	}
+	if pending, _ := nudge.Pending(townRoot, gtSession); pending != 0 {
+		t.Fatalf("pending = %d, want 0", pending)
+	}
+}
+
+func TestDeliverQueuedNudgesKeepsQueueWhileBusy(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ses_test":{"type":"busy"}}`))
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	_ = nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "wait"})
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	delivered, err := deliverQueuedNudges(context.Background(), client, townRoot, gtSession, "ses_test")
+	if err != nil || delivered {
+		t.Fatalf("deliverQueuedNudges = %v, %v", delivered, err)
+	}
+	if pending, _ := nudge.Pending(townRoot, gtSession); pending != 1 {
+		t.Fatalf("pending = %d, want 1", pending)
+	}
+}
+
+func TestDeliverQueuedNudgesRequeuesFailedPrompt(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/session/status" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	_ = nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "retry"})
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	delivered, err := deliverQueuedNudges(context.Background(), client, townRoot, gtSession, "ses_test")
+	if err == nil || delivered {
+		t.Fatalf("deliverQueuedNudges = %v, %v, want failure", delivered, err)
+	}
+	if pending, _ := nudge.Pending(townRoot, gtSession); pending != 1 {
+		t.Fatalf("pending = %d, want 1", pending)
+	}
+}
+
+func TestDeliverQueuedNudgesRecognizesAcceptedPromptAfterResponseError(t *testing.T) {
+	t.Parallel()
+	var messageExists bool
+	var prompts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session/status":
+			_, _ = w.Write([]byte(`{}`))
+		case strings.HasPrefix(r.URL.Path, "/session/ses_test/message/"):
+			if !messageExists {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/session/ses_test/prompt_async":
+			var body struct {
+				MessageID string `json:"messageID"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if !strings.HasPrefix(body.MessageID, "msg") {
+				t.Fatalf("messageID = %q", body.MessageID)
+			}
+			prompts++
+			messageExists = true
+			http.Error(w, "response lost after acceptance", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	if err := nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "once"}); err != nil {
+		t.Fatal(err)
+	}
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	delivered, err := deliverQueuedNudges(context.Background(), client, townRoot, gtSession, "ses_test")
+	if err != nil || !delivered || prompts != 1 {
+		t.Fatalf("delivery = %v, %v, prompts=%d", delivered, err, prompts)
+	}
+	if pending, _ := nudge.Pending(townRoot, gtSession); pending != 0 {
+		t.Fatalf("pending = %d, want 0", pending)
+	}
+}
+
+func TestDeliverQueuedNudgesRecoversExistingMessageWithoutWedging(t *testing.T) {
+	t.Parallel()
+	var prompts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session/status":
+			_, _ = w.Write([]byte(`{}`))
+		case strings.HasPrefix(r.URL.Path, "/session/ses_test/message/"):
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/session/ses_test/prompt_async":
+			prompts++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	if err := nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "already accepted"}); err != nil {
+		t.Fatal(err)
+	}
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	lifecycle := newSessionLifecycle("ses_test", Status{})
+	delivered, err := deliverQueuedNudgesWithLifecycle(context.Background(), client, lifecycle, townRoot, gtSession, "ses_test")
+	if err != nil || !delivered || prompts != 0 {
+		t.Fatalf("delivery = %v, %v, prompts=%d", delivered, err, prompts)
+	}
+	if lifecycle.Ready() || !lifecycle.InFlight() {
+		t.Fatal("existing message recovery admitted another prompt before status confirmation")
+	}
+	lifecycle.Reconcile(Status{Type: "idle"})
+	if lifecycle.Ready() {
+		t.Fatal("one idle check completed recovered prompt")
+	}
+	lifecycle.Reconcile(Status{Type: "idle"})
+	if !lifecycle.Ready() {
+		t.Fatal("existing message recovery remained in flight after confirmed idle")
+	}
+}
+
+func TestDeliverQueuedNudgesWaitsForBusyToIdleTransition(t *testing.T) {
+	t.Parallel()
+	var prompts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session/status":
+			_, _ = w.Write([]byte(`{}`))
+		case "/session/ses_test/prompt_async":
+			prompts++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	gtSession := "gt-rig-worker"
+	client, _ := NewClient(server.URL, "opencode", "secret", t.TempDir(), server.Client())
+	lifecycle := newSessionLifecycle("ses_test", Status{})
+
+	_ = nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "first"})
+	delivered, err := deliverQueuedNudgesWithLifecycle(context.Background(), client, lifecycle, townRoot, gtSession, "ses_test")
+	if err != nil || !delivered {
+		t.Fatalf("first delivery = %v, %v", delivered, err)
+	}
+
+	_ = nudge.Enqueue(townRoot, gtSession, nudge.QueuedNudge{Sender: "mayor", Message: "second"})
+	delivered, err = deliverQueuedNudgesWithLifecycle(context.Background(), client, lifecycle, townRoot, gtSession, "ses_test")
+	if err != nil || delivered {
+		t.Fatalf("delivery before busy transition = %v, %v", delivered, err)
+	}
+	if prompts != 1 {
+		t.Fatalf("prompts = %d, want 1", prompts)
+	}
+	if pending, _ := nudge.Pending(townRoot, gtSession); pending != 1 {
+		t.Fatalf("pending = %d, want 1", pending)
+	}
+
+	lifecycle.Observe(Event{Type: "session.status", Properties: EventProperties{
+		SessionID: "ses_test",
+		Status:    Status{Type: "busy"},
+	}})
+	lifecycle.Observe(Event{Type: "session.idle", Properties: EventProperties{SessionID: "ses_test"}})
+	delivered, err = deliverQueuedNudgesWithLifecycle(context.Background(), client, lifecycle, townRoot, gtSession, "ses_test")
+	if err != nil || !delivered || prompts != 2 {
+		t.Fatalf("delivery after idle = %v, %v, prompts=%d", delivered, err, prompts)
+	}
+}
+
+func TestResolveWorkerSessionResumesSameWorkKey(t *testing.T) {
+	t.Parallel()
+	var creates int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/session/ses_existing":
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_existing", Directory: "/worktree"})
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			creates++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_new", Directory: "/worktree"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	opts := WorkerOptions{TownRoot: townRoot, GasTownSession: "gt-rig-worker", Directory: "/worktree", WorkKey: "polecat/worker/gt-123"}
+	if err := SaveState(townRoot, State{
+		GasTownSession:  opts.GasTownSession,
+		OpenCodeSession: "ses_existing",
+		WorkKey:         opts.WorkKey,
+		Directory:       opts.Directory,
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, _ := NewClient(server.URL, "opencode", "secret", opts.Directory, server.Client())
+	session, err := resolveWorkerSession(context.Background(), client, opts)
+	if err != nil || session.ID != "ses_existing" || creates != 0 {
+		t.Fatalf("resolveWorkerSession = %#v, %v, creates=%d", session, err, creates)
+	}
+
+	opts.WorkKey = "polecat/worker/gt-456"
+	session, err = resolveWorkerSession(context.Background(), client, opts)
+	if err != nil || session.ID != "ses_new" || creates != 1 {
+		t.Fatalf("new work resolve = %#v, %v, creates=%d", session, err, creates)
+	}
+}
+
+func TestResolveWorkerSessionDoesNotResumeWithoutWorkKey(t *testing.T) {
+	t.Parallel()
+	var gets, creates int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/session/ses_existing":
+			gets++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_existing", Directory: "/worktree"})
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			creates++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_new", Directory: "/worktree"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	opts := WorkerOptions{TownRoot: townRoot, GasTownSession: "gt-rig-worker", Directory: "/worktree"}
+	if err := SaveState(townRoot, State{
+		GasTownSession:  opts.GasTownSession,
+		OpenCodeSession: "ses_existing",
+		Directory:       opts.Directory,
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client, _ := NewClient(server.URL, "opencode", "secret", opts.Directory, server.Client())
+	session, err := resolveWorkerSession(context.Background(), client, opts)
+	if err != nil || session.ID != "ses_new" || gets != 0 || creates != 1 {
+		t.Fatalf("resolveWorkerSession = %#v, %v, gets=%d creates=%d", session, err, gets, creates)
+	}
+}
+
+func TestResolveWorkerSessionReturnsCorruptStateError(t *testing.T) {
+	t.Parallel()
+	var creates int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/session" {
+			creates++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_new", Directory: "/worktree"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	opts := WorkerOptions{TownRoot: townRoot, GasTownSession: "gt-rig-worker", Directory: "/worktree", WorkKey: "feature/test"}
+	statePath := StatePath(townRoot, opts.GasTownSession)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, _ := NewClient(server.URL, "opencode", "secret", opts.Directory, server.Client())
+	if _, err := resolveWorkerSession(context.Background(), client, opts); err == nil {
+		t.Fatal("resolveWorkerSession silently replaced corrupt durable state")
+	}
+	if creates != 0 {
+		t.Fatalf("creates = %d, want 0", creates)
+	}
+}
+
+func TestResolveWorkerSessionReturnsTransientLookupError(t *testing.T) {
+	t.Parallel()
+	var creates int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/session/ses_existing":
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			creates++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_new", Directory: "/worktree"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	opts := WorkerOptions{TownRoot: townRoot, GasTownSession: "gt-rig-worker", Directory: "/worktree", WorkKey: "feature/test"}
+	if err := SaveState(townRoot, State{
+		GasTownSession:  opts.GasTownSession,
+		OpenCodeSession: "ses_existing",
+		WorkKey:         opts.WorkKey,
+		Directory:       opts.Directory,
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	client, _ := NewClient(server.URL, "opencode", "secret", opts.Directory, server.Client())
+	if _, err := resolveWorkerSession(context.Background(), client, opts); err == nil {
+		t.Fatal("resolveWorkerSession silently forked on a transient lookup failure")
+	}
+	if creates != 0 {
+		t.Fatalf("creates = %d, want 0", creates)
+	}
+}
+
+func TestResolveWorkerSessionCreatesWhenPriorSessionIsMissing(t *testing.T) {
+	t.Parallel()
+	var creates int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/session/ses_missing":
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			creates++
+			_ = json.NewEncoder(w).Encode(Session{ID: "ses_new", Directory: "/worktree"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	opts := WorkerOptions{TownRoot: townRoot, GasTownSession: "gt-rig-worker", Directory: "/worktree", WorkKey: "feature/test"}
+	if err := SaveState(townRoot, State{
+		GasTownSession:  opts.GasTownSession,
+		OpenCodeSession: "ses_missing",
+		WorkKey:         opts.WorkKey,
+		Directory:       opts.Directory,
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	client, _ := NewClient(server.URL, "opencode", "secret", opts.Directory, server.Client())
+	session, err := resolveWorkerSession(context.Background(), client, opts)
+	if err != nil || session.ID != "ses_new" || creates != 1 {
+		t.Fatalf("resolveWorkerSession = %#v, %v, creates=%d", session, err, creates)
+	}
+}

--- a/internal/opencodeserver/worker_windows_test.go
+++ b/internal/opencodeserver/worker_windows_test.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package opencodeserver
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestSameDirectoryTreatsWindowsShortAndLongPathsAsEqual(t *testing.T) {
+	dir := t.TempDir()
+	longPath := windowsPathName(t, dir, windows.GetLongPathName)
+	shortPath := windowsPathName(t, longPath, windows.GetShortPathName)
+	if strings.EqualFold(filepath.Clean(longPath), filepath.Clean(shortPath)) {
+		t.Skip("8.3 short path names are unavailable on this volume")
+	}
+	if !sameDirectory(longPath, shortPath) {
+		t.Fatalf("sameDirectory(%q, %q) = false", longPath, shortPath)
+	}
+}
+
+func windowsPathName(t *testing.T, path string, convert func(*uint16, *uint16, uint32) (uint32, error)) string {
+	t.Helper()
+	source, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]uint16, 32768)
+	length, err := convert(source, &buffer[0], uint32(len(buffer)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if length == 0 || length >= uint32(len(buffer)) {
+		t.Fatalf("invalid converted path length %d", length)
+	}
+	return windows.UTF16ToString(buffer[:length])
+}

--- a/internal/opencodestate/lock_test.go
+++ b/internal/opencodestate/lock_test.go
@@ -1,0 +1,36 @@
+package opencodestate
+
+import "testing"
+
+func TestAcquireSessionLockRejectsSecondOwner(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	release, err := AcquireSessionLock(townRoot, "gt-rig-worker")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer release()
+	if held, err := SessionLockHeld(townRoot, "gt-rig-worker"); err != nil || !held {
+		t.Fatalf("SessionLockHeld = %v, %v, want true", held, err)
+	}
+
+	if _, err := AcquireSessionLock(townRoot, "gt-rig-worker"); err == nil {
+		t.Fatal("second acquire succeeded")
+	}
+	release()
+	if held, err := SessionLockHeld(townRoot, "gt-rig-worker"); err != nil || held {
+		t.Fatalf("SessionLockHeld after release = %v, %v, want false", held, err)
+	}
+	if nextRelease, err := AcquireSessionLock(townRoot, "gt-rig-worker"); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	} else {
+		nextRelease()
+	}
+}
+
+func TestSessionLockHeldWithoutLockFile(t *testing.T) {
+	t.Parallel()
+	if held, err := SessionLockHeld(t.TempDir(), "gt-rig-worker"); err != nil || held {
+		t.Fatalf("SessionLockHeld = %v, %v, want false", held, err)
+	}
+}

--- a/internal/opencodestate/security_unix.go
+++ b/internal/opencodestate/security_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package opencodestate
+
+import "os"
+
+func protectCredentialPath(path string, directory bool) error {
+	if directory {
+		return os.Chmod(path, 0700)
+	}
+	return os.Chmod(path, 0600)
+}

--- a/internal/opencodestate/security_windows.go
+++ b/internal/opencodestate/security_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package opencodestate
+
+import "golang.org/x/sys/windows"
+
+func protectCredentialPath(path string, directory bool) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return err
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return err
+	}
+	inheritance := uint32(windows.NO_INHERITANCE)
+	if directory {
+		inheritance = windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT
+	}
+	entries := []windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       inheritance,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+			},
+		},
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       inheritance,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(system),
+			},
+		},
+	}
+	dacl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return err
+	}
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	)
+}

--- a/internal/opencodestate/state.go
+++ b/internal/opencodestate/state.go
@@ -1,0 +1,206 @@
+// Package opencodestate stores the durable mapping between a Gas Town tmux
+// session and its OpenCode HTTP session. It intentionally has no dependency on
+// the worker process package so low-level transports can query it safely.
+package opencodestate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/atomicfile"
+	"github.com/steveyegge/gastown/internal/constants"
+)
+
+const maxStateSize = 64 << 10
+
+type State struct {
+	GasTownSession  string    `json:"gastown_session"`
+	OpenCodeSession string    `json:"opencode_session"`
+	WorkKey         string    `json:"work_key,omitempty"`
+	Directory       string    `json:"directory"`
+	Agent           string    `json:"agent,omitempty"`
+	Model           string    `json:"model,omitempty"`
+	Variant         string    `json:"variant,omitempty"`
+	URL             string    `json:"url"`
+	Username        string    `json:"username"`
+	Password        string    `json:"password"`
+	PID             int       `json:"pid"`
+	Version         string    `json:"version"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+func Path(townRoot, gasTownSession string) string {
+	sum := sha256.Sum256([]byte(gasTownSession))
+	name := hex.EncodeToString(sum[:16]) + ".json"
+	return filepath.Join(townRoot, constants.DirRuntime, "opencode-server", name)
+}
+
+func AcquireSessionLock(townRoot, gasTownSession string) (func(), error) {
+	if townRoot == "" || gasTownSession == "" {
+		return nil, fmt.Errorf("town root and Gas Town session are required")
+	}
+	lockPath := Path(townRoot, gasTownSession) + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		return nil, fmt.Errorf("creating OpenCode lock directory: %w", err)
+	}
+	if err := protectCredentialPath(filepath.Dir(lockPath), true); err != nil {
+		return nil, fmt.Errorf("protecting OpenCode lock directory: %w", err)
+	}
+	fileLock := flock.New(lockPath, flock.SetPermissions(0600))
+	locked, err := fileLock.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("acquiring OpenCode worker lock: %w", err)
+	}
+	if !locked {
+		return nil, fmt.Errorf("OpenCode server worker is already running for %s", gasTownSession)
+	}
+	if err := protectCredentialPath(lockPath, false); err != nil {
+		_ = fileLock.Unlock()
+		return nil, fmt.Errorf("protecting OpenCode worker lock: %w", err)
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() { _ = fileLock.Unlock() })
+	}, nil
+}
+
+func SessionLockHeld(townRoot, gasTownSession string) (bool, error) {
+	if townRoot == "" || gasTownSession == "" {
+		return false, fmt.Errorf("town root and Gas Town session are required")
+	}
+	lockPath := Path(townRoot, gasTownSession) + ".lock"
+	if _, err := os.Stat(lockPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking OpenCode worker lock: %w", err)
+	}
+	probe := flock.New(lockPath)
+	locked, err := probe.TryLock()
+	if err != nil {
+		return false, fmt.Errorf("probing OpenCode worker lock: %w", err)
+	}
+	if locked {
+		_ = probe.Unlock()
+		return false, nil
+	}
+	return true, nil
+}
+
+func Save(townRoot string, state State) error {
+	if townRoot == "" || state.GasTownSession == "" || state.OpenCodeSession == "" || state.Directory == "" || state.URL == "" || state.Username == "" || state.Password == "" {
+		return fmt.Errorf("incomplete OpenCode server state")
+	}
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = time.Now().UTC()
+	}
+	path := Path(townRoot, state.GasTownSession)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating OpenCode state directory: %w", err)
+	}
+	if err := protectCredentialPath(filepath.Dir(path), true); err != nil {
+		return fmt.Errorf("protecting OpenCode state directory: %w", err)
+	}
+	if err := atomicfile.WriteJSONWithPerm(path, state, 0600); err != nil {
+		return fmt.Errorf("writing OpenCode state: %w", err)
+	}
+	if err := protectCredentialPath(path, false); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("protecting OpenCode state: %w", err)
+	}
+	return nil
+}
+
+func Load(townRoot, gasTownSession string) (State, error) {
+	path := Path(townRoot, gasTownSession)
+	file, err := os.Open(path) //nolint:gosec // path is derived from a hash under townRoot
+	if err != nil {
+		return State{}, err
+	}
+	defer file.Close()
+
+	var state State
+	decoder := json.NewDecoder(io.LimitReader(file, maxStateSize+1))
+	if err := decoder.Decode(&state); err != nil {
+		return State{}, fmt.Errorf("decoding OpenCode state: %w", err)
+	}
+	if info, err := file.Stat(); err == nil && info.Size() > maxStateSize {
+		return State{}, fmt.Errorf("OpenCode state exceeds %d bytes", maxStateSize)
+	}
+	if state.GasTownSession != gasTownSession {
+		return State{}, fmt.Errorf("OpenCode state session mismatch: got %q, want %q", state.GasTownSession, gasTownSession)
+	}
+	return state, nil
+}
+
+func Remove(townRoot, gasTownSession, openCodeSession string) error {
+	state, err := Load(townRoot, gasTownSession)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if state.OpenCodeSession != openCodeSession {
+		return nil
+	}
+	if err := os.Remove(Path(townRoot, gasTownSession)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing OpenCode state: %w", err)
+	}
+	return nil
+}
+
+func Active(ctx context.Context, townRoot, gasTownSession string) (State, bool) {
+	state, err := Load(townRoot, gasTownSession)
+	if err != nil {
+		return State{}, false
+	}
+	if held, err := SessionLockHeld(townRoot, gasTownSession); err != nil || !held {
+		return State{}, false
+	}
+	parsed, err := url.Parse(state.URL)
+	if err != nil || parsed.Scheme != "http" || parsed.Host == "" {
+		return State{}, false
+	}
+	host := parsed.Hostname()
+	ip := net.ParseIP(host)
+	if host != "localhost" && (ip == nil || !ip.IsLoopback()) {
+		return State{}, false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(state.URL, "/")+"/global/health", nil)
+	if err != nil {
+		return State{}, false
+	}
+	req.SetBasicAuth(state.Username, state.Password)
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return State{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return State{}, false
+	}
+	var health struct {
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&health); err != nil || !health.Healthy {
+		return State{}, false
+	}
+	return state, true
+}

--- a/internal/opencodestate/state_security_windows_test.go
+++ b/internal/opencodestate/state_security_windows_test.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+package opencodestate
+
+import (
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestSaveProtectsCredentialsWithWindowsACL(t *testing.T) {
+	townRoot := t.TempDir()
+	state := State{
+		GasTownSession:  "gt-rig-worker",
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             "http://127.0.0.1:1234",
+		Username:        "opencode",
+		Password:        "secret",
+	}
+	if err := Save(townRoot, state); err != nil {
+		t.Fatal(err)
+	}
+
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRestrictedDACL(t, Path(townRoot, state.GasTownSession), user.User.Sid, system)
+	assertRestrictedDACL(t, filepath.Dir(Path(townRoot, state.GasTownSession)), user.User.Sid, system)
+}
+
+func TestAcquireSessionLockProtectsWindowsACL(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-rig-worker"
+	release, err := AcquireSessionLock(townRoot, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRestrictedDACL(t, Path(townRoot, session)+".lock", user.User.Sid, system)
+}
+
+func assertRestrictedDACL(t *testing.T, path string, user, system *windows.SID) {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatalf("%s inherits its DACL", path)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dacl.AceCount < 2 {
+		t.Fatalf("%s DACL entries = %d, want at least 2", path, dacl.AceCount)
+	}
+	var hasUser, hasSystem bool
+	for i := uint32(0); i < uint32(dacl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			t.Fatal(err)
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		switch {
+		case user.Equals(sid):
+			hasUser = true
+		case system.Equals(sid):
+			hasSystem = true
+		default:
+			t.Fatalf("%s DACL grants unexpected SID %s", path, sid.String())
+		}
+	}
+	if !hasUser || !hasSystem {
+		t.Fatalf("%s DACL missing user or Local System access", path)
+	}
+}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -132,7 +132,7 @@ switch ($cmd) {
   default { exit 0 }
 }
 `
-		cmdScript := "@echo off\r\npwsh -NoProfile -NoLogo -File \"" + psPath + "\" %*\r\n"
+		cmdScript := "@echo off\r\npowershell.exe -NoProfile -NoLogo -ExecutionPolicy Bypass -File \"" + psPath + "\" %*\r\n"
 		if err := os.WriteFile(psPath, []byte(psScript), 0644); err != nil {
 			t.Fatalf("write mock bd.ps1: %v", err)
 		}
@@ -2356,7 +2356,7 @@ switch ($cmd) {
   default { exit 0 }
 }
 `
-		cmdScript := "@echo off\r\npwsh -NoProfile -NoLogo -File \"" + psPath + "\" %*\r\n"
+		cmdScript := "@echo off\r\npowershell.exe -NoProfile -NoLogo -ExecutionPolicy Bypass -File \"" + psPath + "\" %*\r\n"
 		if err := os.WriteFile(psPath, []byte(psScript), 0644); err != nil {
 			t.Fatalf("write mock bd.ps1: %v", err)
 		}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
@@ -248,15 +249,21 @@ func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string
 	if err != nil {
 		return ""
 	}
+	currentWorkKey := currentBranch
+	if currentBranch == "HEAD" {
+		if workKey, workKeyErr := g.WorkKey(); workKeyErr == nil {
+			currentWorkKey = workKey
+		}
+	}
 
 	startPoint := m.canonicalSessionStartPoint(g)
 	if startPoint == "" {
 		debugSession("canonical session start point unresolved", fmt.Errorf("no default branch in rig config or remote"))
-		return currentBranch
+		return currentWorkKey
 	}
 	canonicalBranch := strings.TrimPrefix(startPoint, "origin/")
 	if !shouldCreateFreshSessionBranch(currentBranch, opts.Issue, canonicalBranch) {
-		return currentBranch
+		return currentWorkKey
 	}
 
 	// Refresh origin refs before branching so recovered sessions start from the
@@ -268,17 +275,17 @@ func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string
 	exists, err := g.RefExists(startPoint)
 	if err != nil {
 		debugSession("check canonical session start point", err)
-		return currentBranch
+		return currentWorkKey
 	}
 	if !exists {
 		debugSession("missing canonical session start point", fmt.Errorf("%s", startPoint))
-		return currentBranch
+		return currentWorkKey
 	}
 
 	newBranch := m.freshBranchName(polecat, opts.Issue)
 	if err := g.CheckoutNewBranch(newBranch, startPoint); err != nil {
 		debugSession("auto-checkout fresh branch on canonical base", err)
-		return currentBranch
+		return currentWorkKey
 	}
 
 	return newBranch
@@ -469,6 +476,11 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	// for show-environment lookups.
 	if _, hasGTAgent := envVars["GT_AGENT"]; !hasGTAgent && runtimeConfig.ResolvedAgent != "" {
 		envVars["GT_AGENT"] = runtimeConfig.ResolvedAgent
+	}
+	if runtimeConfig.ManagesNudgeQueue {
+		if err := nudge.StopPoller(townRoot, sessionID); err != nil {
+			debugSession("StopPoller", err)
+		}
 	}
 	// Custom agent config dir env (e.g., GEMINI_CONFIG_DIR) for non-Claude agents.
 	if runtimeConfig.Session != nil && runtimeConfig.Session.ConfigDirEnv != "" && opts.RuntimeConfigDir != "" {

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -398,6 +398,23 @@ func TestEnsureCanonicalSessionBranch_KeepsCurrentIssueBranch(t *testing.T) {
 	}
 }
 
+func TestEnsureCanonicalSessionBranchUsesSHAForDetachedHead(t *testing.T) {
+	workDir, repoGit := setupSessionBranchTestRepo(t)
+	command := exec.Command("git", "-C", workDir, "checkout", "--detach", "main")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("detach HEAD: %v\n%s", err, output)
+	}
+	revision, err := repoGit.Rev("HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sm := NewSessionManager(tmux.NewTmux(), &rig.Rig{Name: "gastown", Path: workDir})
+	if got := sm.ensureCanonicalSessionBranch(repoGit, "toast", SessionStartOptions{}); got != revision {
+		t.Fatalf("detached work key = %q, want %q", got, revision)
+	}
+}
+
 // TestSessionManager_resolveBeadsDir verifies that SessionManager correctly
 // resolves the beads directory for cross-rig issues via routes.jsonl.
 // This is a regression test for GitHub issue #1056.

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -1220,7 +1220,19 @@ fi
 printf 'unexpected gh args: %s\n' "$*" >&2
 exit 1
 `
-	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+	mode := os.FileMode(0755)
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+		script = "@echo off\r\n" +
+			"if \"%~1\"==\"pr\" if \"%~2\"==\"list\" (\r\n" +
+			"  echo []\r\n" +
+			"  exit /b 0\r\n" +
+			")\r\n" +
+			"echo unexpected gh args: %* 1>&2\r\n" +
+			"exit /b 1\r\n"
+		mode = 0644
+	}
+	if err := os.WriteFile(path, []byte(script), mode); err != nil {
 		t.Fatalf("write fake gh: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -186,7 +186,7 @@ func (m *Manager) start(foreground bool, agentOverride string, allowForkRig bool
 		}
 		// Zombie - tmux alive but agent dead. Kill and recreate.
 		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -233,7 +233,15 @@ func (m *Manager) start(foreground bool, agentOverride string, allowForkRig bool
 		runtimeConfigDir = os.Getenv("CLAUDE_CONFIG_DIR")
 	}
 
-	runtimeConfig := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
+	var runtimeConfig *config.RuntimeConfig
+	if agentOverride != "" {
+		runtimeConfig, _, err = config.ResolveAgentConfigWithOverride(townRoot, m.rig.Path, agentOverride)
+		if err != nil {
+			return fmt.Errorf("resolving refinery agent %s: %w", agentOverride, err)
+		}
+	} else {
+		runtimeConfig = config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
+	}
 	refinerySettingsDir := config.RoleSettingsDir("refinery", m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(refinerySettingsDir, refineryRigDir, "refinery", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
@@ -308,7 +316,11 @@ func (m *Manager) start(foreground bool, agentOverride string, allowForkRig bool
 	// Start nudge-queue poller (gt-dgf). Claude's UserPromptSubmit hook only
 	// drains when the agent submits a prompt. Idle agents never submit, so
 	// queued nudges deadlock. The poller breaks the cycle by polling every 10s.
-	if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+	if runtimeConfig.ManagesNudgeQueue {
+		if pollerErr := nudge.StopPoller(townRoot, sessionID); pollerErr != nil {
+			log.Printf("warning: could not stop stale nudge poller for %s: %v", sessionID, pollerErr)
+		}
+	} else if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
 		log.Printf("warning: could not start nudge poller for %s: %v", sessionID, pollerErr)
 	}
 
@@ -415,7 +427,7 @@ func (m *Manager) Stop() error {
 	}
 
 	// Kill the tmux session
-	return t.KillSession(sessionID)
+	return t.KillSessionWithProcesses(sessionID)
 }
 
 // Queue returns the current merge queue.

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -290,6 +292,31 @@ func TestEnsureSettingsForRole_OpenCodeUsesWorkDir(t *testing.T) {
 	}
 	if _, err := os.Stat(workDir + "/plugins/gastown.js"); err != nil {
 		t.Error("OpenCode plugin should be in workDir")
+	}
+}
+
+func TestEnsureSettingsForRole_OpenCodeServerPresetInstallsPlugin(t *testing.T) {
+	settingsDir := t.TempDir()
+	workDir := t.TempDir()
+	rc := config.RuntimeConfigFromPreset(config.AgentOpenCodeServer)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset(opencode-server) returned nil")
+	}
+
+	if err := EnsureSettingsForRole(settingsDir, workDir, "crew", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	pluginPath := filepath.Join(workDir, ".opencode", "plugins", "gastown.js")
+	content, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("reading installed OpenCode plugin: %v", err)
+	}
+	if !strings.Contains(string(content), "Bun.spawn(options)") {
+		t.Fatal("installed OpenCode plugin does not use cross-platform process execution")
+	}
+	if _, err := os.Stat(filepath.Join(settingsDir, ".opencode", "plugins", "gastown.js")); !os.IsNotExist(err) {
+		t.Fatal("OpenCode plugin should be installed in workDir, not settingsDir")
 	}
 }
 

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -297,6 +298,11 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (_ *StartResult, retErr error
 	// 14. Track PID for defense-in-depth orphan cleanup.
 	if cfg.TrackPID && cfg.TownRoot != "" {
 		_ = TrackSessionPID(cfg.TownRoot, cfg.SessionID, t)
+	}
+	if runtimeConfig.ManagesNudgeQueue && cfg.TownRoot != "" {
+		if err := nudge.StopPoller(cfg.TownRoot, cfg.SessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not stop stale nudge poller for %s: %v\n", cfg.SessionID, err)
+		}
 	}
 
 	// 14. Stream agent conversation events to VictoriaLogs (opt-in).

--- a/internal/tmux/opencode_nudge_test.go
+++ b/internal/tmux/opencode_nudge_test.go
@@ -1,0 +1,49 @@
+package tmux
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/opencodestate"
+)
+
+func TestNudgeSessionQueuesForOpenCodeServer(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"healthy": true})
+	}))
+	defer server.Close()
+
+	townRoot := t.TempDir()
+	sessionName := "gt-rig-worker"
+	if err := opencodestate.Save(townRoot, opencodestate.State{
+		GasTownSession:  sessionName,
+		OpenCodeSession: "ses_test",
+		Directory:       t.TempDir(),
+		URL:             server.URL,
+		Username:        "opencode",
+		Password:        "secret",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release, err := opencodestate.AcquireSessionLock(townRoot, sessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	tmux := NewTmux()
+	if err := tmux.NudgeSessionWithOpts(sessionName, "check your hook", NudgeOpts{TownRoot: townRoot}); err != nil {
+		t.Fatalf("NudgeSessionWithOpts: %v", err)
+	}
+	drained, err := nudge.Drain(townRoot, sessionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drained) != 1 || drained[0].Message != "check your hook" || drained[0].Sender != "system" {
+		t.Fatalf("drained = %#v", drained)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/opencodestate"
 	"github.com/steveyegge/gastown/internal/telemetry"
 )
 
@@ -1697,7 +1699,7 @@ func (t *Tmux) sendKeysLiteralWithRetry(target, text string, timeout time.Durati
 // queue up and execute one at a time. This prevents garbled input when
 // SessionStart hooks and nudges arrive simultaneously.
 func (t *Tmux) NudgeSession(session, message string) error {
-	return t.NudgeSessionWithOpts(session, message, NudgeOpts{})
+	return t.NudgeSessionWithOpts(session, message, NudgeOpts{TownRoot: t.sessionTownRoot(session)})
 }
 
 // NudgeOpts controls optional behavior for nudge delivery.
@@ -1775,6 +1777,17 @@ func isTmuxIndex(value string) bool {
 // NudgeSessionWithOpts is like NudgeSession but accepts delivery options.
 // See NudgeOpts for available options.
 func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) error {
+	if opts.TownRoot == "" {
+		opts.TownRoot = t.sessionTownRoot(session)
+	}
+	if opts.TownRoot != "" && t.isStructuredNudgeSession(opts.TownRoot, session) {
+		return nudge.Enqueue(opts.TownRoot, session, nudge.QueuedNudge{
+			Sender:   "system",
+			Message:  message,
+			Priority: nudge.PriorityNormal,
+		})
+	}
+
 	// Cross-process lock: serialize nudges across OS processes via flock(2).
 	// Each `gt nudge` CLI invocation is a separate process, so the in-process
 	// channel semaphore below provides no cross-process protection. Without
@@ -1884,6 +1897,32 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	// delivered nudge. Targeting the resolved pane wakes the correct window.
 	t.WakePaneIfDetached(target)
 	return nil
+}
+
+func (t *Tmux) sessionTownRoot(session string) string {
+	if townRoot, err := t.GetEnvironment(session, "GT_ROOT"); err == nil && townRoot != "" {
+		return townRoot
+	}
+	if townRoot := os.Getenv("GT_ROOT"); townRoot != "" {
+		return townRoot
+	}
+	return os.Getenv("GT_TOWN_ROOT")
+}
+
+func (t *Tmux) isStructuredNudgeSession(townRoot, session string) bool {
+	if agent, err := t.GetEnvironment(session, "GT_AGENT"); err == nil && agent != "" {
+		rigPath := ""
+		if rigName, rigErr := t.GetEnvironment(session, "GT_RIG"); rigErr == nil && rigName != "" {
+			rigPath = filepath.Join(townRoot, rigName)
+		}
+		if config.AgentManagesNudgeQueue(townRoot, rigPath, agent) {
+			return true
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, active := opencodestate.Active(ctx, townRoot, session)
+	return active
 }
 
 // NudgePane sends a message to a specific pane reliably.

--- a/internal/util/exec_test.go
+++ b/internal/util/exec_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -114,5 +115,17 @@ func TestExecWithOutput_StderrInError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "error message") {
 		t.Errorf("expected error to contain stderr, got %q", err.Error())
+	}
+}
+
+func TestSetProcessGroupInstallsCancelHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process cancellation hooks are Unix-specific")
+	}
+	cmd := exec.Command("true")
+	SetProcessGroup(cmd)
+
+	if cmd.Cancel == nil {
+		t.Fatal("SetProcessGroup did not install a cancellation hook")
 	}
 }

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -148,7 +148,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 			return ErrAlreadyRunning
 		}
 
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -175,7 +175,15 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 		runtimeConfigDir = os.Getenv("CLAUDE_CONFIG_DIR")
 	}
 
-	runtimeConfig := config.ResolveRoleAgentConfig("witness", townRoot, m.rig.Path)
+	var runtimeConfig *config.RuntimeConfig
+	if agentOverride != "" {
+		runtimeConfig, _, err = config.ResolveAgentConfigWithOverride(townRoot, m.rig.Path, agentOverride)
+		if err != nil {
+			return fmt.Errorf("resolving witness agent %s: %w", agentOverride, err)
+		}
+	} else {
+		runtimeConfig = config.ResolveRoleAgentConfig("witness", townRoot, m.rig.Path)
+	}
 	witnessSettingsDir := config.RoleSettingsDir("witness", m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(witnessSettingsDir, witnessDir, "witness", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
@@ -270,7 +278,11 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// Start nudge-queue poller (gt-dgf). Claude's UserPromptSubmit hook only
 	// drains when the agent submits a prompt. Idle agents never submit, so
 	// queued nudges deadlock. The poller breaks the cycle by polling every 10s.
-	if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+	if runtimeConfig.ManagesNudgeQueue {
+		if pollerErr := nudge.StopPoller(townRoot, sessionID); pollerErr != nil {
+			log.Printf("warning: could not stop stale nudge poller for %s: %v", sessionID, pollerErr)
+		}
+	} else if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
 		log.Printf("warning: could not start nudge poller for %s: %v", sessionID, pollerErr)
 	}
 
@@ -338,6 +350,13 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 	}
 	if roleConfig != nil && roleConfig.StartCommand != "" {
 		rc := config.ResolveRoleAgentConfig("witness", townRoot, rigPath)
+		if agentOverride != "" {
+			var err error
+			rc, _, err = config.ResolveAgentConfigWithOverride(townRoot, rigPath, agentOverride)
+			if err != nil {
+				return "", fmt.Errorf("resolving witness agent %s: %w", agentOverride, err)
+			}
+		}
 		if !config.IsResolvedAgentClaude(rc) {
 			// Non-Claude agent: skip TOML start_command entirely.
 			// Built-in role TOMLs hardcode "exec claude ..." which is wrong
@@ -399,5 +418,5 @@ func (m *Manager) Stop() error {
 	}
 
 	// Kill the tmux session
-	return t.KillSession(sessionID)
+	return t.KillSessionWithProcesses(sessionID)
 }

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -81,15 +81,17 @@ func TestBuildWitnessStartCommand_UsesRoleConfig(t *testing.T) {
 
 func TestBuildWitnessStartCommand_DefaultsToRuntime(t *testing.T) {
 	t.Parallel()
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", nil, "")
+	townRoot := t.TempDir()
+	got, err := buildWitnessStartCommand(filepath.Join(townRoot, "rig"), "gastown", townRoot, "", "", nil, "")
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
+	got = witnessStartupScriptOrCommand(t, townRoot, got)
 
-	if !strings.Contains(got, "GT_ROLE=gastown/witness") {
+	if !strings.Contains(got, "GT_ROLE") || !strings.Contains(got, "gastown/witness") {
 		t.Errorf("expected GT_ROLE=gastown/witness in command, got %q", got)
 	}
-	if !strings.Contains(got, "BD_ACTOR=gastown/witness") {
+	if !strings.Contains(got, "BD_ACTOR") || !strings.Contains(got, "gastown/witness") {
 		t.Errorf("expected BD_ACTOR=gastown/witness in command, got %q", got)
 	}
 }
@@ -125,30 +127,47 @@ func TestRoleConfigEnvVars_NilConfig(t *testing.T) {
 
 func TestBuildWitnessStartCommand_IncludesConfigDir(t *testing.T) {
 	t.Parallel()
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", nil, "/home/user/.claude-accounts/work")
+	townRoot := t.TempDir()
+	got, err := buildWitnessStartCommand(filepath.Join(townRoot, "rig"), "gastown", townRoot, "", "", nil, "/home/user/.claude-accounts/work")
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
+	got = witnessStartupScriptOrCommand(t, townRoot, got)
 
-	if !strings.Contains(got, "CLAUDE_CONFIG_DIR=/home/user/.claude-accounts/work") {
+	if !strings.Contains(got, "CLAUDE_CONFIG_DIR") || !strings.Contains(got, "/home/user/.claude-accounts/work") {
 		t.Errorf("expected CLAUDE_CONFIG_DIR in command, got %q", got)
 	}
 }
 
 func TestBuildWitnessStartCommand_AgentOverrideWins(t *testing.T) {
 	t.Parallel()
+	townRoot := t.TempDir()
 	roleCfg := &beads.RoleConfig{
 		StartCommand: "exec run --role {role}",
 	}
 
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "codex", roleCfg, "")
+	got, err := buildWitnessStartCommand(filepath.Join(townRoot, "rig"), "gastown", townRoot, "", "codex", roleCfg, "")
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
+	got = witnessStartupScriptOrCommand(t, townRoot, got)
 	if strings.Contains(got, "exec run") {
 		t.Fatalf("expected agent override to bypass role start_command, got %q", got)
 	}
-	if !strings.Contains(got, "GT_ROLE=gastown/witness") {
+	if !strings.Contains(got, "GT_ROLE") || !strings.Contains(got, "gastown/witness") {
 		t.Errorf("expected GT_ROLE=gastown/witness in command, got %q", got)
 	}
+}
+
+func witnessStartupScriptOrCommand(t *testing.T, townRoot, command string) string {
+	t.Helper()
+	scriptPath := filepath.Join(townRoot, "daemon", "scripts", "gastown-witness-startup.ps1")
+	data, err := os.ReadFile(scriptPath)
+	if os.IsNotExist(err) {
+		return command
+	}
+	if err != nil {
+		t.Fatalf("read witness startup script: %v", err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
## Summary

- add an opt-in `opencode-server` agent preset backed by an authenticated loopback OpenCode HTTP worker
- persist session mappings and locks, serialize SSE lifecycle events, and deliver durable idempotent nudge claims without TUI keystrokes
- integrate managed routing with sling, handoff, daemon, deacon, crew, polecat, witness, refinery, and tmux lifecycle paths
- make OpenCode hooks cross-platform, timeout-bounded, and session-scoped, with official OpenCode session ID propagation
- tolerate cold OpenCode project initialization and canonicalize Windows short/long path aliases so durable sessions resume correctly
- add cross-platform process-tree cleanup, Windows-safe startup argument handling and atomic config replacement, documentation, and Windows CI coverage

## Testing

- `go test ./internal/atomicfile ./internal/config ./internal/hooks ./internal/opencodeserver ./internal/opencodestate ./internal/nudge ./internal/tmux ./internal/deacon`
- `go test ./internal/daemon ./internal/crew ./internal/polecat ./internal/witness ./internal/refinery ./internal/session`
- focused `internal/cmd` OpenCode, handoff, nudge, and work-key tests
- repeated and race-enabled OpenCode server tests, including cold-session timeout routing, caller cancellation, and Windows 8.3 path aliases
- Bun plugin behavior test covering concurrent sessions, compaction, deletion cleanup, and command timeout
- full local-model E2E using real `gt opencode-worker` and OpenCode 1.18.18: create session, inject hook context, deliver two durable nudges, persist model responses, restart worker, resume the same session, and clean up the process tree
- `go test -tags=integration ./internal/opencodeserver -run '^TestRealOpenCodeServerLifecycle$'`
- `go vet` across all affected packages
- Linux amd64 cross-compilation across all affected packages