### PR TITLE
fix(cmd): scope done-guard to root 'gt done' only (unbreaks gt dog done)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -189,13 +189,14 @@ func isRoleCommand(cmd *cobra.Command) bool {
 	return false
 }
 
+// isDoneCommand reports whether cmd is the root-level `gt done` (the
+// polecat completion command). It must NOT match `done` subcommands of
+// other roles — `gt dog done`, `gt wl done`, `gt molecule step done` —
+// which have their own semantics and identities; routing them through
+// the polecat-only worktree guard breaks their sign-off (#4587, #4676,
+// #4690).
 func isDoneCommand(cmd *cobra.Command) bool {
-	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "done" {
-			return true
-		}
-	}
-	return false
+	return cmd.Name() == "done" && cmd.Parent() != nil && !cmd.Parent().HasParent()
 }
 
 // initCLITheme initializes the CLI color theme based on settings and environment.


### PR DESCRIPTION
Fixes #4676. Related: #4587, #4690. Companion to #4729 (the identity side).

`isDoneCommand` matched any command named `done` anywhere in the parent chain, so `gt dog done` / `gt wl done` / `gt molecule step done` were routed through `resolveDonePolecatWorktree` in PersistentPreRun. Dogs fail hard there — `donePolecatActorIdentity` rejects `BD_ACTOR=deacon/dogs/<name>` — so a dog can never sign off and the kennel wedges after every dispatch until the next deacon patrol repairs it.

This scopes `isDoneCommand` to the root-level `gt done`; both call sites (the pre-run guard and `isDoneInvocation`) intend exactly the polecat command.

Verified in a production town (2026-08-19): with #4729 + this patch, a dispatched dog completed `mol-dog-reaper` and `gt dog done` cleared work → idle cleanly, no kennel wedge. `go test ./internal/cmd/` passes (the -run Done subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)