### PR TITLE
fix: align generated bd and gt command ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Git-backed issue tracking system that stores work state as structured data.
 
 **Bead IDs** (also called **issue IDs**) use a prefix + 5-character alphanumeric format (e.g., `gt-abc12`, `hq-x7k2m`). The prefix indicates the item's origin or rig. Commands like `gt sling` and `gt convoy` accept these IDs to reference specific work items. The terms "bead" and "issue" are used interchangeably—beads are the underlying data format, while issues are the work items stored as beads.
 
+Use `bd` for issue CRUD in the owning rig's ledger: `bd create`, `bd show`,
+`bd update`, and `bd close`. Existing issue IDs route by prefix; use
+`bd create --repo <rig> "..."` when creating work for another registered rig.
+Use `gt` for execution: `gt sling` dispatches work, `gt convoy` tracks it, and
+`gt done` submits completed polecat work to the merge queue. The Witness handles
+polecat recovery, and the Refinery verifies and integrates queued work.
+
 ### Molecules 🧬
 
 Workflow templates that coordinate multi-step work. Formulas (TOML definitions) are instantiated as molecules with tracked steps. Two modes: root-only wisps (steps materialized at runtime, lightweight) and poured wisps (steps materialized as sub-wisps with checkpoint recovery). See [Molecules](docs/concepts/molecules.md).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Use `bd` for issue CRUD in the owning rig's ledger: `bd create`, `bd show`,
 Use `gt` for execution: `gt sling` dispatches work, `gt convoy` tracks it, and
 `gt done` submits completed polecat work to the merge queue. The Witness handles
 polecat recovery, and the Refinery verifies and integrates queued work.
+Fork-backed assignments use their GitHub PR/no-merge workflow instead of the
+local merge queue.
 
 ### Molecules 🧬
 

--- a/docs/design/directives-and-overlays.md
+++ b/docs/design/directives-and-overlays.md
@@ -34,8 +34,9 @@ formula they are running.
 ```
 
 **Injection point:** After the role template, before context files and handoff
-content. Directives carry an authority marker: "Rig Policy — overrides formula
-instructions where they conflict."
+content. Directives carry an authority marker that lets them override formula
+workflow instructions. They cannot redefine the installed command contract:
+`bd` owns issue CRUD, while `gt` owns execution and lifecycle.
 
 **Precedence:** Town and rig directives **concatenate**. If both exist, the
 combined output is `<town content>\n<rig content>`. The rig directive gets the
@@ -287,13 +288,13 @@ effect immediately on the next `gt prime`.
 - **Follows hooks override precedent:** `~/.gt/hooks-overrides/<target>.json`
 - **Extends property layers:** Rig > town > system precedence
 - **ZFC-compliant:** Go transports the content, agents interpret the instructions
-- **Only touches gt:** `bd` doesn't render formulas, so overlays are gt-only
+- **Rendered through gt:** `bd` doesn't render formulas, so `gt prime` injects overlays
 
 ### Dissonance to Manage
 
-- **Conflicting instructions:** Directive says "don't X", formula says "do X" →
-  mitigated with clear authority framing at injection ("Rig Policy — overrides
-  formula instructions where they conflict")
+- **Conflicting workflow instructions:** Directive says "don't X", formula says
+  "do X" → mitigated with clear authority framing at injection. A directive that
+  changes installed command ownership is invalid rather than an override.
 - **Unstable step IDs:** Formula steps are not a stable API; step IDs can change
   across versions → `gt doctor` warns about stale overlays
 - **Discoverability:** `gt prime --explain` shows active directives/overlays

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,6 +10,8 @@ Use `bd` for issue CRUD in the ledger that owns the work. Use `gt` for
 execution and lifecycle: `gt sling` dispatches work, `gt convoy` tracks it,
 and `gt done` submits completed polecat work to the merge queue. The Witness
 recovers stalled polecats; the Refinery verifies and integrates queued work.
+Fork-backed assignments use their GitHub PR/no-merge workflow instead of the
+local merge queue.
 
 Existing issue IDs route `bd show`, `bd update`, and `bd close` by prefix from
 any directory inside the town. `bd create` has no issue ID to route yet, so

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,20 +4,27 @@ Technical reference for Gas Town internals. Read the README first.
 
 > For directory structure details, see [architecture.md](design/architecture.md).
 
-## Beads Routing
+## Beads routing and command ownership
 
-Gas Town `gt` commands route beads work based on issue ID prefix. For direct
-`bd` commands, run from the owning repository/root so the active `.beads`
-directory matches the database you intend to touch.
+Use `bd` for issue CRUD in the ledger that owns the work. Use `gt` for
+execution and lifecycle: `gt sling` dispatches work, `gt convoy` tracks it,
+and `gt done` submits completed polecat work to the merge queue. The Witness
+recovers stalled polecats; the Refinery verifies and integrates queued work.
+
+Existing issue IDs route `bd show`, `bd update`, and `bd close` by prefix from
+any directory inside the town. `bd create` has no issue ID to route yet, so
+create from the owning rig or pass `--repo` explicitly:
 
 ```bash
-bd -C ~/gt/greenplace/mayor/rig show gp-xyz  # Greenplace rig beads
-bd -C ~/gt show hq-abc                       # Town-level beads
-bd -C ~/gt/wyvern/mayor/rig show wyv-123     # Wyvern rig beads
+bd show gp-xyz                              # Routes to Greenplace by gp- prefix
+bd update wyv-123 --status=in_progress      # Routes to Wyvern by wyv- prefix
+bd close hq-abc                             # Routes to the town ledger by hq- prefix
+bd create --repo greenplace "Fix auth"      # Creates in Greenplace's ledger
+bd -C ~/gt/wyvern/mayor/rig create "Quest"  # Explicit owning-root form
 ```
 
-**How it works**: Routes are defined in `~/gt/.beads/routes.jsonl`. Each rig's
-prefix maps to its beads location (the mayor's clone in that rig).
+Routes are defined in `~/gt/.beads/routes.jsonl`. Each rig's prefix maps to
+the canonical ledger in that rig's mayor clone.
 
 | Prefix | Routes To | Purpose |
 |--------|-----------|---------|
@@ -25,7 +32,7 @@ prefix maps to its beads location (the mayor's clone in that rig).
 | `gp-*` | `~/gt/greenplace/mayor/rig/.beads/` | Greenplace project issues |
 | `wyv-*` | `~/gt/wyvern/mayor/rig/.beads/` | Wyvern project issues |
 
-Debug routing: `BD_DEBUG_ROUTING=1 bd -C <owning-root> show <id>`
+Debug routing: `BD_DEBUG_ROUTING=1 bd show <id>`
 
 `bd --global` is not Gas Town's town database. In Beads it targets a separate
 shared-server database named `beads_global`; run `bd -C ~/gt ...` for
@@ -687,6 +694,9 @@ bd update <id> --status=in_progress
 bd close <id>
 bd dep add <child> <parent>  # child depends on parent
 ```
+
+These commands operate on the owning ledger described in
+[Beads routing and command ownership](#beads-routing-and-command-ownership).
 
 ## Patrol Agents
 

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -112,7 +112,8 @@ func roleRigContext(ctx RoleContext) (defaultBranch string, isForkRig bool, upst
 
 // outputRoleDirectives loads and emits operator-provided role directives.
 // These come from the directive file layout (town-level and/or rig-level)
-// and override formula defaults where they conflict.
+// and override formula workflow instructions where they conflict. Directives
+// cannot redefine the installed bd/gt command ownership contract.
 //
 // w and explainEnabled are injected so tests can capture output without
 // mutating os.Stdout or the primeExplain global (avoiding data races
@@ -163,13 +164,14 @@ func outputRoleDirectives(ctx RoleContext, w io.Writer, explainEnabled bool) {
 
 	fmt.Fprintln(w)
 	if hasTown && hasRig {
-		fmt.Fprintln(w, "## Town & Rig Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Town & Rig Directives (operator policy — overrides formula workflow where they conflict)")
 	} else if hasRig {
-		fmt.Fprintln(w, "## Rig Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Rig Directives (operator policy — overrides formula workflow where they conflict)")
 	} else {
-		fmt.Fprintln(w, "## Town Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Town Directives (operator policy — overrides formula workflow where they conflict)")
 	}
 	fmt.Fprintln(w)
+	fmt.Fprintf(w, "> Directives may refine workflow, but they do not change installed command ownership: `bd` handles issue CRUD; `%s` handles orchestration.\n\n", cli.Name())
 	fmt.Fprintln(w, content)
 }
 
@@ -190,6 +192,9 @@ func outputPrimeContextFallback(ctx RoleContext) {
 	default:
 		outputUnknownContext(ctx)
 	}
+
+	_, isForkRig, _ := roleRigContext(ctx)
+	fmt.Print(templates.CommandOwnership(isForkRig))
 }
 
 func outputMayorContext(ctx RoleContext) {

--- a/internal/cmd/prime_output_test.go
+++ b/internal/cmd/prime_output_test.go
@@ -56,6 +56,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 		if !strings.Contains(out, "Always be polite.") {
 			t.Errorf("expected directive content, got: %s", out)
 		}
+		if !strings.Contains(out, "do not change installed command ownership: `bd` handles issue CRUD; `gt` handles orchestration") {
+			t.Errorf("expected command ownership boundary, got: %s", out)
+		}
 	})
 
 	t.Run("rig-level directive emits rig header", func(t *testing.T) {
@@ -196,5 +199,23 @@ func TestOutputCommandQuickReferenceBootBlocksRawTmux(t *testing.T) {
 	}
 	if strings.Contains(output, "tmux send-keys~~ (unreliable)") {
 		t.Fatalf("Boot quick reference still calls raw tmux merely unreliable:\n%s", output)
+	}
+}
+
+func TestOutputPrimeContextFallbackIncludesCommandOwnership(t *testing.T) {
+	output := captureStdout(t, func() {
+		outputPrimeContextFallback(RoleContext{Role: RolePolecat, Rig: "myrig", Polecat: "toast"})
+	})
+
+	for _, want := range []string{
+		"Use `bd` for issue CRUD in the ledger that owns the work",
+		"`gt sling <bead> <rig>` dispatches work",
+		"`gt done` submits completed polecat work to the merge queue",
+		"The Witness recovers stalled polecats",
+		"The Refinery verifies and integrates queued work",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("fallback command contract missing %q:\n%s", want, output)
+		}
 	}
 }

--- a/internal/templates/polecat-CLAUDE.md
+++ b/internal/templates/polecat-CLAUDE.md
@@ -6,24 +6,24 @@
 
 ## 🚨 THE IDLE POLECAT HERESY 🚨
 
-**After completing work, you MUST run `gt done`. No exceptions.**
+**After completing work, you MUST follow the completion protocol rendered by
+`gt prime`. No exceptions.**
 
 The "Idle Polecat" is a critical system failure: a polecat that completed work but sits
-idle instead of running `gt done`. **There is no approval step.**
+idle instead of completing its assigned landing path. **There is no approval step.**
 
-**If you have finished your implementation work, your ONLY next action is:**
-```bash
-gt done
-```
+- Standard rigs finish with `gt done`, which submits work to the merge queue.
+- Fork-backed rigs push to the fork, create or update the upstream PR, and use
+  `gt done` only for the no-merge/report cleanup path specified by the assignment.
 
 Do NOT:
 - Sit idle waiting for more work (there is no more work — you're done)
-- Say "work complete" without running `gt done`
-- Try `gt unsling` or other commands (only `gt done` signals completion)
-- Wait for confirmation or approval (just run `gt done`)
+- Say "work complete" without completing the rendered landing path
+- Try `gt unsling` or invent another completion command
+- Wait for confirmation or approval
 
-**Your session should NEVER end without running `gt done`.** If `gt done` fails,
-escalate to Witness — but you must attempt it.
+**Your session should NEVER end before the rendered completion path finishes.**
+If cleanup fails, escalate to Witness with the exact failure.
 
 ---
 
@@ -66,15 +66,16 @@ formula checklist (from `mol-polecat-work`, shown inline at prime time) and sign
 
 1. Receive work via your hook (formula checklist + issue)
 2. Work through formula steps in order (shown inline at prime time)
-3. Complete and self-clean (`gt done`) — you exit AND nuke yourself
-4. Refinery merges your work from the MQ
+3. Complete the landing and cleanup path rendered by `gt prime`
+4. Standard-rig work enters the Refinery MQ; fork-backed work enters the upstream PR workflow
 
-**Self-cleaning model:** `gt done` pushes your branch, submits to MQ, nukes sandbox, exits session.
+**Self-cleaning model:** standard rigs use `gt done`; fork-backed rigs use the
+assignment's PR/no-merge cleanup path.
 
 **Three operating states:**
 - **Working** — actively doing assigned work (normal)
 - **Stalled** — session stopped mid-work (failure)
-- **Zombie** — `gt done` failed during cleanup (failure)
+- **Zombie** — the assigned cleanup path failed (failure)
 
 Done means gone. Run `gt prime` to see your formula steps.
 
@@ -94,8 +95,9 @@ Your work is defined by the attached formula. Steps are shown inline at prime ti
 ```bash
 gt hook                  # What's on my hook?
 gt prime                 # Shows formula checklist
-# Work through steps in order, then:
-gt done                  # Submit and self-clean
+# Work through steps in order, then complete the protocol rendered above.
+# Standard rig: gt done
+# Fork-backed rig: push fork branch, create/update upstream PR, run specified cleanup
 ```
 
 ---
@@ -108,7 +110,7 @@ Your work is driven by **formulas** — structured workflow templates with step-
 1. A formula (e.g., `mol-polecat-work`) is attached to your hook bead when dispatched
 2. `gt prime` renders the formula steps inline — you see the full checklist
 3. Work through steps in order. Each step has exit criteria.
-4. `gt done` submits your work and exits
+4. Complete the rendered standard-rig MQ or fork-backed PR/no-merge path
 
 **You do NOT need to manually find or run formulas.** They are attached to your hook
 bead and rendered automatically. This reference exists to eliminate discovery overhead.
@@ -154,19 +156,19 @@ gt dolt status                     # Check server health + latency
 2. Run: `gt prime`
 3. Check hook: `gt hook`
 4. If formula attached, steps are shown inline by `gt prime`
-5. Work through the checklist, then `gt done`
+5. Work through the checklist, then complete the rendered landing path
 
-**If NO work on hook and NO mail:** run `gt done` immediately.
+**If NO work is on your hook and NO mail explains why:** escalate to Witness.
 
 **If your assigned bead has nothing to implement** (already done, can't reproduce, not applicable):
 ```bash
 bd close <id> --reason="no-changes: <brief explanation>"
-gt done
+# Then run the no-changes cleanup command rendered by gt prime.
 ```
 **DO NOT** exit without closing the bead. Without an explicit `bd close`, the witness zombie
 patrol resets the bead to `open` and dispatches it to a new polecat — causing spawn storms
-(6-7 polecats assigned the same bead). Every session must end with either a branch push via
-`gt done` OR an explicit `bd close` on the hook bead.
+(6-7 polecats assigned the same bead). Every session must end with either the rendered
+landing path complete or an explicit `bd close` followed by the rendered cleanup path.
 
 ---
 
@@ -203,7 +205,7 @@ bd create --title "..."         # File discovered work (don't fix it yourself)
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Signal work complete | `gt done` | ~~gt unsling~~ or sitting idle |
+| Signal work complete | Completion protocol from `gt prime` | ~~gt unsling~~ or sitting idle |
 | Message another agent | `gt nudge <target> "msg"` | ~~tmux send-keys~~ (drops Enter) |
 | See formula steps | `gt prime` (inline checklist) | ~~bd mol current~~ (steps not materialized) |
 | File discovered work | `bd create "title"` | Fixing it yourself |
@@ -240,7 +242,7 @@ When your work is done, follow this checklist — **step 4 is REQUIRED**:
        - Go projects:  go test ./... && go vet ./...
 [ ] 2. Stage changes:     git add <files>
 [ ] 3. Commit changes:    git commit -m "msg (issue-id)"
-[ ] 4. Self-clean:        gt done   ← MANDATORY FINAL STEP
+[ ] 4. Land and clean:    follow the completion protocol from gt prime
 ```
 
 **Quality gates are not optional.** Worktrees may not trigger pre-commit hooks,
@@ -251,25 +253,31 @@ the project's definition of done. Many projects require a specific test harness
 (not just `go test` or `dotnet test`). If AGENTS.md exists, its "Core rule"
 section defines what "done" means for this project.
 
-The `gt done` command pushes your branch, creates an MR bead in the MQ, nukes
-your sandbox, and exits your session. **You are gone after `gt done`.**
+For standard rigs, `gt done` pushes your branch, creates an MR bead in the MQ,
+cleans the sandbox, and exits your session. Fork-backed rigs instead push the
+work branch to the fork, create or update the upstream PR, and use `gt done`
+only when the assignment's no-merge/report cleanup path calls for it.
 
 ### Do NOT Push Directly to Main
 
-**You are a polecat. You NEVER push directly to main.**
+**You are a polecat. You NEVER push directly to the protected branch.**
 
-Your work goes through the merge queue:
+Standard-rig work goes through the merge queue:
 1. You work on your branch
 2. `gt done` pushes your branch and submits an MR to the merge queue
 3. Refinery merges to main after Witness verification
 
-**Do NOT create GitHub PRs either.** The merge queue handles everything.
+Fork-backed work follows the assignment's GitHub PR/no-merge workflow instead:
+push the work branch to the fork remote and create or update a PR against the
+upstream protected branch. Never push directly to that upstream branch.
 
 ### The Landing Rule
 
-> **Work is NOT landed until it's in the Refinery MQ.**
+> **Work is NOT handed off until it reaches the integration surface selected by
+> the rendered completion protocol.**
 
-**Local branch → `gt done` → MR in queue → Refinery merges → LANDED**
+- Standard rig: **local branch → `gt done` → MR in queue → Refinery**
+- Fork-backed rig: **local branch → fork remote → upstream PR → maintainer**
 
 ---
 
@@ -327,7 +335,7 @@ See `docs/dolt-health-guide.md` for the full picture.
 
 ## Do NOT
 
-- Push to main (Refinery does this)
+- Push directly to a protected branch
 - Work on unrelated issues (file beads instead)
 - Skip tests or self-review
 - Guess when confused (ask Witness)
@@ -335,9 +343,10 @@ See `docs/dolt-health-guide.md` for the full picture.
 
 ---
 
-## 🚨 FINAL REMINDER: RUN `gt done` 🚨
+## 🚨 FINAL REMINDER: COMPLETE THE RENDERED WORKFLOW 🚨
 
-**Before your session ends, you MUST run `gt done`.**
+**Before your session ends, complete the standard-rig MQ or fork-backed
+PR/no-merge protocol rendered by `gt prime`.**
 
 ---
 

--- a/internal/templates/polecat-CLAUDE.md
+++ b/internal/templates/polecat-CLAUDE.md
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `gt prime` after compaction, clear, or new session
 
+{{command_contract}}
+
 ## 🚨 THE IDLE POLECAT HERESY 🚨
 
 **After completing work, you MUST run `gt done`. No exceptions.**

--- a/internal/templates/roles/boot.md.tmpl
+++ b/internal/templates/roles/boot.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## Your Role: BOOT (Deacon Watchdog)
 
 You are **Boot** - the daemon's watchdog for Deacon triage. You are spawned fresh

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -88,7 +88,7 @@ The overseer uses crew for two main patterns:
    Alongside the Mayor, crew are the primary agents that dispatch polecat work.
    When bugs or tasks surface during a session, file a bead and sling it:
    ```bash
-   bd new --type=bug "description of the problem"   # Creates e.g. gt-h8x
+   bd create --type=bug "description of the problem"   # Creates e.g. gt-h8x
    {{ cmd }} sling gt-h8x {{ .RigName }}             # Spawns a polecat to fix it
    ```
    The overseer also farms tasks to crew via `{{ cmd }} nudge` — a lightweight
@@ -114,7 +114,7 @@ auto-execute on handoff.
 ### Beads: Persistent by Default
 
 Most beads you file are **persistent** (durable). Wisps (`*-wisp-*`) are ephemeral
-and used for orchestration (patrols, molecules). When you `bd new` a bug or task,
+and used for orchestration (patrols, molecules). When you `bd create` a bug or task,
 it creates a persistent bead with an adaptive-hash ID (e.g., `gt-h8x`). Let the
 system choose the ID — don't force prefixes.
 
@@ -508,7 +508,7 @@ succeeds. **YOU must push — NEVER say "ready to push when you are!"**
 ## Desire Paths: Improving the Tooling
 
 When a command fails but your guess felt reasonable, file a bead with `desire-path` label:
-`bd new -t task "Add gt mail hook alias" -l desire-path`
+`bd create -t task "Add gt mail hook alias" -l desire-path`
 
 See `{{ .TownRoot }}/docs/AGENT-ERGONOMICS.md` for the philosophy.
 

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## 🚫 The Approval Fallacy
 
 **There is no approval step.** When your work is done, you act — you don't wait.

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## ⚡ Theory of Operation: The Propulsion Principle
 
 Gas Town is a steam engine. You are the flywheel.

--- a/internal/templates/roles/dog.md.tmpl
+++ b/internal/templates/roles/dog.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## Your Role: DOG (Infrastructure Worker)
 
 You are a **Dog** - a town-level infrastructure worker. Dogs are dispatched by the

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## ⚡ Theory of Operation: The Propulsion Principle
 
 Gas Town is a steam engine. You are the main drive shaft.

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## Completion Protocol
 
 {{ if .IsForkRig -}}

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -245,7 +245,7 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 
 ### Desire Paths
 When a command fails but your guess felt reasonable, file a bead with `desire-path` label:
-`bd new -t task "Add gt mail hook alias" -l desire-path`
+`bd create -t task "Add gt mail hook alias" -l desire-path`
 
 See `{{ .TownRoot }}/docs/AGENT-ERGONOMICS.md` for the philosophy.
 

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## ⚡ Theory of Operation: The Propulsion Principle
 
 Gas Town is a steam engine. You are the gearbox.

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -2,6 +2,8 @@
 
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
+{{ commandOwnership .IsForkRig }}
+
 ## ⚡ Theory of Operation: The Propulsion Principle
 
 Gas Town is a steam engine. You are the pressure gauge.

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -34,9 +34,34 @@ func CmdName() string {
 	return cmdName
 }
 
+// CommandOwnership returns the canonical split between Beads issue CRUD and
+// Gas Town execution lifecycle commands. Every generated agent context uses
+// this text so role-specific instructions cannot drift onto invented commands.
+func CommandOwnership(isForkRig bool) string {
+	c := CmdName()
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "## Command ownership: `bd` and `%s`\n\n", c)
+	b.WriteString("Use `bd` for issue CRUD in the ledger that owns the work:\n\n")
+	b.WriteString("- `bd create` creates issues. Create in the owning rig, or use `bd create --repo <rig> \"...\"` to target another registered rig.\n")
+	b.WriteString("- `bd show <id>`, `bd update <id>`, and `bd close <id>` read or change existing issues. The ID prefix routes each command through the town's `.beads/routes.jsonl`.\n")
+	fmt.Fprintf(&b, "- Issue creation stays on `bd`; `%s` has no issue-creation command.\n\n", c)
+	fmt.Fprintf(&b, "Use `%s` for execution and lifecycle:\n\n", c)
+	fmt.Fprintf(&b, "- `%s sling <bead> <rig>` dispatches work, and `%s convoy` tracks it.\n", c, c)
+	if isForkRig {
+		b.WriteString("- This fork-backed rig uses the assignment's GitHub PR/no-merge workflow for upstream changes; do not send them to the local merge queue.\n")
+	} else {
+		fmt.Fprintf(&b, "- `%s done` submits completed polecat work to the merge queue. Fork-backed assignments use their GitHub PR/no-merge workflow instead.\n", c)
+	}
+	b.WriteString("- The Witness recovers stalled polecats. The Refinery verifies and integrates queued work.\n")
+
+	return b.String()
+}
+
 // templateFuncs provides custom functions for templates.
 var templateFuncs = template.FuncMap{
-	"cmd": CmdName, // {{ cmd }} returns the CLI command name
+	"cmd":              CmdName,          // {{ cmd }} returns the CLI command name
+	"commandOwnership": CommandOwnership, // {{ commandOwnership .IsForkRig }} emits the CLI contract
 }
 
 //go:embed roles/*.md.tmpl messages/*.md.tmpl
@@ -240,6 +265,7 @@ func CreatePolecatCLAUDEmd(worktreePath, rigName, polecatName string) (bool, err
 
 	// Render the polecat template with rig/name substitutions
 	content := polecatCLAUDEmd
+	content = strings.ReplaceAll(content, "{{command_contract}}", CommandOwnership(false))
 	content = strings.ReplaceAll(content, "{{rig}}", rigName)
 	content = strings.ReplaceAll(content, "{{name}}", polecatName)
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -129,6 +129,9 @@ func TestRenderRole_CommandOwnership(t *testing.T) {
 					t.Fatalf("rendered %s command contract missing %q:\n%s", role, want, output)
 				}
 			}
+			if strings.Contains(output, "bd new") {
+				t.Fatalf("rendered %s uses legacy bd new instead of canonical bd create:\n%s", role, output)
+			}
 		})
 	}
 }
@@ -737,15 +740,27 @@ func TestCreatePolecatCLAUDEmd(t *testing.T) {
 		t.Error("CLAUDE.md does not contain polecat name 'furiosa'")
 	}
 
-	// Verify critical gt done instructions are present
+	// Verify both supported completion paths are present. This provisioned file
+	// is shared by standard and fork-backed rigs; gt prime selects the active one.
 	if !strings.Contains(content, "gt done") {
 		t.Fatal("CLAUDE.md does not contain 'gt done' — polecats will not know to call it")
+	}
+	if !strings.Contains(content, "Fork-backed rigs instead push the") {
+		t.Fatal("CLAUDE.md does not explain the fork-backed PR/no-merge path")
 	}
 	if !strings.Contains(content, "IDLE POLECAT HERESY") {
 		t.Error("CLAUDE.md missing 'IDLE POLECAT HERESY' warning section")
 	}
-	if !strings.Contains(content, "MANDATORY FINAL STEP") {
-		t.Error("CLAUDE.md missing completion protocol with MANDATORY FINAL STEP")
+	if !strings.Contains(content, "follow the completion protocol from gt prime") {
+		t.Error("CLAUDE.md missing the rendered-workflow completion step")
+	}
+	for _, forbidden := range []string{
+		"After completing work, you MUST run `gt done`. No exceptions.",
+		"Do NOT create GitHub PRs either.",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("CLAUDE.md contains fork-unsafe completion guidance %q", forbidden)
+		}
 	}
 	for _, want := range []string{
 		"Use `bd` for issue CRUD in the ledger that owns the work",

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -88,6 +88,67 @@ func TestRenderRole_Polecat(t *testing.T) {
 	}
 }
 
+func TestRenderRole_CommandOwnership(t *testing.T) {
+	tmpl, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	data := RoleData{
+		RigName:       "myrig",
+		TownRoot:      "/test/town",
+		TownName:      "town",
+		WorkDir:       "/test/town/myrig/polecats/TestCat",
+		DefaultBranch: "main",
+		Polecat:       "TestCat",
+		DogName:       "boot",
+		MayorSession:  "gt-town-mayor",
+		DeaconSession: "gt-town-deacon",
+	}
+
+	for _, role := range []string{"mayor", "crew", "polecat", "witness", "refinery", "deacon", "dog", "boot"} {
+		t.Run(role, func(t *testing.T) {
+			data.Role = role
+			output, renderErr := tmpl.RenderRole(role, data)
+			if renderErr != nil {
+				t.Fatalf("RenderRole(%q) error = %v", role, renderErr)
+			}
+
+			for _, want := range []string{
+				"Use `bd` for issue CRUD in the ledger that owns the work",
+				"`bd create --repo <rig>",
+				"`bd show <id>`, `bd update <id>`, and `bd close <id>`",
+				"ID prefix routes each command",
+				"`gt sling <bead> <rig>` dispatches work",
+				"`gt convoy` tracks it",
+				"`gt done` submits completed polecat work to the merge queue",
+				"The Witness recovers stalled polecats",
+				"The Refinery verifies and integrates queued work",
+			} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("rendered %s command contract missing %q:\n%s", role, want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandOwnership_ForkRigUsesPRWorkflow(t *testing.T) {
+	output := CommandOwnership(true)
+
+	if !strings.Contains(output, "fork-backed rig uses the assignment's GitHub PR/no-merge workflow") {
+		t.Fatalf("fork command contract missing PR/no-merge workflow:\n%s", output)
+	}
+	if strings.Contains(output, "`gt done` submits") {
+		t.Fatalf("fork command contract directs upstream work to the merge queue:\n%s", output)
+	}
+	for _, invented := range []string{"`gt create`", "`gt issue create`"} {
+		if strings.Contains(output, invented) {
+			t.Fatalf("command contract documents nonexistent command %s:\n%s", invented, output)
+		}
+	}
+}
+
 func TestRenderRole_PolecatForkRigUsesPRWorkflow(t *testing.T) {
 	tmpl, err := New()
 	if err != nil {
@@ -664,6 +725,9 @@ func TestCreatePolecatCLAUDEmd(t *testing.T) {
 	if strings.Contains(content, "{{name}}") {
 		t.Error("CLAUDE.md still contains {{name}} placeholder")
 	}
+	if strings.Contains(content, "{{command_contract}}") {
+		t.Error("CLAUDE.md still contains {{command_contract}} placeholder")
+	}
 
 	// Verify substituted values are present
 	if !strings.Contains(content, "greenplace") {
@@ -682,6 +746,16 @@ func TestCreatePolecatCLAUDEmd(t *testing.T) {
 	}
 	if !strings.Contains(content, "MANDATORY FINAL STEP") {
 		t.Error("CLAUDE.md missing completion protocol with MANDATORY FINAL STEP")
+	}
+	for _, want := range []string{
+		"Use `bd` for issue CRUD in the ledger that owns the work",
+		"`gt sling <bead> <rig>` dispatches work",
+		"The Witness recovers stalled polecats",
+		"The Refinery verifies and integrates queued work",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("CLAUDE.md command contract missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- centralize the canonical command contract: `bd` owns issue CRUD in the owning ledger, while `gt` owns dispatch and lifecycle
- render that contract in every role, the prime fallback, and provisioned polecat context, including the fork-backed PR/no-merge exception
- narrow directive authority to formula workflow and align README/reference guidance
- add role, fork, fallback, and provisioning regression coverage

## Validation

- `go test ./internal/templates -count=1` (pass)
- focused `internal/cmd` prime directive/fallback tests (pass)
- `make build` (pass)
- built `./gt prime --dry-run` renders the expected fork-backed command contract (pass)
- generated-content drift guards and `git diff --check upstream/main...HEAD` (pass)

## Local full-suite blocker

`make test` is not green in this operator environment. It first fails the stuck-agent-dog shell harness because inherited `BASH_ENV` prepends the installed `gt` ahead of test fakes (tracked as `gtf-dvf`; normal 60/93, controlled `env -u BASH_ENV` 93/93). The sanitized full run then reaches unrelated local Dolt/tmux state failures in `internal/doctor`, `internal/doltserver`, `internal/refinery`, and `internal/tmux`. Task-owned packages pass; this PR remains draft pending CI and review.
