### PR TITLE
fix(formula): resolve extends/compose in prime + inject issue= for standalone formula sling

### DIFF
--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -179,8 +179,33 @@ func resolveFormulaForRendering(formulaName, townRoot, rigName string, vars []st
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not parse formula %s: %w", formulaName, err)
 	}
+
+	// Resolve extends/compose so child formulas (e.g. wc26-frontend extends
+	// mol-polecat-work) inherit their parent steps. Without this, formulas
+	// that only use extends/compose render zero steps.
+	f, err = formula.Resolve(f, formulaSearchPaths(townRoot, rigName))
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not resolve formula %s: %w", formulaName, err)
+	}
+
 	applyFormulaOverlays(f, formulaName, townRoot, rigName)
 	return f, buildFormulaVarMap(f, vars), nil
+}
+
+// formulaSearchPaths returns on-disk directories Resolve uses to locate
+// parent formulas referenced via extends/compose. Mirrors the precedence
+// of ResolveFormulaContent: rig-level before town-level. Embedded formulas
+// are tried first inside Resolve, so these are fallbacks for rig-specific
+// formulas that are NOT embedded.
+func formulaSearchPaths(townRoot, rigName string) []string {
+	var paths []string
+	if townRoot != "" && rigName != "" {
+		paths = append(paths, filepath.Join(townRoot, rigName, ".beads", "formulas"))
+	}
+	if townRoot != "" {
+		paths = append(paths, filepath.Join(townRoot, ".beads", "formulas"))
+	}
+	return paths
 }
 
 func firstFormulaVars(extraVars [][]string) []string {

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -74,6 +74,21 @@ func TestRenderFormulaStepsFull_DeaconIncludesHeartbeatCommand(t *testing.T) {
 	}
 }
 
+func TestRenderFormulaStepsFull_ResolvesExtendsAndCompose(t *testing.T) {
+	out, err := renderFormulaStepsFull("mol-polecat-work-monorepo-tdd", t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("renderFormulaStepsFull: %v", err)
+	}
+	for _, want := range []string{
+		"Load context and verify assignment", // inherited via extends from mol-polecat-work-monorepo
+		"Write failing tests",                // injected via compose.expand from tdd-cycle
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rendered mol-polecat-work-monorepo-tdd missing %q (extends/compose not resolved):\n%s", want, out)
+		}
+	}
+}
+
 func TestGetAgentBeadID_UsesRigPrefix(t *testing.T) {
 	townRoot := t.TempDir()
 	writeTestRoutes(t, townRoot, []beads.Route{

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -522,13 +522,19 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
 	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
 	// creates a wisp that's bonded to a separate base bead.
+	// Prepend `issue=<wispRootID>` so polecat formula step descriptions render
+	// `{{issue}}` correctly. For standalone formula sling, the wisp IS the
+	// work, so its own ID is the "issue" (an explicit --var issue=... still
+	// wins, since it's appended after and later entries override earlier
+	// ones on substitution).
+	storedVars := append([]string{fmt.Sprintf("issue=%s", wispRootID)}, slingVars...)
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:      actor,
 		Args:            slingArgs,
-		Vars:            append([]string(nil), slingVars...),
+		Vars:            storedVars,
 		AttachedFormula: formulaName,
 		Mode:            &mode,
-		FormulaVars:     strings.Join(slingVars, "\n"),
+		FormulaVars:     strings.Join(storedVars, "\n"),
 	}
 	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2226,6 +2226,9 @@ exit /b 0
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
 	}
+	if !strings.Contains(attachment, "issue=gt-wisp-xyz") {
+		t.Fatalf("issue= var (wisp root ID) missing from persisted standalone formula description:\n%s", attachment)
+	}
 	if !strings.Contains(attachment, "mode: ralph") {
 		t.Fatalf("ralph mode missing from persisted standalone formula description:\n%s", attachment)
 	}


### PR DESCRIPTION
Replacement/fixup for #4066 by @flipch. Carries forward the two bug fixes on current `upstream/main`.

Original-PR: https://github.com/gastownhall/gastown/pull/4066
Original-Commit: df492747486c3506eb31a775fcbc43d2829e2004
Attribution: original diagnosis and fix by @flipch, with original co-author Claude Opus 4.7 (1M context); this replacement rebuilt on current main by a PR Sheriff pass (Claude Sonnet 5), preserving `Co-authored-by: flipch`.

## Changes

1. **`internal/cmd/prime_molecule.go`**: `resolveFormulaForRendering` — the single shared helper now feeding `showFormulaSteps`, `showFormulaStepsFull`, and `renderFormulaRootAndStepsFull` — called `formula.Parse()` but never `formula.Resolve()`. Formulas using `extends`/`compose.expand` therefore rendered **zero** steps in `gt prime --hook` output. Added the `Resolve()` call (with a small `formulaSearchPaths` helper mirroring `ResolveFormulaContent`'s rig→town precedence) between `Parse` and `applyFormulaOverlays`.
2. **`internal/cmd/sling_formula.go`**: the standalone-formula-sling path (used when the wisp itself is the work, no base bead) stored `attached_vars`/`formula_vars` from `slingVars` without `issue=<wispRootID>`, so `{{issue}}` placeholders in step descriptions rendered literally. Fixed by prepending `issue=<wispRootID>` once the wisp's ID is known.

**Not touched**: `sling.go` / `sling_dispatch.go`. On current `main` both already route through `InstantiateFormulaOnBead` → `formulaVarsForBead`, which unconditionally prepends `issue=<beadID>` before storing attachment fields — an independent refactor already fixed this part of #4066's original diff. Re-applying the old diff there would be pure churn against already-correct code.

## Verification

- `CGO_ENABLED=0 go build ./...` clean
- `CGO_ENABLED=0 go vet ./internal/cmd/... ./internal/formula/...` clean
- `CGO_ENABLED=0 go test ./internal/cmd/... ./internal/formula/...` — all pass
- Added `TestRenderFormulaStepsFull_ResolvesExtendsAndCompose` and extended `TestRunSlingFormulaPersistsVarContext`; both independently confirmed to **fail** against the pre-fix code (via `git stash`) and pass with the fix.
- `gt pr-sheriff-check --merge-gate --base upstream/main`: `{"ahead":1,"behind":0,"severity":"clean","merge_path_allowed":true}`

## PR Sheriff note

Original #4066 is stale (base ~3 months old), CI `Test` check failing, never reviewed, `status/review-failed`, and should not merge as-is. A prior Sheriff pass opened #4445 as a first replacement attempt; #4445 is now stale/conflicting against current main and its sole commit carries no real attribution trailer despite its PR body's claim, so it is being closed as superseded-by-defect in favor of this PR, which fixes both the staleness and the attribution gap.