### PR TITLE
fix(tmux): read key bindings via table enumeration for tmux 3.7

### DIFF
--- a/internal/tmux/cycle_bindings_test.go
+++ b/internal/tmux/cycle_bindings_test.go
@@ -84,7 +84,7 @@ func TestSetCycleBindings_RefreshesStalePattern(t *testing.T) {
 
 	// Verify the binding was updated with the current pattern
 	currentPattern := sessionPrefixPattern()
-	output, err := tm.run("list-keys", "-T", "prefix", "n")
+	output, err := tm.keyBindingOutput("prefix", "n")
 	if err != nil {
 		t.Fatalf("listing keys: %v", err)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3899,7 +3899,7 @@ func (t *Tmux) SetTownCycleBindings(session string) error {
 //  2. Unguarded form (set by EnsureBindingsOnSocket): direct run-shell
 //     invoking "gt agents menu" or "gt feed --window".
 func (t *Tmux) isGTBinding(table, key string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.keyBindingOutput(table, key)
 	if err != nil || output == "" {
 		return false
 	}
@@ -3917,7 +3917,7 @@ func (t *Tmux) isGTBinding(table, key string) bool {
 // --client for multi-client support. Older GT bindings without --client cause
 // switch-client to target the wrong client when multiple clients are attached.
 func (t *Tmux) isGTBindingWithClient(table, key string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.keyBindingOutput(table, key)
 	if err != nil || output == "" {
 		return false
 	}
@@ -3929,7 +3929,7 @@ func (t *Tmux) isGTBindingWithClient(table, key string) bool {
 // current prefix pattern. Returns false if the binding is stale (e.g., after
 // gt rig add introduces a new prefix not yet in the grep pattern).
 func (t *Tmux) isGTBindingCurrent(table, key, currentPattern string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.keyBindingOutput(table, key)
 	if err != nil || output == "" {
 		return false
 	}
@@ -3956,7 +3956,7 @@ func (t *Tmux) getKeyBinding(table, key string) string {
 	//   bind-key [-r] -T <table> <key> <command...>
 	// If tmux changes this format, parsing fails safely (returns ""),
 	// which causes the caller to use its default fallback.
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.keyBindingOutput(table, key)
 	if err != nil || output == "" {
 		return ""
 	}
@@ -4002,6 +4002,22 @@ func (t *Tmux) getKeyBinding(table, key string) string {
 	}
 
 	return cmd
+}
+
+func (t *Tmux) keyBindingOutput(table, key string) (string, error) {
+	output, err := t.run("list-keys", "-T", table)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		for index, field := range fields {
+			if field == "-T" && index+2 < len(fields) && fields[index+1] == table && fields[index+2] == key {
+				return line, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 // safePrefixRe matches the character set guaranteed by beadsPrefixRegexp in

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2708,7 +2708,7 @@ func TestSetBindings_PreserveFallbackOnRepeatedCalls(t *testing.T) {
 		"display-message custom-user-cmd")
 
 	// Record the binding after first configuration
-	firstRaw, _ := tm.run("list-keys", "-T", "prefix", "F11")
+	firstRaw, _ := tm.keyBindingOutput("prefix", "F11")
 
 	// isGTBinding should return true, causing Set*Binding to skip
 	if !tm.isGTBinding("prefix", "F11") {


### PR DESCRIPTION
## Summary

tmux 3.7 returns empty output for `list-keys -T <table> <key>` while table enumeration still contains the binding. This silently broke GT-binding detection (`isGTBinding`, `isGTBindingWithClient`, `isGTBindingCurrent`) and fallback capture (`getKeyBinding`), which in turn made `SetCycleBindings` rebind on every call and cycle bindings never refresh stale prefix patterns.

## Related Issue

<!-- Deterministic repro on tmux 3.7b; no upstream issue filed yet. -->

## Changes

- Add `Tmux.keyBindingOutput(table, key)`: lists the table once and selects the matching `bind-key -T <table> <key>` line
- Use it in `isGTBinding`, `isGTBindingWithClient`, `isGTBindingCurrent`, and `getKeyBinding` instead of the per-key query
- Tests updated to the same helper for direct verification

## Testing

- [x] Unit tests pass (`go test ./internal/tmux -count=1`)
- [x] Manual testing performed: on tmux 3.7b, `tmux list-keys -T prefix n` returns empty while `tmux list-keys -T prefix` contains the binding; the new helper returns the correct line; the previously failing tests (`TestGetKeyBinding_CapturesDefaultBinding`, `TestGetKeyBinding_CapturesUserBinding`, `TestIsGTBinding_DetectsGasTownBindings`, `TestSetBindings_PreserveFallbackOnRepeatedCalls`, `TestIsGTBindingCurrent_DetectsStalePattern`, `TestSetCycleBindings_RefreshesStalePattern`) now pass

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable — internal adapter fix)
- [x] No breaking changes (falls back to empty string exactly as before when the binding is absent)