### PR TITLE
fix(refinery): load merge queue config from rig settings

### DIFF
--- a/internal/cmd/rig_settings_test.go
+++ b/internal/cmd/rig_settings_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/refinery"
+	"github.com/steveyegge/gastown/internal/rig"
 )
 
 // setupTestRigForSettings creates a test rig for settings testing.
@@ -27,9 +29,9 @@ func setupTestRigForSettings(t *testing.T) (string, string) {
 	// Create town.json (primary marker for workspace detection)
 	townConfig := &config.TownConfig{
 		Type:      "town",
-		Version:    config.CurrentTownVersion,
-		Name:       "test-town",
-		CreatedAt:  time.Now().Truncate(time.Second),
+		Version:   config.CurrentTownVersion,
+		Name:      "test-town",
+		CreatedAt: time.Now().Truncate(time.Second),
 	}
 	townConfigPath := filepath.Join(mayorDir, "town.json")
 	if err := config.SaveTownConfig(townConfigPath, townConfig); err != nil {
@@ -77,6 +79,30 @@ func setupTestRigForSettings(t *testing.T) (string, string) {
 	})
 
 	return townRoot, "testrig"
+}
+
+func TestRigSettingsSetMergeQueueReadByRefinery(t *testing.T) {
+	townRoot, rigName := setupTestRigForSettings(t)
+	rigPath := filepath.Join(townRoot, rigName)
+
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.max_concurrent", "3"}); err != nil {
+		t.Fatalf("set merge_queue.max_concurrent: %v", err)
+	}
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.on_conflict", "auto_rebase"}); err != nil {
+		t.Fatalf("set merge_queue.on_conflict: %v", err)
+	}
+
+	engineer := refinery.NewEngineer(&rig.Rig{Name: rigName, Path: rigPath})
+	if err := engineer.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if engineer.Config().MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent = %d, want 3", engineer.Config().MaxConcurrent)
+	}
+	if engineer.Config().OnConflict != "auto_rebase" {
+		t.Errorf("OnConflict = %q, want auto_rebase", engineer.Config().OnConflict)
+	}
 }
 
 func TestRigSettingsShow(t *testing.T) {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/git"
@@ -315,9 +316,9 @@ func (e *Engineer) SetOutput(w io.Writer) {
 	e.output = w
 }
 
-// LoadConfig loads merge queue configuration from the rig's config.json.
+// LoadConfig loads merge queue configuration from the rig's canonical settings/config.json.
 func (e *Engineer) LoadConfig() error {
-	configPath := filepath.Join(e.rig.Path, "config.json")
+	configPath := config.RigSettingsPath(e.rig.Path)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -3,9 +3,7 @@ package refinery
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -44,7 +42,7 @@ func TestEngineer_LoadConfig_MergeStrategyPR(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	requireReview := true
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
 		"name":    "test-rig",
@@ -53,11 +51,7 @@ func TestEngineer_LoadConfig_MergeStrategyPR(t *testing.T) {
 			"require_review": requireReview,
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -76,17 +70,13 @@ func TestEngineer_LoadConfig_MergeStrategyPR(t *testing.T) {
 func TestEngineer_LoadConfig_MergeStrategyDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"type":        "rig",
 		"version":     1,
 		"name":        "test-rig",
 		"merge_queue": map[string]interface{}{},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/testutil"
 )
@@ -332,8 +333,39 @@ func setupEngineerTerminalCloseTest(t *testing.T, activeMR string) (*Engineer, *
 	return e, b, mrIssue, agentIssue, srcIssue
 }
 
+func writeEngineerSettingsConfig(t *testing.T, rigPath string, cfg map[string]interface{}) string {
+	t.Helper()
+
+	settingsPath := config.RigSettingsPath(rigPath)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal settings config: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatalf("write settings config: %v", err)
+	}
+	return settingsPath
+}
+
+func writeEngineerRootConfig(t *testing.T, rigPath string, cfg map[string]interface{}) string {
+	t.Helper()
+
+	rootPath := filepath.Join(rigPath, "config.json")
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal root config: %v", err)
+	}
+	if err := os.WriteFile(rootPath, data, 0644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	return rootPath
+}
+
 func TestEngineer_LoadConfig_NoFile(t *testing.T) {
-	// Create a temp directory without config.json
+	// Create a temp directory without settings/config.json
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
@@ -359,15 +391,15 @@ func TestEngineer_LoadConfig_NoFile(t *testing.T) {
 }
 
 func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
-	// Create a temp directory with config.json
+	// Create a temp directory with settings/config.json
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Write config file
-	config := map[string]interface{}{
+	// Write settings file
+	settings := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
 		"name":    "test-rig",
@@ -380,11 +412,7 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 			"stale_claim_timeout": "1h",
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -424,6 +452,56 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 	}
 }
 
+func TestEngineer_LoadConfig_IgnoresRigRootConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeEngineerRootConfig(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 9,
+			"on_conflict":    "auto_rebase",
+		},
+	})
+
+	e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if e.config.MaxConcurrent != 1 {
+		t.Errorf("MaxConcurrent = %d, want default 1", e.config.MaxConcurrent)
+	}
+	if e.config.OnConflict != "assign_back" {
+		t.Errorf("OnConflict = %q, want default assign_back", e.config.OnConflict)
+	}
+}
+
+func TestEngineer_LoadConfig_SettingsConfigWinsOverRigRootConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeEngineerRootConfig(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 9,
+			"on_conflict":    "auto_rebase",
+		},
+	})
+	writeEngineerSettingsConfig(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 3,
+			"on_conflict":    "assign_back",
+		},
+	})
+
+	e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if e.config.MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent = %d, want settings value 3", e.config.MaxConcurrent)
+	}
+	if e.config.OnConflict != "assign_back" {
+		t.Errorf("OnConflict = %q, want settings value assign_back", e.config.OnConflict)
+	}
+}
+
 func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
@@ -431,7 +509,7 @@ func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
 		"name":    "test-rig",
@@ -439,11 +517,7 @@ func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 			"auto_push": false,
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -461,24 +535,20 @@ func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 }
 
 func TestEngineer_LoadConfig_NoMergeQueueSection(t *testing.T) {
-	// Create a temp directory with config.json without merge_queue
+	// Create a temp directory with settings/config.json without merge_queue
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Write config file without merge_queue
-	config := map[string]interface{}{
+	// Write settings file without merge_queue
+	settings := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
 		"name":    "test-rig",
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -504,16 +574,12 @@ func TestEngineer_LoadConfig_InvalidPollInterval(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"merge_queue": map[string]interface{}{
 			"poll_interval": "not-a-duration",
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -546,16 +612,12 @@ func TestEngineer_LoadConfig_InvalidStaleClaimTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := map[string]interface{}{
+			settings := map[string]interface{}{
 				"merge_queue": map[string]interface{}{
 					"stale_claim_timeout": tt.timeout,
 				},
 			}
-
-			data, _ := json.MarshalIndent(config, "", "  ")
-			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-				t.Fatal(err)
-			}
+			writeEngineerSettingsConfig(t, tmpDir, settings)
 
 			r := &rig.Rig{
 				Name: "test-rig",
@@ -601,7 +663,7 @@ func TestEngineer_LoadConfig_WithGates(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"merge_queue": map[string]interface{}{
 			"gates": map[string]interface{}{
 				"test": map[string]interface{}{
@@ -619,11 +681,7 @@ func TestEngineer_LoadConfig_WithGates(t *testing.T) {
 			"gates_parallel": true,
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -669,7 +727,7 @@ func TestEngineer_LoadConfig_GateInvalidTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := map[string]interface{}{
+			settings := map[string]interface{}{
 				"merge_queue": map[string]interface{}{
 					"gates": map[string]interface{}{
 						"bad": map[string]interface{}{
@@ -679,11 +737,7 @@ func TestEngineer_LoadConfig_GateInvalidTimeout(t *testing.T) {
 					},
 				},
 			}
-
-			data, _ := json.MarshalIndent(config, "", "  ")
-			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-				t.Fatal(err)
-			}
+			writeEngineerSettingsConfig(t, tmpDir, settings)
 
 			r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 			e := NewEngineer(r)
@@ -699,7 +753,7 @@ func TestEngineer_LoadConfig_GateInvalidTimeout(t *testing.T) {
 func TestEngineer_LoadConfig_GatePhase(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"merge_queue": map[string]interface{}{
 			"gates": map[string]interface{}{
 				"lint": map[string]interface{}{
@@ -716,11 +770,7 @@ func TestEngineer_LoadConfig_GatePhase(t *testing.T) {
 			},
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -744,7 +794,7 @@ func TestEngineer_LoadConfig_GatePhase(t *testing.T) {
 func TestEngineer_LoadConfig_GateInvalidPhase(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config := map[string]interface{}{
+	settings := map[string]interface{}{
 		"merge_queue": map[string]interface{}{
 			"gates": map[string]interface{}{
 				"bad": map[string]interface{}{
@@ -754,11 +804,7 @@ func TestEngineer_LoadConfig_GateInvalidPhase(t *testing.T) {
 			},
 		},
 	}
-
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeEngineerSettingsConfig(t, tmpDir, settings)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)


### PR DESCRIPTION
Supersedes #4325 and #4432. Rebases #4432's fix onto current upstream/main and resolves the single trivial import conflict that made #4432 unmergeable (#4432 had gone 62 commits stale).

Original PR: https://github.com/gastownhall/gastown/pull/4325 by @Ben-Williams-Founder
Clean replacement: https://github.com/gastownhall/gastown/pull/4432 by @Bella-Giraffety (head commit e54d015eff7b31044ea54d3ddc955d8e9cec706a, co-authored by @Ben-Williams-Founder), cherry-picked here unchanged onto current upstream/main.

## Summary
- Make `refinery.Engineer.LoadConfig` read the canonical rig settings file via `config.RigSettingsPath(e.rig.Path)` (`<rig>/settings/config.json`).
- Keep the existing refinery `merge_queue` parser/default overlay unchanged.
- Add focused regressions proving rig-root `config.json` is ignored, canonical settings win when both files exist, and values written by `gt rig settings set merge_queue.*` are read by the refinery loader.

## Scope Control
This intentionally does not carry over #4325's legacy rig-root fallback, `EffectiveConfig`, or `gt rig settings show --effective` surface, matching #4432's scope decision.

## Rebase conflict resolution
Rebasing onto current upstream/main produced exactly one conflict, in `internal/refinery/engineer_pr_merge_test.go`'s import block: upstream/main independently added a `fmt` import (used by an unrelated `fmt.Errorf` call added after #4432's branch point) while #4432 dropped the by-then-unused `encoding/json` and `os` imports. Resolved by keeping `fmt` and dropping `encoding/json`/`os`. No logic changes.

## Verification
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test ./internal/refinery -run 'TestEngineer_LoadConfig|TestEngineer_LoadConfig_MergeStrategy' -count=1` — pass
- `CGO_ENABLED=0 go test ./internal/refinery -count=1` (full package) — pass
- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestRigSettings.*Refinery' -count=1` — pass
- `gofmt -l` on all touched files — clean
- `go vet ./internal/refinery/... ./internal/cmd/...` — clean

## Superseded closure
Do not close #4325 or #4432 until this replacement merges. Maintainer note: #4432's push-capable remote is a fork this bot has no push access to, so this is opened as a fresh PR from an owned fork rather than a force-push to #4432's branch — see gt-h5p1 for the access-check trail.
