### PR TITLE
fix(done): refuse premature auto-close of assigned code bead (hq-6ijuy)

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -77,8 +77,7 @@ const (
 	ExitDeferred  = "DEFERRED"
 )
 
-func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
-	targetBranch := defaultBranch
+func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {	targetBranch := defaultBranch
 	if explicitTarget != "" {
 		targetBranch = strings.TrimSpace(explicitTarget)
 		if strings.HasPrefix(targetBranch, "origin/") || strings.HasPrefix(targetBranch, "upstream/") {
@@ -1070,6 +1069,26 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					if fatal {
 						return fmt.Errorf("cannot complete review-only/no-MR work: %s", skipReason)
 					}
+					skipClose = true
+				}
+
+				// Antifalse-completion guard (hq-6ijuy): a polecat on a FRESH
+				// code bead with zero commits ahead is indistinguishable from a
+				// genuine no-op, and freshly-spawned polecats have repeatedly run
+				// `gt done` while the hook/assignment was still attaching (46s after
+				// boot, hook empty) — auto-closing the assigned bead with the
+				// "no code changes" reason even though the task was NOT done (it was
+				// never started). For a polecat closing a hooked CODE bead (not
+				// no_merge/review_only) with zero work, refuse to auto-close unless
+				// the polecat explicitly confirms the no-op via --skip-verify (the
+				// documented escape hatch for report-only / genuinely-no-code tasks).
+				// Otherwise leave the bead open and notify the witness/mayor to
+				// review, so a premature close never destroys an assignment.
+				if prematureNoWorkClose(stackHasSpawnedPolecat(), isNoMergeTask, doneSkipVerify) {
+					skipReason := "gt done with zero commits on an assigned code bead; premature-close guard (hq-6ijuy): does not auto-close. If this is a genuine no-work completion, re-run with --skip-verify."
+					style.PrintWarning("%s", skipReason)
+					fmt.Printf("  The bead remains open for witness/mayor review.\n")
+					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 					skipClose = true
 				}
 
@@ -2488,6 +2507,29 @@ func isStaleBranchIssue(branchIssue, hookedIssue string) bool {
 		return false
 	}
 	return branchIssue != hookedIssue && !strings.HasPrefix(branchIssue, hookedIssue+".")
+}
+
+// prematureNoWorkClose reports whether a polecat's `gt done` on a hooked CODE
+// bead (not no_merge/review_only) with zero commits ahead should be refused
+// auto-close (hq-6ijuy antifalse-completion guard). Freshly-spawned polecats
+// have run gt done while the hook/assignment was still attaching, which
+// auto-closed the assigned bead with the "no code changes" reason even though
+// the task was never started. We refuse to auto-close unless the polecat
+// explicitly confirms the no-op via --skip-verify or the task is a genuine
+// no-code (no_merge/review_only) task.
+func prematureNoWorkClose(isPolecat, isNoMergeTask, skipVerify bool) bool {
+	return isPolecat && !isNoMergeTask && !skipVerify
+}
+
+// stackHasSpawnedPolecat reports whether the current actor is a spawned
+// polecat (as opposed to crew/mayor/witness/refinery/deacon). Identity comes
+// from the same env vars `gt done` uses for its polecat-only guard.
+func stackHasSpawnedPolecat() bool {
+	if os.Getenv("GT_POLECAT") != "" {
+		return true
+	}
+	actor := os.Getenv("BD_ACTOR")
+	return actor != "" && isPolecatActor(actor)
 }
 
 // selectAssignedIssue returns the one authoritative assignment to use for

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -845,6 +845,72 @@ func TestIsPolecatActor(t *testing.T) {
 	}
 }
 
+// TestPrematureNoWorkClose verifies the antifalse-completion guard (hq-6ijuy):
+// a polecat closing a hooked CODE bead with zero commits must NOT auto-close
+// unless it explicitly confirms a no-op via --skip-verify or the task is a
+// genuine no-code (no_merge/review_only) task.
+func TestPrematureNoWorkClose(t *testing.T) {
+	tests := []struct {
+		name        string
+		isPolecat   bool
+		isNoMerge   bool
+		skipVerify  bool
+		wantGuardOn bool
+	}{
+		{"fresh polecat, code bead, no skip-verify → guard ON (don't auto-close)", true, false, false, true},
+		{"fresh polecat, code bead, skip-verify → guard OFF (explicit confirm)", true, false, true, false},
+		{"fresh polecat, no_merge task → guard OFF (genuine no-code)", true, true, false, false},
+		{"fresh polecat, review_only task → guard OFF", true, true, true, false},
+		{"non-polecat (crew), code bead → guard OFF", false, false, false, false},
+		{"non-polecat (mayor), no_merge → guard OFF", false, true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prematureNoWorkClose(tt.isPolecat, tt.isNoMerge, tt.skipVerify)
+			if got != tt.wantGuardOn {
+				t.Errorf("prematureNoWorkClose(%v,%v,%v) = %v, want %v",
+					tt.isPolecat, tt.isNoMerge, tt.skipVerify, got, tt.wantGuardOn)
+			}
+		})
+	}
+}
+
+// TestStackHasSpawnedPolecat verifies polecat detection from the same env vars
+// used by the gt done polecat-only guard.
+func TestStackHasSpawnedPolecat(t *testing.T) {
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("BD_ACTOR", "")
+
+	// GT_POLECAT set → polecat
+	t.Setenv("GT_POLECAT", "testrig/polecats/furiosa")
+	if !stackHasSpawnedPolecat() {
+		t.Error("expected polecat when GT_POLECAT set")
+	}
+	t.Setenv("GT_POLECAT", "")
+
+	// BD_ACTOR set with polecat identity → polecat
+	t.Setenv("BD_ACTOR", "testrig/polecats/nux")
+	if !stackHasSpawnedPolecat() {
+		t.Error("expected polecat when BD_ACTOR is a polecat identity")
+	}
+
+	// Crew / mayor → not a polecat
+	t.Setenv("BD_ACTOR", "gastown/crew/george")
+	if stackHasSpawnedPolecat() {
+		t.Error("did not expect polecat for crew identity")
+	}
+	t.Setenv("BD_ACTOR", "testrig/mayor")
+	if stackHasSpawnedPolecat() {
+		t.Error("did not expect polecat for mayor identity")
+	}
+
+	// Neither set → not a polecat
+	t.Setenv("BD_ACTOR", "")
+	if stackHasSpawnedPolecat() {
+		t.Error("did not expect polecat with no identity env vars")
+	}
+}
+
 // TestDoneIntentLabelFormat verifies the done-intent label format matches
 // the expected pattern: done-intent:<type>:<unix-ts>
 func TestDoneIntentLabelFormat(t *testing.T) {


### PR DESCRIPTION
## Problem
Freshly-spawned polecats have repeatedly run `gt done` while the hook/assignment was still attaching (46s after boot, hook empty), which auto-closed their assigned bead via the 'no code changes (already fixed)' path — with zero commits ahead — destroying legitimate assignments even though the task was never started.

This caused multiple false completions in the Sobral rig today (hq-6ijuy): james/nora/stella/zoey each closed a hooked code bead citing the latest main commit with no work done.

## Fix
When a polecat closes a hooked **code** bead (not no_merge/review_only) with **zero commits ahead**, `gt done` now refuses to auto-close unless the polecat explicitly confirms the no-op via `--skip-verify` (the documented escape hatch). Otherwise the bead stays open and the witness/mayor is notified for review.

Adds helpers:
- `prematureNoWorkClose(isPolecat, isNoMergeTask, skipVerify)` — the guard predicate
- `stackHasSpawnedPolecat()` — polecat identity detection from `GT_POLECAT` / `BD_ACTOR`

## Tests
`TestPrematureNoWorkClose` + `TestStackHasSpawnedPolecat` (6 + 5 cases):
- fresh polecat + code bead + no skip-verify → guard ON (don't auto-close)
- with `--skip-verify` / no_merge / non-polecat → guard OFF
- polecat detection from GT_POLECAT / BD_ACTOR

`CGO_ENABLED=0 go test ./internal/cmd/ -run 'TestPrematureNoWorkClose|TestStackHasSpawnedPolecat|TestIsPolecatActor' ` passes.