### PR TITLE
scheduler: optional load sentinel file gates polecat admission

### DIFF
--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -113,6 +113,20 @@ func acquirePolecatAdmission(townRoot, rigName, beadID, operation string) (*pole
 	if err != nil {
 		return nil, polecatCapacitySnapshot{}, err
 	}
+	// The load sentinel gates every admission, including direct dispatch
+	// (max <= 0): an external governor saying "the host is overloaded"
+	// outranks the scheduler being disabled, the same way ESTOP does.
+	if reason, present, serr := loadSentinelReason(townRoot); serr != nil {
+		return nil, polecatCapacitySnapshot{}, serr
+	} else if present {
+		return nil, polecatCapacitySnapshot{Max: max, ActiveSessions: countActivePolecats()},
+			&polecatCapacityAdmissionError{
+				Snapshot: polecatCapacitySnapshot{Max: max},
+				Rig:      rigName,
+				Bead:     beadID,
+				Reason:   reason,
+			}
+	}
 	if max <= 0 {
 		return &polecatAdmissionHandle{disabled: true}, polecatCapacitySnapshot{Max: max, ActiveSessions: countActivePolecats()}, nil
 	}
@@ -147,6 +161,38 @@ func acquirePolecatAdmission(townRoot, rigName, beadID, operation string) (*pole
 	snapshot.Reservations++
 	snapshot.Free--
 	return &polecatAdmissionHandle{townRoot: townRoot, id: reservation.ID, path: path}, snapshot, nil
+}
+
+// loadSentinelReason reports whether the configured load sentinel file
+// exists and, if so, the admission-refusal reason derived from its first
+// line. No sentinel configured or present means admission proceeds.
+func loadSentinelReason(townRoot string) (string, bool, error) {
+	settings, err := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot))
+	if err != nil {
+		return "", false, fmt.Errorf("loading town settings for load sentinel: %w", err)
+	}
+	if settings.Scheduler == nil || settings.Scheduler.LoadSentinelFile == "" {
+		return "", false, nil
+	}
+	path := settings.Scheduler.LoadSentinelFile
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(townRoot, path)
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		// An unreadable sentinel fails open: a broken governor must not
+		// wedge the town, mirroring how stale reservations are cleaned
+		// up rather than trusted.
+		return "", false, nil
+	}
+	reason := strings.TrimSpace(strings.SplitN(string(data), "\n", 2)[0])
+	if reason == "" {
+		reason = "load sentinel present"
+	}
+	return fmt.Sprintf("load sentinel %s: %s", path, reason), true, nil
 }
 
 func configuredSchedulerMaxPolecats(townRoot string) (int, error) {

--- a/internal/scheduler/capacity/config.go
+++ b/internal/scheduler/capacity/config.go
@@ -10,9 +10,10 @@ import "time"
 // API rate limits, memory, and CPU are shared resources across all rigs.
 //
 // Behavior is driven entirely by MaxPolecats:
-//   -1 (default): direct dispatch — gt sling works as before, near-zero overhead
-//    0:           direct dispatch (same as -1)
-//    N > 0:       deferred dispatch — labels/metadata applied, daemon dispatches
+//
+//	-1 (default): direct dispatch — gt sling works as before, near-zero overhead
+//	 0:           direct dispatch (same as -1)
+//	 N > 0:       deferred dispatch — labels/metadata applied, daemon dispatches
 type SchedulerConfig struct {
 	// MaxPolecats is the max concurrent polecats across ALL rigs.
 	// Includes both scheduler-dispatched and directly-slung polecats.
@@ -28,6 +29,16 @@ type SchedulerConfig struct {
 	// SpawnDelay is the delay between spawns to prevent Dolt lock contention.
 	// Default: "0s".
 	SpawnDelay string `json:"spawn_delay,omitempty"`
+
+	// LoadSentinelFile is an optional path to a host-load sentinel file.
+	// While the file exists, NEW polecat admissions are refused (running
+	// polecats are untouched); the file's first line is reported as the
+	// reason. This is the hook for external resource governors (thermal
+	// guards, load monitors) to pause scale-up: capacity control is
+	// host-wide, and the host knows things the scheduler cannot (see the
+	// package comment above about memory and CPU being shared resources).
+	// Relative paths are resolved against the town root. Empty = disabled.
+	LoadSentinelFile string `json:"load_sentinel_file,omitempty"`
 }
 
 // DefaultSchedulerConfig returns a SchedulerConfig with sensible defaults.


### PR DESCRIPTION
The capacity package's own comment says it best: "capacity control is host-wide: API rate limits, memory, and CPU are shared resources across all rigs." Today the scheduler enforces a static `max_polecats`, but nothing lets the HOST itself say "not right now" - a thermal guard, a load monitor, or an ops script watching memory pressure has no seam to plug into.

This adds `scheduler.load_sentinel_file` (default: unset, zero behavior change). When configured and the file exists, new polecat admissions are refused with the file's first line as the reason; running polecats are untouched. When the file is gone, admission resumes. Relative paths resolve against the town root. An unreadable sentinel fails open - a broken governor must not wedge the town.

Why a sentinel file and not a metric: the same pattern ESTOP already uses - any external process can create/remove a file atomically, no IPC, no new dependencies, works from cron, from a menu-bar app, from a shell one-liner. The scheduler stays policy-free; the governor owns the policy. The check runs before the `max_polecats` early-return on purpose: an overloaded host outranks a disabled scheduler, the same way ESTOP does.

Context: I build [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin), a macOS thermal guard for exactly this class of machines; with this seam it can hold a town's scale-up while the chip is above threshold and release it when it cools, without Gas Town knowing anything about thermals. But the seam is deliberately generic - anything that can touch a file can govern admission.

Happy to adjust naming/placement to taste.