### PR TITLE
fix(session): carry AgentName into startup command env (malformed BD_ACTOR for dogs)

### DIFF
--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -466,13 +466,19 @@ func buildPrompt(cfg SessionConfig) string {
 }
 
 // buildCommand creates the startup command using the config package.
+// It must carry cfg.AgentName through to AgentEnv: the command's inline
+// `exec env` exports override the tmux -e session env, and AgentEnv's
+// named-agent fallbacks (e.g. BD_ACTOR="dog" for dogs) produce malformed
+// actors that break identity-guarded commands like `gt done` (hq-3rk).
 func buildCommand(cfg SessionConfig, prompt string) (string, error) {
-	if cfg.AgentOverride != "" {
-		return config.BuildAgentStartupCommandWithAgentOverride(
-			cfg.Role, cfg.RigName, cfg.TownRoot, cfg.RigPath, prompt, cfg.AgentOverride)
-	}
-	return config.BuildAgentStartupCommand(
-		cfg.Role, cfg.RigName, cfg.TownRoot, cfg.RigPath, prompt), nil
+	return config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
+		Role:        cfg.Role,
+		Rig:         cfg.RigName,
+		AgentName:   cfg.AgentName,
+		TownRoot:    cfg.TownRoot,
+		Prompt:      prompt,
+		SessionName: cfg.SessionID,
+	}, cfg.RigPath, prompt, cfg.AgentOverride)
 }
 
 // ShutdownDelay is the standard delay after session creation.


### PR DESCRIPTION
Fixes #4728. Related: #4690, #4587, #4676 (guard-routing side of the same symptom).

`buildCommand` built the startup command's inline `exec env` exports via `BuildAgentStartupCommand`, which takes no AgentName. Those inline exports shadow the tmux `-e` session environment computed (correctly, with AgentName) in `StartSession` step 4 — so named agents on the generic lifecycle path get `AgentEnv`'s anonymous fallbacks. For dogs that means `BD_ACTOR="dog"` instead of `deacon/dogs/<name>`: sign-off fails with `gt done is for polecats only (BD_ACTOR=dog)`, the dog wedges in working state until the next deacon patrol, and all bd/mail activity is misattributed. Recurs on every dog dispatch.

Fix: route `buildCommand` through the existing `BuildStartupCommandFromConfig` with the full `AgentEnvConfig` (Role, Rig, AgentName, TownRoot, Prompt, SessionName) so the command env and session env agree.

Tested: `go test ./internal/session/ ./internal/config/ ./internal/dog/` all pass; running in a production town since 2026-08-19 (dogs now spawn with correct BD_ACTOR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)