### PR TITLE
test: isolate doctor and Dolt server fixtures

### DIFF
--- a/internal/doctor/migration_check.go
+++ b/internal/doctor/migration_check.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 var verifyExpectedDatabasesAtConfig = doltserver.VerifyExpectedDatabasesAtConfig
@@ -479,10 +479,10 @@ func (c *DoltServerReachableCheck) getServerAddr(beadsDir string, townRoot strin
 		host = "127.0.0.1"
 	}
 	if port == 0 {
-		// Use the same port resolution as Start/Stop/Status: config.yaml takes
-		// precedence over GT_DOLT_PORT env var, which takes precedence over
-		// daemon.json, which falls back to DefaultPort (3307). This ensures
-		// the doctor probes the same port that the server actually uses.
+		// Use the same port resolution as Start/Stop/Status: GT_DOLT_PORT takes
+		// precedence over config.yaml, which takes precedence over daemon.json
+		// and finally DefaultPort (3307). This ensures the doctor probes the same
+		// port that the server actually uses.
 		port = doltserver.DefaultConfig(townRoot).Port
 	}
 	if port == 0 {

--- a/internal/doctor/migration_check_test.go
+++ b/internal/doctor/migration_check_test.go
@@ -188,6 +188,10 @@ func TestGetServerAddr_NoMetadata(t *testing.T) {
 }
 
 func TestGetServerAddr_UsesConfigYAMLPort(t *testing.T) {
+	t.Setenv("GT_DOLT_HOST", "")
+	t.Setenv("GT_DOLT_PORT", "")
+	t.Setenv("GT_DOLT_IGNORE_CONFIG", "")
+
 	check := NewDoltServerReachableCheck()
 	townRoot := t.TempDir()
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -2355,27 +2355,60 @@ func TestIsDoltRetryableError_CatalogRace(t *testing.T) {
 	}
 }
 
+func setupNoServerDoltConfig(t *testing.T, townRoot string) *Config {
+	t.Helper()
+
+	// The parent Gas Town process normally exports its live Dolt endpoint.
+	// Clear those overrides so this fixture's managed config is authoritative.
+	t.Setenv("GT_DOLT_HOST", "")
+	t.Setenv("GT_DOLT_PORT", "")
+	t.Setenv("GT_DOLT_IGNORE_CONFIG", "")
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate isolated Dolt port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release isolated Dolt port: %v", err)
+	}
+
+	config := DefaultConfig(townRoot)
+	config.Host = "127.0.0.1"
+	config.Port = port
+	if err := os.MkdirAll(config.DataDir, 0755); err != nil {
+		t.Fatalf("create isolated Dolt data dir: %v", err)
+	}
+	if err := writeServerConfig(config, filepath.Join(config.DataDir, "config.yaml")); err != nil {
+		t.Fatalf("write isolated Dolt config: %v", err)
+	}
+
+	resolved := DefaultConfig(townRoot)
+	if resolved.HostPort() != config.HostPort() {
+		t.Fatalf("isolated Dolt endpoint = %q, want %q", resolved.HostPort(), config.HostPort())
+	}
+	if running, _, err := IsRunning(townRoot); err != nil {
+		t.Fatalf("check isolated Dolt endpoint: %v", err)
+	} else if running {
+		t.Fatalf("isolated Dolt endpoint %s unexpectedly has a server", resolved.HostPort())
+	}
+
+	return resolved
+}
+
 func TestWaitForCatalog_NoServer(t *testing.T) {
-	// When no Dolt server is reachable, waitForCatalog should fail.
-	// Use port 13399 (unlikely to be in use) to ensure no server responds.
 	townRoot := t.TempDir()
-	dataDir := filepath.Join(townRoot, ".dolt-data")
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	// Write a config.yaml with an unreachable port so buildServerSQLCmd
-	// tries to connect to a port that nobody is listening on.
-	configContent := "listener:\n  port: 13399\ndata_dir: " + dataDir + "\n"
-	if err := os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte(configContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+	config := setupNoServerDoltConfig(t, townRoot)
+
 	err := waitForCatalog(townRoot, "testdb")
 	if err == nil {
 		t.Fatal("expected error when no server is running")
 	}
-	// Connection refused or similar non-retryable error
 	if !strings.Contains(err.Error(), "non-retryable") {
 		t.Errorf("expected non-retryable error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(config.Port)) {
+		t.Errorf("expected error from isolated port %d, got: %v", config.Port, err)
 	}
 }
 
@@ -2913,16 +2946,7 @@ func TestFindBrokenWorkspaces_SqliteNotBroken(t *testing.T) {
 
 func TestFindBrokenWorkspaces_MultipleRigs(t *testing.T) {
 	townRoot := t.TempDir()
-
-	// Isolate from real Dolt server on default port
-	doltDataDir := filepath.Join(townRoot, ".dolt-data")
-	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"),
-		[]byte("listener:\n  port: 13307\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	config := setupNoServerDoltConfig(t, townRoot)
 
 	// Set up rigs.json with two rigs
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
@@ -2952,11 +2976,12 @@ func TestFindBrokenWorkspaces_MultipleRigs(t *testing.T) {
 		[]byte(`{"backend":"dolt","dolt_mode":"server","dolt_database":"rig-b"}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(townRoot, ".dolt-data", "rig-b", ".dolt"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	setupDoltDB(t, config.DataDir, "rig-b")
 
-	broken, _ := FindBrokenWorkspaces(townRoot)
+	broken, warning := FindBrokenWorkspaces(townRoot)
+	if warning != "" {
+		t.Fatalf("unexpected live-catalog warning: %s", warning)
+	}
 	if len(broken) != 1 {
 		t.Fatalf("expected 1 broken workspace (rig-a only), got %d", len(broken))
 	}


### PR DESCRIPTION
## Summary

Make the doctor and Doltserver no-server tests independent of a running Gas Town Dolt server and its exported endpoint environment.

## Related Issue

Bead `gtf-790`

## Changes

- Clear ambient `GT_DOLT_HOST`, `GT_DOLT_PORT`, and `GT_DOLT_IGNORE_CONFIG` in the doctor config-port fixture.
- Add a Doltserver fixture that allocates an isolated port, writes managed config through `writeServerConfig`, and proves no server is reachable there.
- Build the healthy rig catalog with the existing `setupDoltDB` owner and fail on any unexpected live-catalog warning.
- Correct the nearby endpoint-precedence comment to match `ResolveDoltPort`.

## Testing

- [ ] Unit tests pass (`go test ./...`) — full repository matrix is delegated to PR CI.
- [x] `go test -race -short -timeout=10m ./internal/doctor ./internal/doltserver -count=1`
- [x] Targeted tests pass with hostile ambient endpoint/config-ignore values while the town Dolt server remains live on port 3307.
- [x] `golangci-lint run --timeout=5m ./internal/doctor ./internal/doltserver`
- [x] `go vet ./internal/doctor ./internal/doltserver`

## Checklist

- [x] Code follows project style.
- [x] Documentation updated where behavior comments were stale.
- [x] No breaking changes.
