### PR TITLE
feat(dolt): explicit external ownership for loopback Dolt endpoints

### DIFF
--- a/docs/design/dolt-storage.md
+++ b/docs/design/dolt-storage.md
@@ -43,6 +43,7 @@ translates its variables to bd's equivalents when spawning agents.
 |---------------|------------|---------|
 | `GT_DOLT_HOST` | `BEADS_DOLT_SERVER_HOST` | Server host (bd defaults to `127.0.0.1` if unset) |
 | `GT_DOLT_PORT` | `BEADS_DOLT_PORT` | Server port (default: `3307`) |
+| `GT_DOLT_EXTERNAL` | — (gt-only ownership flag) | Marks the endpoint as externally managed, even on loopback |
 
 **Remote Dolt servers**: If Dolt runs on a different machine (e.g., over
 Tailscale), set `GT_DOLT_HOST` in the environment. gt propagates this as
@@ -52,6 +53,23 @@ connects to localhost and fails.
 
 Per-workspace override: set `dolt.host` in a rig's `.beads/config.yaml`.
 This takes priority over the env var for that specific workspace.
+
+**Externally managed local servers**: When the Dolt server is owned by
+another process on this machine (e.g., Beads' shared server on `:3308`),
+set `gt config set dolt.external true`. This writes `GT_DOLT_EXTERNAL=true`
+to `mayor/daemon.json` and changes ownership semantics everywhere:
+
+- `gt dolt start`/`stop`, `gt up`/`start`/`down`, and the daemon's Dolt
+  manager never start, stop, restart, or kill the shared server;
+- `gt doctor` probes the declared endpoint instead of rewriting
+  `.beads/metadata.json` to the local managed port;
+- endpoint resolution (host/port) prefers `daemon.json` over the local
+  `.dolt-data/config.yaml`, which may describe a stale local server;
+- `GT_DOLT_EXTERNAL` is propagated to spawned agents alongside the port.
+
+Lifecycle commands that require Town-owned storage (`gt dolt migrate`,
+`recover`, `rollback`, `flatten`, `rebase`, `sync`, `pull`, `maintain`)
+refuse to run against an externally managed endpoint.
 
 ## Commands
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -625,6 +625,8 @@ Supported keys:
   dolt.port                   Dolt SQL server port (default: 3307). Set this when
                               another Gas Town instance is using the same port.
                               Writes GT_DOLT_PORT to mayor/daemon.json env section.
+	  dolt.external               Mark the configured Dolt server as externally managed.
+	                              This preserves a loopback shared server without lifecycle control.
   scheduler.max_polecats      Dispatch mode: -1 = direct (default), N > 0 = deferred
   scheduler.batch_size        Beads per heartbeat (default: 1)
   scheduler.spawn_delay       Delay between spawns (default: 0s)
@@ -808,11 +810,30 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s\n", style.Dim.Render("Restart the daemon for the change to take effect: gt daemon restart"))
 		return nil
 
+	case "dolt.external":
+		external, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %w (expected true/false)", key, err)
+		}
+		patrolCfg := daemon.LoadPatrolConfig(townRoot)
+		if patrolCfg == nil {
+			patrolCfg = &daemon.DaemonPatrolConfig{Type: "daemon-patrol-config", Version: 1}
+		}
+		if patrolCfg.Env == nil {
+			patrolCfg.Env = make(map[string]string)
+		}
+		patrolCfg.Env["GT_DOLT_EXTERNAL"] = strconv.FormatBool(external)
+		if err := daemon.SavePatrolConfig(townRoot, patrolCfg); err != nil {
+			return fmt.Errorf("saving daemon.json: %w", err)
+		}
+		fmt.Printf("Set GT_DOLT_EXTERNAL = %t in mayor/daemon.json\n", external)
+		return nil
+
 	default:
 		if strings.HasPrefix(key, "lifecycle.") {
 			return setLifecycleConfig(townRoot, key, value)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  dolt.external\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	if err := config.SaveTownSettings(settingsPath, townSettings); err != nil {
@@ -900,11 +921,19 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		fmt.Println("3307") // DefaultPort
 		return nil
 
+	case "dolt.external":
+		if config.ResolveDoltExternal(townRoot) {
+			fmt.Println("true")
+			return nil
+		}
+		fmt.Println("false")
+		return nil
+
 	default:
 		if strings.HasPrefix(key, "lifecycle.") {
 			return getLifecycleConfig(townRoot, key)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  dolt.external\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	fmt.Println(value)

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/daemon"
 )
 
 // setupTestTown creates a minimal Gas Town workspace for testing.
@@ -722,6 +723,27 @@ func TestConfigDefaultAgentList(t *testing.T) {
 }
 
 func TestConfigSetGet(t *testing.T) {
+	t.Run("set and get dolt.external", func(t *testing.T) {
+		// Given
+		townRoot := setupTestTownForConfig(t)
+		originalWd, _ := os.Getwd()
+		defer os.Chdir(originalWd)
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatal(err)
+		}
+
+		// When
+		if err := runConfigSet(&cobra.Command{}, []string{"dolt.external", "true"}); err != nil {
+			t.Fatalf("runConfigSet: %v", err)
+		}
+
+		// Then
+		patrolConfig := daemon.LoadPatrolConfig(townRoot)
+		if patrolConfig == nil || patrolConfig.Env["GT_DOLT_EXTERNAL"] != "true" {
+			t.Fatal("dolt.external was not persisted in daemon configuration")
+		}
+	})
+
 	t.Run("set and get convoy.notify_on_complete", func(t *testing.T) {
 		townRoot := setupTestTownForConfig(t)
 		settingsPath := config.TownSettingsPath(townRoot)

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -396,8 +396,8 @@ func runDoltStart(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s)", config.HostPort())
 	}
 
 	// Check for databases before starting — user-facing guard for manual starts.
@@ -448,8 +448,8 @@ func runDoltKillImposters(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote — imposter detection requires local server")
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed — imposter detection requires a Town-owned server")
 	}
 
 	conflictPID, conflictDataDir := doltserver.CheckPortConflict(townRoot)
@@ -482,8 +482,8 @@ func runDoltStop(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s)", config.HostPort())
 	}
 
 	_, pid, _ := doltserver.IsRunning(townRoot)
@@ -503,8 +503,8 @@ func runDoltRestart(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s)", config.HostPort())
 	}
 
 	// Step 1: Stop tracked server (if running)
@@ -578,7 +578,7 @@ func runDoltStatus(cmd *cobra.Command, args []string) error {
 
 	config := doltserver.DefaultConfig(townRoot)
 
-	if config.IsRemote() {
+	if config.IsExternallyManaged() {
 		if running {
 			fmt.Printf("%s Dolt server is %s (remote: %s)\n",
 				style.Bold.Render("●"),
@@ -1208,8 +1208,8 @@ func runDoltMigrate(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — migration requires local server access", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — migration requires a Town-owned server", config.HostPort())
 	}
 
 	// Check if daemon is running - must stop first to avoid race conditions.
@@ -1360,8 +1360,8 @@ func runDoltRecover(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — recovery requires local server access", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — recovery requires a Town-owned server", config.HostPort())
 	}
 
 	running, _, _ := doltserver.IsRunning(townRoot)
@@ -1394,8 +1394,8 @@ func runDoltRollback(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — rollback requires local server access", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — rollback requires a Town-owned server", config.HostPort())
 	}
 
 	// Find available backups
@@ -1576,8 +1576,8 @@ func runDoltSync(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — sync requires local server access", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — sync requires a Town-owned server", config.HostPort())
 	}
 
 	// Validate --db flag if set
@@ -1699,8 +1699,8 @@ func runDoltPull(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — pull requires local server access", config.HostPort())
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — pull requires a Town-owned server", config.HostPort())
 	}
 
 	// Validate --db flag if set

--- a/internal/cmd/dolt_dsn.go
+++ b/internal/cmd/dolt_dsn.go
@@ -111,7 +111,7 @@ func buildDoltDSN(user string, port int, dbName string, opts dsnOpts) string {
 // and host from a *doltserver.Config (matches the maintain.go /
 // dolt_flatten.go / dolt_rebase.go callsite pattern).
 func buildDoltDSNFromConfig(c *doltserver.Config, dbName string, opts dsnOpts) string {
-	if !c.IsRemote() {
+	if !c.IsExternallyManaged() {
 		if sock := localDoltSocketPath(c.Port); sock != "" {
 			return formatDoltDSN(c.User, "unix", sock, dbName, opts)
 		}

--- a/internal/cmd/dolt_flatten.go
+++ b/internal/cmd/dolt_flatten.go
@@ -57,6 +57,10 @@ func runDoltFlatten(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
+	config := doltserver.DefaultConfig(townRoot)
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — flatten requires a Town-owned server", config.HostPort())
+	}
 
 	// Verify server is running.
 	running, _, err := doltserver.IsRunning(townRoot)
@@ -64,7 +68,6 @@ func runDoltFlatten(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Dolt server is not running — start with 'gt dolt start'")
 	}
 
-	config := doltserver.DefaultConfig(townRoot)
 	// wa-d6f: socket-first DSN (TCP fallback) — eliminates TIME_WAIT churn.
 	dsn := buildDoltDSNFromConfig(config, dbName, dsnOpts{
 		ParseTime:    true,

--- a/internal/cmd/dolt_rebase.go
+++ b/internal/cmd/dolt_rebase.go
@@ -78,13 +78,16 @@ func runDoltRebase(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
+	config := doltserver.DefaultConfig(townRoot)
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s) — rebase requires a Town-owned server", config.HostPort())
+	}
 
 	running, _, err := doltserver.IsRunning(townRoot)
 	if err != nil || !running {
 		return fmt.Errorf("Dolt server is not running — start with 'gt dolt start'")
 	}
 
-	config := doltserver.DefaultConfig(townRoot)
 	// wa-d6f: socket-first DSN (TCP fallback) — eliminates TIME_WAIT churn.
 	dsn := buildDoltDSNFromConfig(config, dbName, dsnOpts{
 		ParseTime:    true,
@@ -365,6 +368,7 @@ func rebaseCleanup(db *sql.DB, baseBranch, workBranch string) {
 }
 
 // rebaseAbortAndCleanup aborts an in-progress rebase then cleans up branches.
+//
 //nolint:unparam // baseBranch always "compact-base" — API kept flexible for future callers
 func rebaseAbortAndCleanup(db *sql.DB, baseBranch, workBranch string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -376,6 +380,7 @@ func rebaseAbortAndCleanup(db *sql.DB, baseBranch, workBranch string) {
 }
 
 // rebaseCleanupAll cleans up both branches after a failed rebase.
+//
 //nolint:unparam // baseBranch always "compact-base" — API kept flexible for future callers
 func rebaseCleanupAll(db *sql.DB, baseBranch, workBranch string) {
 	rebaseCleanup(db, baseBranch, workBranch)

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -260,35 +260,36 @@ func runDown(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Phase 4b-i: Stop bd dolt idle-monitor processes.
-	// These background processes respawn per-agent Dolt servers after they're
-	// terminated, creating a race condition where rogues grab the port before
-	// the canonical server can restart. Must be stopped BEFORE Dolt shutdown.
-	idleMonitors := doltserver.FindIdleMonitorProcesses(townRoot)
-	if len(idleMonitors) > 0 {
-		if downDryRun {
-			printDownStatus("Dolt idle-monitors", true, fmt.Sprintf("%d would stop", len(idleMonitors)))
-		} else {
-			stopped := stopIdleMonitors(idleMonitors)
-			if stopped > 0 {
-				printDownStatus("Dolt idle-monitors", true, fmt.Sprintf("stopped %d", stopped))
+	doltCfg := doltserver.DefaultConfig(townRoot)
+	if doltCfg.IsExternallyManaged() {
+		printDownStatus("Dolt", true, fmt.Sprintf("externally managed at %s; left running", doltCfg.HostPort()))
+	} else {
+		// Phase 4b-i: Stop bd dolt idle-monitor processes.
+		// These background processes respawn per-agent Dolt servers after they're
+		// terminated, creating a race condition where rogues grab the port before
+		// the canonical server can restart. Must be stopped BEFORE Dolt shutdown.
+		idleMonitors := doltserver.FindIdleMonitorProcesses(townRoot)
+		if len(idleMonitors) > 0 {
+			if downDryRun {
+				printDownStatus("Dolt idle-monitors", true, fmt.Sprintf("%d would stop", len(idleMonitors)))
+			} else {
+				stopped := stopIdleMonitors(idleMonitors)
+				if stopped > 0 {
+					printDownStatus("Dolt idle-monitors", true, fmt.Sprintf("stopped %d", stopped))
+				}
 			}
 		}
-	}
 
-	// Phase 4b-ii: Stop Dolt server
-	doltCfg := doltserver.DefaultConfig(townRoot)
-	if _, statErr := os.Stat(doltCfg.DataDir); statErr == nil {
-		doltRunning, doltPid, doltErr := doltserver.IsRunning(townRoot)
-		if doltErr != nil {
-			printDownStatus("Dolt", false, fmt.Sprintf("status check failed: %v", doltErr))
-			allOK = false
-		} else if downDryRun {
-			if doltRunning {
-				printDownStatus("Dolt", true, fmt.Sprintf("would stop (PID %d)", doltPid))
-			}
-		} else {
-			if doltRunning {
+		if _, statErr := os.Stat(doltCfg.DataDir); statErr == nil {
+			doltRunning, doltPid, doltErr := doltserver.IsRunning(townRoot)
+			if doltErr != nil {
+				printDownStatus("Dolt", false, fmt.Sprintf("status check failed: %v", doltErr))
+				allOK = false
+			} else if downDryRun {
+				if doltRunning {
+					printDownStatus("Dolt", true, fmt.Sprintf("would stop (PID %d)", doltPid))
+				}
+			} else if doltRunning {
 				if err := doltserver.Stop(townRoot); err != nil {
 					printDownStatus("Dolt", false, err.Error())
 					allOK = false
@@ -299,48 +300,39 @@ func runDown(cmd *cobra.Command, args []string) error {
 				printDownStatus("Dolt", true, "not running")
 			}
 		}
-	}
 
-	// Phase 4b-iii: Stop imposter Dolt servers.
-	// After stopping the canonical server, rogue Dolt servers spawned by bd
-	// from .beads/dolt/ directories may still be running. KillImposters only
-	// catches servers on our port, so also scan for any dolt sql-server
-	// processes rooted in this town's directory tree.
-	if !downDryRun {
-		if err := doltserver.KillImposters(townRoot); err != nil {
-			printDownStatus("Dolt imposters", false, err.Error())
-			allOK = false
-		}
-		orphanDolts := findOrphanDoltServers(townRoot)
-		if len(orphanDolts) > 0 {
-			stopped := stopOrphanDoltServers(orphanDolts)
-			if stopped > 0 {
-				printDownStatus("Dolt orphans", true, fmt.Sprintf("stopped %d rogue server(s)", stopped))
+		if !downDryRun {
+			if err := doltserver.KillImposters(townRoot); err != nil {
+				printDownStatus("Dolt imposters", false, err.Error())
+				allOK = false
+			}
+			orphanDolts := findOrphanDoltServers(townRoot)
+			if len(orphanDolts) > 0 {
+				stopped := stopOrphanDoltServers(orphanDolts)
+				if stopped > 0 {
+					printDownStatus("Dolt orphans", true, fmt.Sprintf("stopped %d rogue server(s)", stopped))
+				}
+			}
+		} else {
+			conflictPID, _ := doltserver.CheckPortConflict(townRoot)
+			if conflictPID > 0 {
+				printDownStatus("Dolt imposters", true, fmt.Sprintf("would stop imposter (PID %d)", conflictPID))
+			}
+			orphanDolts := findOrphanDoltServers(townRoot)
+			if len(orphanDolts) > 0 {
+				printDownStatus("Dolt orphans", true, fmt.Sprintf("%d rogue server(s) would stop", len(orphanDolts)))
 			}
 		}
-	} else {
-		conflictPID, _ := doltserver.CheckPortConflict(townRoot)
-		if conflictPID > 0 {
-			printDownStatus("Dolt imposters", true, fmt.Sprintf("would stop imposter (PID %d)", conflictPID))
-		}
-		orphanDolts := findOrphanDoltServers(townRoot)
-		if len(orphanDolts) > 0 {
-			printDownStatus("Dolt orphans", true, fmt.Sprintf("%d rogue server(s) would stop", len(orphanDolts)))
-		}
-	}
 
-	// Phase 4b-iv: Remove .beads/dolt directories.
-	// These legacy per-agent data directories trigger bd to auto-spawn local
-	// Dolt servers. Removing them prevents rogue respawn on next gt up.
-	// Data has already been migrated to .dolt-data/ by gt dolt migrate.
-	beadsDoltDirs := findBeadsDoltDirs(townRoot)
-	if len(beadsDoltDirs) > 0 {
-		if downDryRun {
-			printDownStatus("Beads dolt dirs", true, fmt.Sprintf("%d would remove", len(beadsDoltDirs)))
-		} else {
-			removed := removeBeadsDoltDirs(beadsDoltDirs)
-			if removed > 0 {
-				printDownStatus("Beads dolt dirs", true, fmt.Sprintf("removed %d", removed))
+		beadsDoltDirs := findBeadsDoltDirs(townRoot)
+		if len(beadsDoltDirs) > 0 {
+			if downDryRun {
+				printDownStatus("Beads dolt dirs", true, fmt.Sprintf("%d would remove", len(beadsDoltDirs)))
+			} else {
+				removed := removeBeadsDoltDirs(beadsDoltDirs)
+				if removed > 0 {
+					printDownStatus("Beads dolt dirs", true, fmt.Sprintf("removed %d", removed))
+				}
 			}
 		}
 	}

--- a/internal/cmd/maintain.go
+++ b/internal/cmd/maintain.go
@@ -81,7 +81,7 @@ func runMaintain(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	if config.IsRemote() {
+	if config.IsExternallyManaged() {
 		return fmt.Errorf("maintain requires local Dolt server (remote: %s)", config.HostPort())
 	}
 

--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -427,7 +427,7 @@ func ensureMayorInfra(townRoot string) error {
 
 	// Dolt (fatal on failure — Mayor requires database access)
 	doltCfg := doltserver.DefaultConfig(townRoot)
-	if !doltCfg.IsRemote() {
+	if !doltCfg.IsExternallyManaged() {
 		if _, err := os.Stat(doltCfg.DataDir); err == nil {
 			doltRunning, _, _ := doltserver.IsRunning(townRoot)
 			if !doltRunning {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -223,7 +223,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// server and bd auto-spawns orphan embedded servers. (gt-t2zf)
 	var doltOK bool
 	cfg := doltserver.DefaultConfig(townRoot)
-	if _, err := os.Stat(cfg.DataDir); os.IsNotExist(err) {
+	if cfg.IsExternallyManaged() {
+		running, _, _ := doltserver.IsRunning(townRoot)
+		doltOK = running
+		if running {
+			fmt.Printf("  %s External Dolt server reachable at %s\n", style.Dim.Render("○"), cfg.HostPort())
+		} else {
+			fmt.Printf("  %s External Dolt server unavailable at %s\n", style.Dim.Render("○"), cfg.HostPort())
+		}
+	} else if _, err := os.Stat(cfg.DataDir); os.IsNotExist(err) {
 		// No Dolt data dir — nothing to start
 		fmt.Printf("  %s Dolt server skipped (no data dir)\n", style.Dim.Render("○"))
 	} else {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -88,6 +88,7 @@ type DoltInfo struct {
 	PID           int    `json:"pid,omitempty"`
 	Port          int    `json:"port"`
 	Remote        bool   `json:"remote,omitempty"`
+	External      bool   `json:"external,omitempty"`
 	DataDir       string `json:"data_dir,omitempty"`
 	PortConflict  bool   `json:"port_conflict,omitempty"`  // Port taken by another town's Dolt
 	ConflictOwner string `json:"conflict_owner,omitempty"` // --data-dir of the process holding the port
@@ -811,8 +812,12 @@ func gatherStatus() (TownStatus, error) {
 
 	// Dolt status
 	doltCfg := doltserver.DefaultConfig(townRoot)
-	if doltCfg.IsRemote() {
-		status.Dolt = &DoltInfo{Remote: true, Port: doltCfg.Port}
+	if doltCfg.IsExternallyManaged() {
+		status.Dolt = &DoltInfo{
+			External: doltCfg.External,
+			Port:     doltCfg.Port,
+			Remote:   doltCfg.IsRemote(),
+		}
 	} else {
 		doltRunning, doltPid, _ := doltserver.IsRunning(townRoot)
 		port := doltCfg.Port
@@ -1040,7 +1045,9 @@ func outputStatusText(w io.Writer, status TownStatus) error {
 			}
 		}
 		if status.Dolt != nil {
-			if status.Dolt.Remote {
+			if status.Dolt.External {
+				parts = append(parts, fmt.Sprintf("dolt %s", style.Dim.Render(fmt.Sprintf("(external :%d)", status.Dolt.Port))))
+			} else if status.Dolt.Remote {
 				parts = append(parts, fmt.Sprintf("dolt %s", style.Dim.Render(fmt.Sprintf("(remote :%d)", status.Dolt.Port))))
 			} else if status.Dolt.Running {
 				dataDir := status.Dolt.DataDir

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -213,6 +213,16 @@ func runUp(cmd *cobra.Command, args []string) error {
 	go func() {
 		defer startupWg.Done()
 		cfg := doltserver.DefaultConfig(townRoot)
+		if cfg.IsExternallyManaged() {
+			running, _, _ := doltserver.IsRunning(townRoot)
+			doltOK = running
+			if running {
+				doltDetail = "externally managed and reachable"
+			} else {
+				doltDetail = fmt.Sprintf("externally managed and unreachable at %s", cfg.HostPort())
+			}
+			return
+		}
 		if _, err := os.Stat(cfg.DataDir); os.IsNotExist(err) {
 			doltSkipped = true
 			return

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -313,6 +313,9 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		if port := ResolveDoltPort(cfg.TownRoot); port > 0 {
 			setDoltPortEnv(env, strconv.Itoa(port))
 		}
+		if ResolveDoltExternal(cfg.TownRoot) {
+			env["GT_DOLT_EXTERNAL"] = "true"
+		}
 	}
 	if _, ok := env["GT_DOLT_PORT"]; !ok {
 		if v := os.Getenv("GT_DOLT_PORT"); v != "" {
@@ -448,6 +451,9 @@ func ResolveDoltPort(townRoot string) int {
 	if townRoot == "" {
 		return 0
 	}
+	if ResolveDoltExternal(townRoot) {
+		return resolveDoltPortFromDaemonJSON(townRoot)
+	}
 
 	if port := resolveDoltPortFromConfigYAML(townRoot); port > 0 {
 		return port
@@ -471,6 +477,12 @@ func ResolveDoltPort(townRoot string) int {
 //  3. mayor/daemon.json env.GT_DOLT_PORT
 //  4. 0 (caller should use its default)
 func ResolveConfiguredDoltPort(townRoot string) int {
+	if ResolveDoltExternal(townRoot) {
+		if port := resolveDoltPortFromEnv(); port > 0 {
+			return port
+		}
+		return resolveDoltPortFromDaemonJSON(townRoot)
+	}
 	if _, port, ok := ManagedDoltEndpoint(townRoot); ok {
 		return port
 	}
@@ -493,6 +505,12 @@ func ResolveConfiguredDoltPort(townRoot string) int {
 //  3. mayor/daemon.json env.GT_DOLT_HOST
 //  4. "" (caller should use its default)
 func ResolveConfiguredDoltHost(townRoot string) string {
+	if ResolveDoltExternal(townRoot) {
+		if host := strings.TrimSpace(os.Getenv("GT_DOLT_HOST")); host != "" {
+			return host
+		}
+		return resolveDoltHostFromDaemonJSON(townRoot)
+	}
 	if host, _, ok := ManagedDoltEndpoint(townRoot); ok {
 		return host
 	}
@@ -500,6 +518,20 @@ func ResolveConfiguredDoltHost(townRoot string) string {
 		return host
 	}
 	return resolveDoltHostFromDaemonJSON(townRoot)
+}
+
+// ResolveDoltExternal reports whether the configured Dolt endpoint is owned
+// outside Gas Town, even when it is bound to a loopback address.
+func ResolveDoltExternal(townRoot string) bool {
+	if value, ok := os.LookupEnv("GT_DOLT_EXTERNAL"); ok {
+		if strings.TrimSpace(value) != "" {
+			return parseDoltExternal(value)
+		}
+	}
+	if townRoot == "" {
+		return false
+	}
+	return resolveDoltExternalFromDaemonJSON(townRoot)
 }
 
 // ManagedDoltEndpoint reads the target town's managed Dolt config.yaml without
@@ -520,6 +552,16 @@ func ManagedDoltEndpoint(townRoot string) (host string, port int, ok bool) {
 // NormalizeConfiguredDoltEnv strips inherited Dolt endpoint env at target-town
 // boundaries and injects the target town's managed endpoint when present.
 func NormalizeConfiguredDoltEnv(base []string, townRoot string) []string {
+	if ResolveDoltExternal(townRoot) {
+		base = stripDoltEndpointEnv(base)
+		if host := ResolveDoltHost(townRoot); host != "" {
+			base = append(base, "GT_DOLT_HOST="+host)
+		}
+		if port := ResolveDoltPort(townRoot); port > 0 {
+			base = append(base, "GT_DOLT_PORT="+strconv.Itoa(port))
+		}
+		return append(base, "GT_DOLT_EXTERNAL=true")
+	}
 	host, port, ok := ManagedDoltEndpoint(townRoot)
 	if !ok {
 		return base
@@ -531,6 +573,9 @@ func NormalizeConfiguredDoltEnv(base []string, townRoot string) []string {
 	if port > 0 {
 		base = append(base, "GT_DOLT_PORT="+strconv.Itoa(port))
 	}
+	if ResolveDoltExternal(townRoot) {
+		base = append(base, "GT_DOLT_EXTERNAL=true")
+	}
 	return base
 }
 
@@ -538,7 +583,7 @@ func NormalizeConfiguredDoltEnv(base []string, townRoot string) []string {
 // process environment for target-town startup boundaries.
 func ApplyConfiguredDoltEnv(townRoot string) {
 	normalized := NormalizeConfiguredDoltEnv(os.Environ(), townRoot)
-	for _, key := range []string{"GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+	for _, key := range []string{"GT_DOLT_EXTERNAL", "GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
 		_ = os.Unsetenv(key)
 	}
 	for _, entry := range normalized {
@@ -562,7 +607,7 @@ func stripDoltEndpointEnv(env []string) []string {
 }
 
 func isDoltEndpointEnvKey(key string) bool {
-	for _, want := range []string{"GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+	for _, want := range []string{"GT_DOLT_EXTERNAL", "GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
 		if runtime.GOOS == "windows" {
 			if strings.EqualFold(key, want) {
 				return true
@@ -639,6 +684,9 @@ func ResolveDoltHost(townRoot string) string {
 	if townRoot == "" {
 		return ""
 	}
+	if ResolveDoltExternal(townRoot) {
+		return resolveDoltHostFromDaemonJSON(townRoot)
+	}
 	if host := resolveDoltHostFromConfigYAML(townRoot); host != "" {
 		return host
 	}
@@ -673,6 +721,30 @@ func resolveDoltHostFromDaemonJSON(townRoot string) string {
 		return ""
 	}
 	return strings.TrimSpace(daemonEnv.Env["GT_DOLT_HOST"])
+}
+
+func parseDoltExternal(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "yes", "1", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveDoltExternalFromDaemonJSON(townRoot string) bool {
+	daemonJSONPath := filepath.Join(townRoot, "mayor", "daemon.json")
+	data, err := os.ReadFile(daemonJSONPath)
+	if err != nil {
+		return false
+	}
+	var daemonEnv struct {
+		Env map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &daemonEnv); err != nil {
+		return false
+	}
+	return parseDoltExternal(daemonEnv.Env["GT_DOLT_EXTERNAL"])
 }
 
 // parsePortFromConfigYAML extracts the listener port from a Dolt config.yaml

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1234,6 +1234,64 @@ func TestResolveDoltPort_FromConfigYAML(t *testing.T) {
 	}
 }
 
+func TestResolveDoltPort_ExternalEndpointBeatsManagedConfig(t *testing.T) {
+	// Given
+	t.Setenv("GT_DOLT_EXTERNAL", "")
+	t.Setenv("GT_DOLT_PORT", "")
+	townRoot := t.TempDir()
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"), []byte("listener:\n  port: 3307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_PORT":"3308"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// When
+	port := ResolveDoltPort(townRoot)
+
+	// Then
+	if port != 3308 {
+		t.Fatalf("ResolveDoltPort() = %d, want 3308", port)
+	}
+}
+
+func TestResolveDoltHost_ExternalEndpointBeatsManagedConfig(t *testing.T) {
+	// Given
+	t.Setenv("GT_DOLT_EXTERNAL", "")
+	t.Setenv("GT_DOLT_HOST", "")
+	townRoot := t.TempDir()
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"), []byte("listener:\n  host: 127.0.0.2\n  port: 3307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_HOST":"127.0.0.1"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// When
+	host := ResolveDoltHost(townRoot)
+
+	// Then
+	if host != "127.0.0.1" {
+		t.Fatalf("ResolveDoltHost() = %q, want 127.0.0.1", host)
+	}
+}
+
 func TestResolveDoltPort_FromEnvVar(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("GT_DOLT_PORT", "3310")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -413,6 +413,9 @@ func applyDoltServerConfigEnv(config *DoltServerConfig) {
 		os.Setenv("GT_DOLT_HOST", config.Host)
 		os.Setenv("BEADS_DOLT_SERVER_HOST", config.Host)
 	}
+	if config.External {
+		os.Setenv("GT_DOLT_EXTERNAL", "true")
+	}
 }
 
 func applyConfiguredDoltHostEnv(townRoot string, logf func(format string, v ...interface{})) {

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -176,6 +176,14 @@ func normalizeDoltServerConfig(townRoot string, config *DoltServerConfig) *DoltS
 		return nil
 	}
 	normalized := *config
+	if agentconfig.ResolveDoltExternal(townRoot) {
+		normalized.External = true
+		normalized.Host = agentconfig.ResolveDoltHost(townRoot)
+		if port := agentconfig.ResolveDoltPort(townRoot); port > 0 {
+			normalized.Port = port
+		}
+		return &normalized
+	}
 	if host, port, ok := agentconfig.ManagedDoltEndpoint(townRoot); ok {
 		normalized.Host = host
 		if port > 0 {
@@ -907,6 +915,9 @@ behavior:
 func (m *DoltServerManager) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.IsExternal() {
+		return fmt.Errorf("Dolt server is externally managed")
+	}
 	return m.startLocked()
 }
 
@@ -998,6 +1009,9 @@ func (m *DoltServerManager) startLocked() error {
 func (m *DoltServerManager) Stop() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.IsExternal() {
+		return fmt.Errorf("Dolt server is externally managed")
+	}
 	m.stopLocked()
 	return nil
 }

--- a/internal/daemon/dolt_endpoint_config_test.go
+++ b/internal/daemon/dolt_endpoint_config_test.go
@@ -86,6 +86,48 @@ func TestNewDoltServerManagerHonorsIgnoreConfig(t *testing.T) {
 	}
 }
 
+func TestNewDoltServerManager_ExternalLoopbackUsesDaemonEndpoint(t *testing.T) {
+	// Given
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_EXTERNAL", "")
+	t.Setenv("GT_DOLT_HOST", "")
+	t.Setenv("GT_DOLT_PORT", "")
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_HOST":"127.0.0.1","GT_DOLT_PORT":"3308"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// When
+	manager := NewDoltServerManager(townRoot, &DoltServerConfig{Enabled: true}, func(string, ...interface{}) {})
+
+	// Then
+	if !manager.IsExternal() {
+		t.Fatal("external loopback endpoint must not be daemon managed")
+	}
+	if manager.config.Host != "127.0.0.1" || manager.config.Port != 3308 {
+		t.Fatalf("endpoint = %s:%d, want 127.0.0.1:3308", manager.config.Host, manager.config.Port)
+	}
+}
+
+func TestDoltServerManager_StartRejectsExternalEndpoint(t *testing.T) {
+	// Given
+	manager := &DoltServerManager{
+		config: &DoltServerConfig{Enabled: true, External: true},
+		logger: func(string, ...interface{}) {},
+	}
+
+	// When
+	err := manager.Start()
+
+	// Then
+	if err == nil {
+		t.Fatal("external server start must be rejected")
+	}
+}
+
 func TestApplyDoltServerConfigEnvUsesNormalizedManagerConfig(t *testing.T) {
 	townRoot := t.TempDir()
 	writeManagedDoltConfig(t, townRoot, "listener:\n  host: 127.0.0.2\n  port: 5507\n")

--- a/internal/doctor/migration_check.go
+++ b/internal/doctor/migration_check.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 var verifyExpectedDatabasesAtConfig = doltserver.VerifyExpectedDatabasesAtConfig
@@ -471,6 +471,14 @@ func (c *DoltServerReachableCheck) getServerAddr(beadsDir string, townRoot strin
 	}
 	if metadata.DoltMode != "server" {
 		return "", false
+	}
+
+	// External endpoint is authoritative: per-rig metadata may still record a
+	// stale locally-managed endpoint (e.g. port 3307) from before the cutover,
+	// which would make the check probe a dead local server instead of the
+	// declared shared endpoint.
+	if cfg := doltserver.DefaultConfig(townRoot); cfg.IsExternallyManaged() {
+		return cfg.HostPort(), true
 	}
 
 	host := metadata.DoltServerHost

--- a/internal/doctor/migration_check_test.go
+++ b/internal/doctor/migration_check_test.go
@@ -215,6 +215,42 @@ func TestGetServerAddr_UsesConfigYAMLPort(t *testing.T) {
 	}
 }
 
+func TestGetServerAddr_ExternalEndpointOverridesStaleMetadata(t *testing.T) {
+	check := NewDoltServerReachableCheck()
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_EXTERNAL", "")
+	t.Setenv("GT_DOLT_HOST", "")
+	t.Setenv("GT_DOLT_PORT", "")
+
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	daemonJSON := `{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_HOST":"127.0.0.1","GT_DOLT_PORT":"3308"}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(daemonJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"), []byte("listener:\n  port: 3307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	beadsDir := filepath.Join(townRoot, ".beads")
+	setupServerMetadata(t, beadsDir, "127.0.0.1", 3307)
+
+	addr, ok := check.getServerAddr(beadsDir, townRoot)
+	if !ok {
+		t.Fatal("getServerAddr() returned ok=false, want true")
+	}
+	if addr != "127.0.0.1:3308" {
+		t.Errorf("getServerAddr() = %q, want 127.0.0.1:3308 from external endpoint", addr)
+	}
+}
+
 func TestDoltServerReachableCheck_FailsWhenExpectedRigDatabaseMissing(t *testing.T) {
 	check := NewDoltServerReachableCheck()
 	townRoot := t.TempDir()

--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -315,6 +315,9 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 // Fix creates missing config.json files, Dolt databases, and rig identity beads.
 func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
+	if config.ResolveDoltExternal(ctx.TownRoot) {
+		return nil
+	}
 	rigsConfigPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
 	rigsConfig, err := config.LoadRigsConfig(rigsConfigPath)
 	if err != nil {

--- a/internal/doctor/stale_dolt_port_check.go
+++ b/internal/doctor/stale_dolt_port_check.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/steveyegge/gastown/internal/config"
 )
 
 // StaleDoltPortCheck detects stale Dolt port files that point to wrong ports.
@@ -15,19 +17,19 @@ import (
 // It also checks metadata.json files for port consistency with the running server.
 type StaleDoltPortCheck struct {
 	FixableCheck
-	stalePorts      []stalePortInfo
-	staleMetadata   []staleMetadataInfo
+	stalePorts    []stalePortInfo
+	staleMetadata []staleMetadataInfo
 }
 
 type stalePortInfo struct {
-	path       string
-	port       int
+	path        string
+	port        int
 	correctPort int
 }
 
 type staleMetadataInfo struct {
-	path       string
-	port       int
+	path        string
+	port        int
 	correctPort int
 }
 
@@ -48,7 +50,14 @@ func NewStaleDoltPortCheck() *StaleDoltPortCheck {
 func (c *StaleDoltPortCheck) Run(ctx *CheckContext) *CheckResult {
 	c.stalePorts = nil
 	c.staleMetadata = nil
-	
+	if config.ResolveDoltExternal(ctx.TownRoot) {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "External Dolt endpoint is not locally managed",
+		}
+	}
+
 	// Get the correct port from the main Dolt config
 	correctPort := c.getCorrectPort(ctx)
 	if correctPort == 0 {
@@ -57,7 +66,7 @@ func (c *StaleDoltPortCheck) Run(ctx *CheckContext) *CheckResult {
 
 	// Find all dolt-server.port files
 	portFiles := c.findPortFiles(ctx.TownRoot)
-	
+
 	var details []string
 	for _, portFile := range portFiles {
 		data, err := os.ReadFile(portFile)
@@ -74,8 +83,8 @@ func (c *StaleDoltPortCheck) Run(ctx *CheckContext) *CheckResult {
 		// Check if port matches the correct port
 		if port != correctPort {
 			c.stalePorts = append(c.stalePorts, stalePortInfo{
-				path:       portFile,
-				port:       port,
+				path:        portFile,
+				port:        port,
 				correctPort: correctPort,
 			})
 			relPath, _ := filepath.Rel(ctx.TownRoot, portFile)
@@ -89,8 +98,8 @@ func (c *StaleDoltPortCheck) Run(ctx *CheckContext) *CheckResult {
 		port := c.getPortFromMetadata(metaFile)
 		if port > 0 && port != correctPort {
 			c.staleMetadata = append(c.staleMetadata, staleMetadataInfo{
-				path:       metaFile,
-				port:       port,
+				path:        metaFile,
+				port:        port,
 				correctPort: correctPort,
 			})
 			relPath, _ := filepath.Rel(ctx.TownRoot, metaFile)
@@ -130,14 +139,14 @@ func (c *StaleDoltPortCheck) Fix(ctx *CheckContext) error {
 			return fmt.Errorf("could not remove stale port file %s: %w", info.path, err)
 		}
 	}
-	
+
 	// Fix metadata.json files with wrong ports
 	for _, info := range c.staleMetadata {
 		if err := c.fixMetadataPort(info.path, info.correctPort); err != nil {
 			return fmt.Errorf("could not fix metadata.json %s: %w", info.path, err)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/internal/doctor/stale_dolt_port_check_test.go
+++ b/internal/doctor/stale_dolt_port_check_test.go
@@ -174,3 +174,50 @@ listener:
 		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
 	}
 }
+
+func TestStaleDoltPortCheck_PreservesExternalLoopbackEndpoint(t *testing.T) {
+	// Given
+	townRoot := t.TempDir()
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"), []byte("listener:\n  port: 3307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_PORT":"3308"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := map[string]interface{}{
+		"dolt_mode":        "server",
+		"dolt_server_host": "127.0.0.1",
+		"dolt_server_port": 3308,
+		"dolt_database":    "hq",
+	}
+	metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadataBytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("3308"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// When
+	result := NewStaleDoltPortCheck().Run(&CheckContext{TownRoot: townRoot})
+
+	// Then
+	if result.Status != StatusOK {
+		t.Fatalf("external loopback endpoint was treated as stale: %s", result.Message)
+	}
+}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -200,6 +200,10 @@ type Config struct {
 	// Empty means localhost (backward-compatible default).
 	Host string
 
+	// External marks a server whose lifecycle is managed outside Gas Town.
+	// It applies even when the server binds only to a loopback address.
+	External bool
+
 	// Port is the MySQL protocol port.
 	Port int
 
@@ -326,6 +330,7 @@ func DefaultConfig(townRoot string) *Config {
 	if h := configpkg.ResolveDoltHost(townRoot); h != "" {
 		config.Host = h
 	}
+	config.External = configpkg.ResolveDoltExternal(townRoot)
 
 	if port := configpkg.ResolveDoltPort(townRoot); port > 0 {
 		config.Port = port
@@ -407,10 +412,16 @@ func (c *Config) IsRemote() bool {
 	return true
 }
 
+// IsExternallyManaged reports whether Gas Town must not manage the server
+// process, storage, or listener lifecycle.
+func (c *Config) IsExternallyManaged() bool {
+	return c.External || c.IsRemote()
+}
+
 // SQLArgs returns the dolt CLI flags needed to connect to a remote server.
 // Returns nil for local servers (dolt auto-detects the running local server).
 func (c *Config) SQLArgs() []string {
-	if !c.IsRemote() {
+	if !c.IsExternallyManaged() {
 		return nil
 	}
 	return []string{
@@ -627,7 +638,7 @@ func SaveState(townRoot string, state *State) error {
 }
 
 func refreshPIDStateFromLiveInfo(townRoot string, config *Config, pid int) (bool, error) {
-	if pid <= 0 || config == nil || config.IsRemote() {
+	if pid <= 0 || config == nil || config.IsExternallyManaged() {
 		return false, nil
 	}
 
@@ -698,8 +709,8 @@ func countDoltDatabases(dataDir string) int {
 func IsRunning(townRoot string) (bool, int, error) {
 	config := DefaultConfig(townRoot)
 
-	// Remote server: no local PID/process to check — just TCP reachability.
-	if config.IsRemote() {
+	// Externally managed servers have no Town-owned PID/process to inspect.
+	if config.IsExternallyManaged() {
 		conn, err := net.DialTimeout("tcp", config.HostPort(), 2*time.Second)
 		if err != nil {
 			return false, 0, nil
@@ -774,7 +785,7 @@ func CheckServerReachable(townRoot string) error {
 	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	if err != nil {
 		hint := ""
-		if !config.IsRemote() {
+		if !config.IsExternallyManaged() {
 			hint = "\n\nStart with: gt dolt start"
 		}
 		return fmt.Errorf("Dolt server not reachable at %s: %w%s", addr, err, hint)
@@ -894,7 +905,7 @@ func hasServerMode(beadsDir string) bool {
 // or (0, "") if the port is free or used by this town's own Dolt.
 func CheckPortConflict(townRoot string) (int, string) {
 	cfg := DefaultConfig(townRoot)
-	if cfg.IsRemote() {
+	if cfg.IsExternallyManaged() {
 		return 0, ""
 	}
 	pid := findDoltServerOnPort(cfg.Port)
@@ -1682,6 +1693,9 @@ behavior:
 // Start starts the Dolt SQL server.
 func Start(townRoot string) error {
 	config := DefaultConfig(townRoot)
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s)", config.HostPort())
+	}
 
 	// Ensure daemon directory exists
 	daemonDir := filepath.Dir(config.LogFile)
@@ -2084,6 +2098,9 @@ func drainConnectionsBeforeStop(config *Config) {
 // Works for both servers started via gt dolt start AND externally-started servers.
 func Stop(townRoot string) error {
 	config := DefaultConfig(townRoot)
+	if config.IsExternallyManaged() {
+		return fmt.Errorf("Dolt server is externally managed (%s)", config.HostPort())
+	}
 
 	running, pid, err := IsRunning(townRoot)
 	if err != nil {
@@ -2101,7 +2118,7 @@ func Stop(townRoot string) error {
 	// Drain active connections before stopping to reduce the nbs_manifest
 	// race window inside Dolt's NomsBlockStore.Close(). Non-fatal: proceeds even
 	// if drain times out (10s max). Skipped for remote servers (no local PID).
-	if !config.IsRemote() {
+	if !config.IsExternallyManaged() {
 		drainConnectionsBeforeStop(config)
 	}
 
@@ -2194,7 +2211,7 @@ func InvalidateDBCache() {
 func ListDatabases(townRoot string) ([]string, error) {
 	config := DefaultConfig(townRoot)
 
-	if config.IsRemote() {
+	if config.IsExternallyManaged() {
 		return listDatabasesCached(config)
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3789,6 +3789,61 @@ func TestIsRemote(t *testing.T) {
 	}
 }
 
+func TestConfig_IsExternallyManaged_when_loopback_external_is_declared(t *testing.T) {
+	// Given
+	config := &Config{Host: "127.0.0.1", External: true}
+
+	// When
+	managed := config.IsExternallyManaged()
+
+	// Then
+	if !managed {
+		t.Fatal("loopback external server must not be owned by Gas Town")
+	}
+}
+
+func TestDefaultConfig_ExternalLoopbackUsesDaemonEndpoint(t *testing.T) {
+	// Given
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_EXTERNAL", "")
+	t.Setenv("GT_DOLT_HOST", "")
+	t.Setenv("GT_DOLT_PORT", "")
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_EXTERNAL":"true","GT_DOLT_HOST":"127.0.0.1","GT_DOLT_PORT":"3308"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// When
+	config := DefaultConfig(townRoot)
+
+	// Then
+	if !config.IsExternallyManaged() {
+		t.Fatal("loopback external server must not be owned by Gas Town")
+	}
+	if config.HostPort() != "127.0.0.1:3308" {
+		t.Fatalf("HostPort() = %q, want 127.0.0.1:3308", config.HostPort())
+	}
+}
+
+func TestStart_RejectsExternalLoopbackEndpoint(t *testing.T) {
+	// Given
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_EXTERNAL", "true")
+	t.Setenv("GT_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GT_DOLT_PORT", "3308")
+
+	// When
+	err := Start(townRoot)
+
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "externally managed") {
+		t.Fatalf("Start() error = %v, want externally managed error", err)
+	}
+}
+
 func TestSQLArgs(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Add an explicit ownership contract so a Gas Town town can consume a Dolt SQL server it does not own, even when that server binds only to a loopback address (for example Beads' shared server on 127.0.0.1:3308). Today a loopback endpoint is always classified as locally managed, which forces towns to either run their own server or risk lifecycle code acting on a shared one.

## Related Issue

<!-- Cross-repo use case; no upstream issue filed yet. -->

## Changes

- `doltserver.Config` gains `External` + `IsExternallyManaged()`; `Start`/`Stop` refuse, `IsRunning` degrades to TCP reachability, and port-conflict/PID bookkeeping is skipped for externally managed endpoints
- `config.ResolveDoltExternal` resolves the ownership flag from `GT_DOLT_EXTERNAL` env or `mayor/daemon.json` env (blank env falls through to persisted config); endpoint resolution then prefers the declared `daemon.json` endpoint over a stale local `.dolt-data/config.yaml`
- `gt config set/get dolt.external` persists the flag alongside `dolt.port`; `GT_DOLT_EXTERNAL` propagates to spawned agents via `AgentEnv`/`NormalizeConfiguredDoltEnv`
- `gt up`/`gt start` check reachability without starting; `gt down` leaves the shared server running and skips idle-monitor/imposter/legacy-dir cleanup for it; `gt status` labels it as `external` (distinct from `remote`)
- Storage-owning commands (`gt dolt migrate`, `recover`, `rollback`, `sync`, `pull`, `flatten`, `rebase`, `gt maintain`) refuse externally managed endpoints
- Doctor: `dolt-server-reachable` probes the declared external endpoint instead of per-rig metadata that may still record the stale local port; `stale-dolt-port` reports OK without rewriting port files or `metadata.json`; `rig-config-sync --fix` becomes a no-op under external ownership
- Daemon `DoltServerManager` adopts the same contract (monitor-only, never restart/kill)

## Testing

- [x] Unit tests pass (`go test ./...` on affected packages: config, doltserver, cmd, daemon, doctor)
- [x] Manual testing performed: `gt config set dolt.external true` + `dolt.port 3308`; `gt doctor` green with `dolt-server-reachable ✓` and `stale-dolt-port: External Dolt endpoint is not locally managed`; `gt dolt start`/`stop` refuse with `externally managed (127.0.0.1:3308)`; `gt up`/`gt down` leave the shared server process untouched; `bd doctor --server` 6/6 against the shared server

## Checklist

- [x] Code follows project style
- [x] Documentation updated (docs/design/dolt-storage.md: env-var table row + external-endpoint semantics section)
- [x] No breaking changes (default behavior unchanged; opt-in via `gt config set dolt.external true`)