### PR TITLE
fix(web): dashboard shows hooked polecats and cuts false stale warnings

### DIFF
--- a/docs/examples/town-settings.example.json
+++ b/docs/examples/town-settings.example.json
@@ -86,7 +86,7 @@
     },
 
     "worker_status": {
-        "stale_threshold": "5m",
+        "stale_threshold": "15m",
         "stuck_threshold": "30m",
         "heartbeat_fresh_threshold": "5m",
         "mayor_active_threshold": "5m"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -168,7 +168,7 @@ func DefaultWebTimeoutsConfig() *WebTimeoutsConfig {
 // WorkerStatusConfig configures activity-age thresholds for worker status classification.
 type WorkerStatusConfig struct {
 	// StaleThreshold is the activity age after which a worker is considered "stale".
-	// Default: "5m".
+	// Default: "15m".
 	StaleThreshold string `json:"stale_threshold,omitempty"`
 	// StuckThreshold is the activity age after which a worker is considered "stuck".
 	// Default: "30m".
@@ -184,7 +184,7 @@ type WorkerStatusConfig struct {
 // DefaultWorkerStatusConfig returns a WorkerStatusConfig with sensible defaults.
 func DefaultWorkerStatusConfig() *WorkerStatusConfig {
 	return &WorkerStatusConfig{
-		StaleThreshold:          "5m",
+		StaleThreshold:          "15m",
 		StuckThreshold:          "30m",
 		HeartbeatFreshThreshold: "5m",
 		MayorActiveThreshold:    "5m",

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -89,8 +89,8 @@ func TestDefaultWorkerStatusConfig(t *testing.T) {
 	}
 
 	stale := ParseDurationOrDefault(cfg.StaleThreshold, 0)
-	if stale != 5*time.Minute {
-		t.Errorf("StaleThreshold = %v, want 5m", stale)
+	if stale != 15*time.Minute {
+		t.Errorf("StaleThreshold = %v, want 15m", stale)
 	}
 	stuck := ParseDurationOrDefault(cfg.StuckThreshold, 0)
 	if stuck != 30*time.Minute {

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -222,7 +222,7 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 		cmdTimeout:              config.ParseDurationOrDefault(webCfg.CmdTimeout, 15*time.Second),
 		ghCmdTimeout:            config.ParseDurationOrDefault(webCfg.GhCmdTimeout, 10*time.Second),
 		tmuxCmdTimeout:          config.ParseDurationOrDefault(webCfg.TmuxCmdTimeout, 2*time.Second),
-		staleThreshold:          config.ParseDurationOrDefault(workerCfg.StaleThreshold, 5*time.Minute),
+		staleThreshold:          config.ParseDurationOrDefault(workerCfg.StaleThreshold, 15*time.Minute),
 		stuckThreshold:          config.ParseDurationOrDefault(workerCfg.StuckThreshold, constants.GUPPViolationTimeout),
 		heartbeatFreshThreshold: config.ParseDurationOrDefault(workerCfg.HeartbeatFreshThreshold, 5*time.Minute),
 		mayorActiveThreshold:    config.ParseDurationOrDefault(workerCfg.MayorActiveThreshold, 5*time.Minute),
@@ -946,23 +946,34 @@ func (f *LiveConvoyFetcher) FetchWorkers() ([]WorkerRow, error) {
 type assignedIssue struct {
 	ID    string
 	Title string
+	// Status is the issue's bd status ("in_progress" or "hooked"). It is only
+	// used internally by getAssignedIssuesMap to resolve duplicate-assignee
+	// precedence; callers of the map should not depend on it.
+	Status string
 }
 
 // getAssignedIssuesMap returns a map of assignee -> assigned issue.
-// Queries beads for all in_progress issues with assignees.
+// Queries beads for all in_progress and hooked issues with assignees.
+// hooked is a freshly-assigned issue an agent hasn't started acting on yet,
+// so both statuses count as "assigned" for dashboard display purposes. If an
+// assignee has issues in both statuses, in_progress takes precedence.
 func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 	result := make(map[string]assignedIssue)
 
-	// Query all in_progress issues (these are the ones being worked on)
-	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=in_progress", "--json")
+	// Query all in_progress and hooked issues (these are the ones assigned to
+	// an agent, whether or not it has started acting on them). --limit=0
+	// avoids bd's default result-count truncation now that the filter spans
+	// two statuses.
+	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=in_progress,hooked", "--json", "--limit=0")
 	if err != nil {
-		log.Printf("warning: bd list in_progress failed: %v", err)
+		log.Printf("warning: bd list in_progress,hooked failed: %v", err)
 		return result
 	}
 
 	var issues []struct {
 		ID       string `json:"id"`
 		Title    string `json:"title"`
+		Status   string `json:"status"`
 		Assignee string `json:"assignee"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
@@ -971,11 +982,21 @@ func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 	}
 
 	for _, issue := range issues {
-		if issue.Assignee != "" {
-			result[issue.Assignee] = assignedIssue{
-				ID:    issue.ID,
-				Title: issue.Title,
+		if issue.Assignee == "" {
+			continue
+		}
+		// Deterministic duplicate-assignee precedence regardless of bd's
+		// result ordering: an already-recorded in_progress issue is never
+		// replaced, and only an in_progress issue replaces a hooked one.
+		if existing, ok := result[issue.Assignee]; ok {
+			if existing.Status == "in_progress" || issue.Status != "in_progress" {
+				continue
 			}
+		}
+		result[issue.Assignee] = assignedIssue{
+			ID:     issue.ID,
+			Title:  issue.Title,
+			Status: issue.Status,
 		}
 	}
 

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -1003,3 +1003,74 @@ func TestFetchHealth_DeaconHeartbeatFieldName(t *testing.T) {
 		t.Error("HeartbeatFresh = false for a just-written heartbeat")
 	}
 }
+
+// TestGetAssignedIssuesMapIncludesHookedWork covers gastownhall/gastown#3828:
+// getAssignedIssuesMap must include hooked (freshly-assigned, not-yet-started)
+// issues alongside in_progress ones, query with --limit=0 to avoid bd's
+// default result-count truncation, skip blank assignees, and resolve
+// duplicate assignees deterministically (in_progress always wins over
+// hooked, regardless of array order; among multiple hooked issues for the
+// same assignee, the first one seen wins).
+func TestGetAssignedIssuesMapIncludesHookedWork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based command test")
+	}
+	t.Parallel()
+
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	argsPath := filepath.Join(binDir, "args.txt")
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$*" > %q
+cat <<'JSON'
+[
+  {"id": "gt-alice", "title": "alice in_progress", "status": "in_progress", "assignee": "rig/polecats/alice"},
+  {"id": "gt-bob", "title": "bob hooked", "status": "hooked", "assignee": "rig/polecats/bob"},
+  {"id": "gt-carol-hooked", "title": "carol hooked", "status": "hooked", "assignee": "rig/polecats/carol"},
+  {"id": "gt-carol-inprogress", "title": "carol in_progress", "status": "in_progress", "assignee": "rig/polecats/carol"},
+  {"id": "gt-dave-first", "title": "dave first hooked", "status": "hooked", "assignee": "rig/polecats/dave"},
+  {"id": "gt-dave-second", "title": "dave second hooked", "status": "hooked", "assignee": "rig/polecats/dave"},
+  {"id": "gt-blank", "title": "no assignee", "status": "hooked", "assignee": ""}
+]
+JSON
+`, argsPath)
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	f := &LiveConvoyFetcher{cmdTimeout: 5 * time.Second, bdBin: bdPath, townRoot: t.TempDir()}
+	got := f.getAssignedIssuesMap()
+
+	// carol has both statuses: in_progress must win regardless of the
+	// hooked entry appearing earlier in the JSON array.
+	if issue, ok := got["rig/polecats/carol"]; !ok || issue.ID != "gt-carol-inprogress" {
+		t.Errorf("rig/polecats/carol = %+v, want in_progress issue gt-carol-inprogress", issue)
+	}
+	// bob has only a hooked issue: it must still appear (this is the #3828 fix).
+	if issue, ok := got["rig/polecats/bob"]; !ok || issue.ID != "gt-bob" {
+		t.Errorf("rig/polecats/bob = %+v, want hooked issue gt-bob", issue)
+	}
+	// alice's plain in_progress case must still work.
+	if issue, ok := got["rig/polecats/alice"]; !ok || issue.ID != "gt-alice" {
+		t.Errorf("rig/polecats/alice = %+v, want gt-alice", issue)
+	}
+	// dave has two hooked issues: the first one seen must win, deterministically.
+	if issue, ok := got["rig/polecats/dave"]; !ok || issue.ID != "gt-dave-first" {
+		t.Errorf("rig/polecats/dave = %+v, want first-seen hooked issue gt-dave-first", issue)
+	}
+	// Blank assignee must be skipped entirely.
+	if len(got) != 4 {
+		t.Errorf("len(got) = %d, want 4 (blank assignee must be excluded): %+v", len(got), got)
+	}
+
+	argsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := string(argsBytes)
+	for _, want := range []string{"--status=in_progress,hooked", "--limit=0"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("bd invoked with args %q, want it to contain %q", args, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Carries forward PR #4059 ("fix: A few bugs I found with proposed fixes",
@esciara), which was closed without merging. Fixes the two still-open
items from #3828 that PR #4059 addressed:

- `getAssignedIssuesMap` (dashboard) only queried `bd list --status=in_progress`,
  so a polecat with freshly-assigned (`hooked`) work didn't show up until it
  started acting on the issue.
- The default `stale_threshold` for worker activity (5m) is too short for
  LLM agents, which routinely spend >5m reasoning/tool-calling with no
  visible tmux activity, causing false "stale" flags.

Issue #3828's third item (tmux socket scoping) was already fixed
independently on `main` and isn't touched here.

## Why a fresh PR instead of merging #4059 or reopening it

PR #4059 itself was not safe to merge as-is even at the time it was open
(needed `--limit=0` once the status filter broadens, missing direct
regression coverage, a duplicated stale-threshold literal, and stale
example docs). Several PR-Sheriff review passes over the past two months
(recorded on #4059 and on a second independent attempt, #4038) reached
that same conclusion and agreed a maintainer fixup was the right path —
but every attempt to actually land it failed silently: one `gt done`
timed out with the branch never pushed, and both #4059 and #4038 were
eventually closed with comments claiming the fix had already merged or
was "already on main." Neither claim holds up: `git log --all -S` against
every string those fixes are supposed to have introduced (`in_progress,hooked`,
`TestGetAssignedIssuesMapIncludesHookedWork`, `TestGetAssignedIssuesMapIncludesAssignedStatuses`)
finds nothing on any branch reachable from `origin/gastownhall/main`. This
PR closes that loop with an actual green build/test run and a real diff.

## Testing

- `go build ./...`
- `go vet ./internal/config ./internal/web`
- `gofmt -l` on all touched `.go` files (clean)
- `go test ./internal/config ./internal/web -count=1` — pass
- New test `TestGetAssignedIssuesMapIncludesHookedWork` confirmed to *fail*
  against pre-fix `internal/config/types.go`/`internal/web/fetcher.go`
  (checked out from this PR's own merge-base) before being confirmed green
  against the fix, so it's a genuine regression test, not a tautology.

## Attribution

Original bug reports and fix direction: @esciara, PR #4059. Commit carries
a `Co-authored-by` trailer with the email from that PR's own commit.

Closes #3828 (items 2 and 3; item 1 was already fixed separately).
