### PR TITLE
fix: restore canonical adopted rig topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Adopted rig git topology** — `gt rig add --adopt`, `gt doctor --fix`, and
+  Refinery startup now share one canonical recovery path for a missing
+  `.repo.git` and `refinery/rig`. Recovery preserves existing Mayor and polecat
+  worktrees, restores the configured integration branch and origin refspec, and
+  fails explicitly instead of running Refinery from `mayor/rig`.
+
 ## [1.2.1] - 2026-06-06
 
 ### Fixed

--- a/docs/guides/local-rig-bootstrap.md
+++ b/docs/guides/local-rig-bootstrap.md
@@ -1,10 +1,14 @@
 # Local Rig Bootstrap
 
-For a NightRider-style local setup, prefer a clean bootstrap over `gt rig add --adopt`.
+For a NightRider-style local setup, use a clean bootstrap when no Gas Town rig
+layout exists yet. Use `gt rig add --adopt` when the directory already contains
+Mayor or polecat work that must remain in place.
 
-`--adopt` is meant for registering an already-assembled rig directory. It trusts the
-existing shape, which makes it a poor fit for manually assembled local rigs where
-`.repo.git`, worktrees, and metadata may already be inconsistent.
+Adoption restores the canonical shared `.repo.git` and dedicated `refinery/rig`
+worktree when they are missing. It reads the rig's configured repository and
+default branch, and it does not rewrite or re-parent existing Mayor and polecat
+worktrees. A conflicting noncanonical refinery directory is reported as an error
+instead of being replaced or used as a fallback.
 
 Use the bootstrap script instead:
 
@@ -35,5 +39,7 @@ What this does:
 
 When to still use `--adopt`:
 
-- You already have a real Gas Town rig directory that was created elsewhere and you
-  only need to register it in a town.
+- You already have a Gas Town rig directory that was created elsewhere and only need
+  to register it in a town.
+- The rig has active Mayor or polecat work, but `.repo.git` or `refinery/rig` is
+  missing and must be restored without touching that work.

--- a/internal/doctor/bare_repo_exists_check_test.go
+++ b/internal/doctor/bare_repo_exists_check_test.go
@@ -95,8 +95,8 @@ func TestBareRepoExistsCheck_MissingBareRepo(t *testing.T) {
 	if result.Status != StatusError {
 		t.Errorf("expected StatusError when .repo.git is missing, got %v", result.Status)
 	}
-	if !strings.Contains(result.Message, "missing .repo.git") {
-		t.Errorf("expected message about missing .repo.git, got %q", result.Message)
+	if !strings.Contains(result.Message, "Canonical shared bare repo is missing") {
+		t.Errorf("expected canonical missing-repo message, got %q", result.Message)
 	}
 	if len(result.Details) < 2 {
 		t.Errorf("expected at least 2 details (bare repo path + worktree), got %d", len(result.Details))
@@ -137,8 +137,9 @@ func TestBareRepoExistsCheck_MultipleWorktreesMissing(t *testing.T) {
 	if result.Status != StatusError {
 		t.Errorf("expected StatusError, got %v", result.Status)
 	}
-	if !strings.Contains(result.Message, "2 worktree") {
-		t.Errorf("expected message about 2 worktrees, got %q", result.Message)
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "refinery/rig") || !strings.Contains(details, filepath.Join("polecats", "worker1", rigName)) {
+		t.Errorf("expected both broken worktrees in details, got %q", details)
 	}
 }
 

--- a/internal/doctor/bare_repo_exists_check_test.go
+++ b/internal/doctor/bare_repo_exists_check_test.go
@@ -49,7 +49,7 @@ func TestBareRepoExistsCheck_BareRepoExists(t *testing.T) {
 	}
 }
 
-func TestBareRepoExistsCheck_NoBareRepoNoWorktrees(t *testing.T) {
+func TestBareRepoExistsCheck_NoBareRepoNoLinkedWorktrees(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 	rigDir := filepath.Join(tmpDir, rigName)
@@ -64,8 +64,11 @@ func TestBareRepoExistsCheck_NoBareRepoNoWorktrees(t *testing.T) {
 	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
 
 	result := check.Run(ctx)
-	if result.Status != StatusOK {
-		t.Errorf("expected StatusOK when no worktrees depend on .repo.git, got %v", result.Status)
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError when canonical .repo.git is missing, got %v", result.Status)
+	}
+	if !strings.Contains(result.Message, "Canonical shared bare repo is missing") {
+		t.Errorf("expected canonical missing-repo message, got %q", result.Message)
 	}
 }
 
@@ -165,7 +168,7 @@ func TestBareRepoExistsCheck_RelativeGitdir(t *testing.T) {
 	}
 }
 
-func TestBareRepoExistsCheck_NonRepoGitWorktree(t *testing.T) {
+func TestBareRepoExistsCheck_NonRepoGitWorktreeStillRequiresCanonicalBareRepo(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 	rigDir := filepath.Join(tmpDir, rigName)
@@ -184,10 +187,10 @@ func TestBareRepoExistsCheck_NonRepoGitWorktree(t *testing.T) {
 	check := NewBareRepoExistsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
 
-	// Worktree doesn't reference .repo.git, so this should pass
+	// A foreign worktree reference does not make the missing canonical repo valid.
 	result := check.Run(ctx)
-	if result.Status != StatusOK {
-		t.Errorf("expected StatusOK when worktrees don't reference .repo.git, got %v", result.Status)
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError when canonical .repo.git is missing, got %v", result.Status)
 	}
 }
 

--- a/internal/doctor/canonical_topology_check_test.go
+++ b/internal/doctor/canonical_topology_check_test.go
@@ -1,0 +1,116 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/git"
+	rigpkg "github.com/steveyegge/gastown/internal/rig"
+)
+
+func TestBareRepoExistsCheckFixBootstrapsAdoptedRigWithoutLinkedWorktrees(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "adopted"
+	rigPath := filepath.Join(townRoot, rigName)
+	remote := createDoctorTopologySourceRepo(t)
+	writeDoctorTopologyConfig(t, rigPath, rigName, remote)
+
+	check := NewBareRepoExistsCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: rigName}
+	if result := check.Run(ctx); result.Status != StatusError {
+		t.Fatalf("Run status = %v, want error: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if result := check.Run(ctx); result.Status != StatusOK {
+		t.Fatalf("Run after Fix status = %v, want OK: %s (%v)", result.Status, result.Message, result.Details)
+	}
+
+	barePath := filepath.Join(rigPath, ".repo.git")
+	if err := git.NewGitWithDir(barePath, "").ValidateBareRepository(); err != nil {
+		t.Fatalf("restored bare repo invalid: %v", err)
+	}
+	refineryPath := filepath.Join(rigPath, "refinery", "rig")
+	if got, err := git.NewGit(refineryPath).CurrentBranch(); err != nil || got != "main" {
+		t.Fatalf("restored refinery branch = %q, %v; want main", got, err)
+	}
+}
+
+func TestRefineryExistsCheckFixRestoresMissingDirectoryAndWorktree(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "repair"
+	rigPath := filepath.Join(townRoot, rigName)
+	remote := createDoctorTopologySourceRepo(t)
+	writeDoctorTopologyConfig(t, rigPath, rigName, remote)
+
+	barePath := filepath.Join(rigPath, ".repo.git")
+	if err := git.NewGit(rigPath).CloneBareWithBranch(remote, barePath, "main"); err != nil {
+		t.Fatalf("create canonical bare repo: %v", err)
+	}
+
+	check := NewRefineryExistsCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: rigName}
+	if result := check.Run(ctx); result.Status != StatusWarning {
+		t.Fatalf("Run status = %v, want warning: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if result := check.Run(ctx); result.Status != StatusOK {
+		t.Fatalf("Run after Fix status = %v, want OK: %s (%v)", result.Status, result.Message, result.Details)
+	}
+	if info, err := os.Stat(filepath.Join(rigPath, "refinery", "rig", ".git")); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("refinery worktree link invalid: info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, "refinery", "mail", "inbox.jsonl")); err != nil {
+		t.Fatalf("refinery inbox was not restored: %v", err)
+	}
+}
+
+func createDoctorTopologySourceRepo(t *testing.T) string {
+	t.Helper()
+	repoPath := filepath.Join(t.TempDir(), "source")
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		t.Fatalf("create source repo: %v", err)
+	}
+	commands := [][]string{
+		{"init", "--initial-branch=main"},
+		{"config", "user.email", "doctor@example.com"},
+		{"config", "user.name", "Doctor Test"},
+		{"commit", "--allow-empty", "-m", "initial"},
+	}
+	for _, args := range commands {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return repoPath
+}
+
+func writeDoctorTopologyConfig(t *testing.T, rigPath, rigName, remote string) {
+	t.Helper()
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("create rig path: %v", err)
+	}
+	data, err := json.Marshal(&rigpkg.RigConfig{
+		Type:          "rig",
+		Version:       rigpkg.CurrentRigConfigVersion,
+		Name:          rigName,
+		GitURL:        remote,
+		DefaultBranch: "main",
+		CreatedAt:     time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("marshal rig config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), data, 0644); err != nil {
+		t.Fatalf("write rig config: %v", err)
+	}
+}

--- a/internal/doctor/migration_check_test.go
+++ b/internal/doctor/migration_check_test.go
@@ -188,6 +188,9 @@ func TestGetServerAddr_NoMetadata(t *testing.T) {
 }
 
 func TestGetServerAddr_UsesConfigYAMLPort(t *testing.T) {
+	// This case exercises durable config resolution, so isolate it from the
+	// active Gas Town session's explicit operator override.
+	t.Setenv("GT_DOLT_PORT", "")
 	check := NewDoltServerReachableCheck()
 	townRoot := t.TempDir()
 

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
+	rigpkg "github.com/steveyegge/gastown/internal/rig"
 )
 
 // RigIsGitRepoCheck verifies the rig has a valid mayor/rig git clone.
@@ -515,23 +516,20 @@ func (c *RefineryExistsCheck) Run(ctx *CheckContext) *CheckResult {
 	c.needsClone = false
 	c.needsMail = false
 
-	// Check refinery/ directory
+	// Each required path is checked independently so a completely missing
+	// refinery directory repairs the mail directory and worktree in one pass.
 	if _, err := os.Stat(refineryDir); os.IsNotExist(err) {
 		issues = append(issues, "Missing: refinery/")
 		c.needsCreate = true
-	} else {
-		// Check refinery/rig/ clone
-		rigGit := filepath.Join(rigClone, ".git")
-		if _, err := os.Stat(rigGit); os.IsNotExist(err) {
-			issues = append(issues, "Missing: refinery/rig/ (git clone)")
-			c.needsClone = true
-		}
+	}
 
-		// Check refinery/mail/inbox.jsonl
-		if _, err := os.Stat(mailInbox); os.IsNotExist(err) {
-			issues = append(issues, "Missing: refinery/mail/inbox.jsonl")
-			c.needsMail = true
-		}
+	if _, err := os.Stat(filepath.Join(rigClone, ".git")); os.IsNotExist(err) {
+		issues = append(issues, "Missing: refinery/rig/ (git worktree)")
+		c.needsClone = true
+	}
+	if _, err := os.Stat(mailInbox); os.IsNotExist(err) {
+		issues = append(issues, "Missing: refinery/mail/inbox.jsonl")
+		c.needsMail = true
 	}
 
 	if len(issues) == 0 {
@@ -572,38 +570,10 @@ func (c *RefineryExistsCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
-	// Auto-repair refinery worktree from shared bare repo (.repo.git).
-	// The refinery/rig is a worktree (not a full clone), so we don't need
-	// the repo URL -- we just create a worktree from the local bare repo.
 	if c.needsClone {
-		bareRepoPath := filepath.Join(c.rigPath, ".repo.git")
-		if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
-			return fmt.Errorf("cannot auto-create refinery/rig/ worktree: bare repo not found at %s", bareRepoPath)
+		if _, err := rigpkg.EnsureCanonicalRepoTopology(c.rigPath); err != nil {
+			return fmt.Errorf("repairing canonical refinery topology: %w", err)
 		}
-
-		bareGit := git.NewGitWithDir(bareRepoPath, "")
-		_ = bareGit.WorktreePrune()
-
-		rigClone := filepath.Join(refineryDir, "rig")
-		// Detect default branch from rig config
-		rigCfgPath := filepath.Join(c.rigPath, "settings", "rig.json")
-		defaultBranch := "main"
-		if data, err := os.ReadFile(rigCfgPath); err == nil {
-			var cfg struct {
-				DefaultBranch string `json:"default_branch"`
-			}
-			if json.Unmarshal(data, &cfg) == nil && cfg.DefaultBranch != "" {
-				defaultBranch = cfg.DefaultBranch
-			}
-		}
-
-		if err := bareGit.WorktreeAddExisting(rigClone, defaultBranch); err != nil {
-			return fmt.Errorf("creating refinery worktree from bare repo: %w", err)
-		}
-
-		// Configure hooks path
-		refineryGit := git.NewGit(rigClone)
-		_ = refineryGit.ConfigureHooksPath()
 	}
 
 	return nil
@@ -1138,34 +1108,7 @@ func hasBeadsData(beadsDir string) bool {
 // and also rejects a non-bare repo masquerading as .repo.git (which would let
 // refspec repair write into a working tree's git dir).
 func bareRepoHealth(bareRepoPath string) error {
-	if _, err := os.Stat(filepath.Join(bareRepoPath, "HEAD")); err != nil {
-		return fmt.Errorf("HEAD missing: %w", err)
-	}
-	cmd := exec.Command("git", "-C", bareRepoPath, "rev-parse", "--git-dir")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return fmt.Errorf("git rev-parse --git-dir failed: %s", msg)
-	}
-	stderr.Reset()
-	bareCmd := exec.Command("git", "-C", bareRepoPath, "rev-parse", "--is-bare-repository")
-	bareCmd.Stderr = &stderr
-	out, err := bareCmd.Output()
-	if err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return fmt.Errorf("git rev-parse --is-bare-repository failed: %s", msg)
-	}
-	if strings.TrimSpace(string(out)) != "true" {
-		return fmt.Errorf(".repo.git is not a bare repository")
-	}
-	return nil
+	return git.NewGitWithDir(bareRepoPath, "").ValidateBareRepository()
 }
 
 // BareRepoRefspecCheck verifies that the shared bare repo has the correct refspec configured.
@@ -1224,10 +1167,9 @@ func (c *BareRepoRefspecCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// Check the refspec
-	cmd := exec.Command("git", "-C", bareRepoPath, "config", "--get", "remote.origin.fetch")
-	out, err := cmd.Output()
-	if err != nil {
+	// Check the refspec through the canonical git owner.
+	refspec, err := git.NewGitWithDir(bareRepoPath, "").ConfigGet("remote.origin.fetch")
+	if err != nil || refspec == "" {
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusError,
@@ -1240,8 +1182,8 @@ func (c *BareRepoRefspecCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	refspec := strings.TrimSpace(string(out))
-	expectedRefspec := "+refs/heads/*:refs/remotes/origin/*"
+	refspec = strings.TrimSpace(refspec)
+	expectedRefspec := rigpkg.CanonicalBareFetchRefspec
 	if refspec != expectedRefspec {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -1280,11 +1222,9 @@ func (c *BareRepoRefspecCheck) Fix(ctx *CheckContext) error {
 		return fmt.Errorf("refusing to set refspec: bare repo is structurally broken (%s); run bare-repo-exists fix to re-clone", healthErr)
 	}
 
-	cmd := exec.Command("git", "-C", bareRepoPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("setting refspec: %s", strings.TrimSpace(stderr.String()))
+	bareGit := git.NewGitWithDir(bareRepoPath, "")
+	if err := bareGit.ConfigSet("remote.origin.fetch", rigpkg.CanonicalBareFetchRefspec); err != nil {
+		return fmt.Errorf("setting refspec: %w", err)
 	}
 	return nil
 }
@@ -1492,6 +1432,7 @@ type BareRepoExistsCheck struct {
 	FixableCheck
 	brokenWorktrees []string          // worktree paths with broken .repo.git references
 	pushURLMismatch bool              // config.json push_url differs from .repo.git push URL
+	bareRepoMissing bool              // canonical .repo.git is absent
 	bareRepoCorrupt bool              // .repo.git exists but is not a usable git directory
 	recoveredHeads  map[string]string // rig-relative worktree path -> HEAD ref captured before re-clone
 }
@@ -1526,6 +1467,7 @@ func (c *BareRepoExistsCheck) Run(ctx *CheckContext) *CheckResult {
 	// Reset mutable state to avoid stale values if check is reused across rigs.
 	c.brokenWorktrees = nil
 	c.pushURLMismatch = false
+	c.bareRepoMissing = false
 	c.bareRepoCorrupt = false
 	c.recoveredHeads = nil
 	worktreeDirs := c.findWorktreeDirs(rigPath, ctx.RigName)
@@ -1569,6 +1511,31 @@ func (c *BareRepoExistsCheck) Run(ctx *CheckContext) *CheckResult {
 				}
 				c.brokenWorktrees = append(c.brokenWorktrees, relPath)
 			}
+		}
+	}
+
+	if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
+		c.bareRepoMissing = true
+		details := []string{"Missing: " + bareRepoPath}
+		if len(c.brokenWorktrees) > 0 {
+			details = append(details, c.brokenWorktrees...)
+		}
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusError,
+			Message:  "Canonical shared bare repo is missing",
+			Details:  details,
+			FixHint:  "Run 'gt doctor --fix --rig " + ctx.RigName + "' to restore .repo.git and refinery/rig",
+			Category: c.Category(),
+		}
+	} else if err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusError,
+			Message:  "Cannot inspect canonical shared bare repo",
+			Details:  []string{err.Error()},
+			FixHint:  "Check permissions for " + bareRepoPath,
+			Category: c.Category(),
 		}
 	}
 
@@ -1737,25 +1704,10 @@ func (c *BareRepoExistsCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// .repo.git missing but no worktrees depend on it
-	if len(c.brokenWorktrees) == 0 {
-		return &CheckResult{
-			Name:     c.Name(),
-			Status:   StatusOK,
-			Message:  "No worktrees depend on .repo.git",
-			Category: c.Category(),
-		}
-	}
-
 	return &CheckResult{
-		Name:    c.Name(),
-		Status:  StatusError,
-		Message: fmt.Sprintf("%d worktree(s) reference missing .repo.git", len(c.brokenWorktrees)),
-		Details: append(
-			[]string{"Missing: " + bareRepoPath},
-			c.brokenWorktrees...,
-		),
-		FixHint:  "Run 'gt doctor --fix --rig " + ctx.RigName + "' to recreate .repo.git from remote",
+		Name:     c.Name(),
+		Status:   StatusError,
+		Message:  "Canonical shared bare repo validation did not complete",
 		Category: c.Category(),
 	}
 }
@@ -1769,6 +1721,17 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 
 	rigPath := ctx.RigPath()
 	bareRepoPath := filepath.Join(rigPath, ".repo.git")
+
+	// Adopted rigs can have a healthy Mayor clone and independent polecat
+	// worktrees without any canonical .repo.git reference. Restore the complete
+	// topology through the rig owner instead of treating that legacy shape as OK.
+	if c.bareRepoMissing && len(c.brokenWorktrees) == 0 {
+		if _, err := rigpkg.EnsureCanonicalRepoTopology(rigPath); err != nil {
+			return fmt.Errorf("restoring canonical repository topology: %w", err)
+		}
+		c.bareRepoMissing = false
+		return nil
+	}
 
 	// If .repo.git is corrupt (exists but unusable), nuke it so the missing-repo
 	// branch below re-clones from config.json. We cannot repair a partial-shell

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -953,6 +953,16 @@ func (g *Git) FetchBranchShallow(remote, branch string) error {
 	return err
 }
 
+// FetchBranchTracking refreshes one remote-tracking branch without widening
+// the configured refspec to every remote branch. On an existing shallow clone,
+// omitting --depth lets git fetch the connecting commits back to its current
+// shallow boundary so a legitimate fast-forward can be verified locally.
+func (g *Git) FetchBranchTracking(remote, branch string) error {
+	refspec := branch + ":refs/remotes/" + remote + "/" + branch
+	_, err := g.run("fetch", remote, refspec)
+	return err
+}
+
 // Pull pulls from the remote branch.
 func (g *Git) Pull(remote, branch string) error {
 	_, err := g.run("pull", remote, branch)
@@ -2011,6 +2021,45 @@ func (g *Git) BranchExists(name string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// AdvanceBranchIfBehind fast-forwards a local branch to target when target is
+// newer, leaves an already-ahead branch unchanged, and rejects divergence.
+// It updates only the ref, so callers must use it only when the branch is not
+// checked out in a live worktree.
+func (g *Git) AdvanceBranchIfBehind(name, target string) error {
+	branchRef := "refs/heads/" + name
+	currentSHA, err := g.Rev(branchRef)
+	if err != nil {
+		return fmt.Errorf("reading branch %s: %w", name, err)
+	}
+	targetSHA, err := g.Rev(target)
+	if err != nil {
+		return fmt.Errorf("reading target %s: %w", target, err)
+	}
+	if currentSHA == targetSHA {
+		return nil
+	}
+
+	behind, err := g.IsAncestor(currentSHA, targetSHA)
+	if err != nil {
+		return fmt.Errorf("checking whether %s can fast-forward to %s: %w", name, target, err)
+	}
+	if behind {
+		if _, err := g.run("update-ref", branchRef, targetSHA, currentSHA); err != nil {
+			return fmt.Errorf("fast-forwarding branch %s to %s: %w", name, target, err)
+		}
+		return nil
+	}
+
+	ahead, err := g.IsAncestor(targetSHA, currentSHA)
+	if err != nil {
+		return fmt.Errorf("checking whether %s is ahead of %s: %w", name, target, err)
+	}
+	if ahead {
+		return nil
+	}
+	return fmt.Errorf("branch %s has diverged from %s", name, target)
 }
 
 // RefExists checks if a ref exists (works for any ref including origin/<branch>).

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -94,6 +94,29 @@ func (g *Git) IsRepo() bool {
 	return err == nil
 }
 
+// ValidateBareRepository verifies that g points at a structurally usable bare
+// repository. Checking HEAD explicitly catches partially deleted repositories
+// that still contain objects or worktree metadata but are no longer operable.
+func (g *Git) ValidateBareRepository() error {
+	if g.gitDir == "" {
+		return fmt.Errorf("no git directory configured for bare repository validation")
+	}
+	if _, err := os.Stat(filepath.Join(g.gitDir, "HEAD")); err != nil {
+		return fmt.Errorf("HEAD missing: %w", err)
+	}
+	if _, err := g.run("rev-parse", "--git-dir"); err != nil {
+		return fmt.Errorf("git rev-parse --git-dir failed: %w", err)
+	}
+	out, err := g.run("rev-parse", "--is-bare-repository")
+	if err != nil {
+		return fmt.Errorf("git rev-parse --is-bare-repository failed: %w", err)
+	}
+	if strings.TrimSpace(out) != "true" {
+		return fmt.Errorf("repository is not bare")
+	}
+	return nil
+}
+
 // run executes a git command and returns stdout.
 func (g *Git) run(args ...string) (string, error) {
 	if err := g.guardUnsafeTownRootMutation(args); err != nil {
@@ -1469,6 +1492,12 @@ func (g *Git) ConfigGet(key string) (string, error) {
 		return "", nil
 	}
 	return out, nil
+}
+
+// ConfigSet sets a repository-local git configuration value.
+func (g *Git) ConfigSet(key, value string) error {
+	_, err := g.run("config", key, value)
+	return err
 }
 
 // Merge merges the given branch into the current branch.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2299,7 +2299,7 @@ func (g *Git) WorktreeAdd(path, branch string) error {
 	); err != nil {
 		return err
 	}
-	return InitSubmodules(path, g.submoduleReferencePath())
+	return g.InitWorktreeSubmodules(path)
 }
 
 // WorktreeAddFromRef creates a new worktree at the given path with a new branch
@@ -2314,7 +2314,7 @@ func (g *Git) WorktreeAddFromRef(path, branch, startPoint string) error {
 	); err != nil {
 		return err
 	}
-	return InitSubmodules(path, g.submoduleReferencePath())
+	return g.InitWorktreeSubmodules(path)
 }
 
 // WorktreeAddDetached creates a new worktree at the given path with a detached HEAD.
@@ -2326,7 +2326,7 @@ func (g *Git) WorktreeAddDetached(path, ref string) error {
 	); err != nil {
 		return err
 	}
-	return InitSubmodules(path, g.submoduleReferencePath())
+	return g.InitWorktreeSubmodules(path)
 }
 
 // WorktreeAddExisting creates a new worktree at the given path for an existing branch.
@@ -2338,7 +2338,7 @@ func (g *Git) WorktreeAddExisting(path, branch string) error {
 	); err != nil {
 		return err
 	}
-	return InitSubmodules(path, g.submoduleReferencePath())
+	return g.InitWorktreeSubmodules(path)
 }
 
 // WorktreeAddExistingForce creates a new worktree even if the branch is already checked out elsewhere.
@@ -2347,6 +2347,13 @@ func (g *Git) WorktreeAddExistingForce(path, branch string) error {
 	if _, err := g.run("worktree", "add", "--force", path, branch); err != nil {
 		return err
 	}
+	return g.InitWorktreeSubmodules(path)
+}
+
+// InitWorktreeSubmodules initializes a worktree's pinned submodules using the
+// same local reference source as worktree creation. Callers use this on retry
+// so a partially initialized worktree cannot bypass a prior checkout failure.
+func (g *Git) InitWorktreeSubmodules(path string) error {
 	return InitSubmodules(path, g.submoduleReferencePath())
 }
 

--- a/internal/refinery/canonical_worktree_test.go
+++ b/internal/refinery/canonical_worktree_test.go
@@ -1,0 +1,45 @@
+package refinery
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+func TestEnsureCanonicalWorktreeNeverFallsBackToMayor(t *testing.T) {
+	rigPath := filepath.Join(t.TempDir(), "broken")
+	mayorPath := filepath.Join(rigPath, "mayor", "rig")
+	if err := os.MkdirAll(mayorPath, 0755); err != nil {
+		t.Fatalf("create Mayor path: %v", err)
+	}
+	markerPath := filepath.Join(mayorPath, "active-wip.txt")
+	marker := []byte("Mayor work must remain untouched\n")
+	if err := os.WriteFile(markerPath, marker, 0644); err != nil {
+		t.Fatalf("write Mayor marker: %v", err)
+	}
+
+	manager := NewManager(&rig.Rig{Name: "broken", Path: rigPath})
+	var output bytes.Buffer
+	manager.SetOutput(&output)
+	workDir, err := manager.ensureCanonicalWorktree()
+	if err == nil {
+		t.Fatal("ensureCanonicalWorktree succeeded without canonical rig config")
+	}
+	if workDir != "" {
+		t.Fatalf("workDir = %q, want empty on canonical topology failure", workDir)
+	}
+	if strings.Contains(output.String(), "mayor/rig") || strings.Contains(output.String(), "falling back") {
+		t.Fatalf("refinery reported a Mayor fallback: %q", output.String())
+	}
+	got, readErr := os.ReadFile(markerPath)
+	if readErr != nil {
+		t.Fatalf("read Mayor marker: %v", readErr)
+	}
+	if !bytes.Equal(got, marker) {
+		t.Fatalf("Mayor WIP changed: got %q, want %q", got, marker)
+	}
+}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
-	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
@@ -196,30 +195,12 @@ func (m *Manager) start(foreground bool, agentOverride string, allowForkRig bool
 	// Background mode: spawn a Claude agent in a tmux session
 	// The Claude agent handles MR processing using git commands and beads
 
-	// Working directory is the refinery worktree (shares .git with mayor/polecats).
-	// If the worktree is missing (pruned, deleted, or corrupted), auto-repair it
-	// from the shared bare repo (.repo.git) instead of falling back to mayor/rig.
-	// Falling back to mayor/rig causes the refinery to operate in the mayor's
-	// clone, which can interfere with mayor operations and confuse agents.
-	//
-	// Rigs using a standard .git clone (e.g. beads) never have a .repo.git bare
-	// repo, so the repair path is not applicable for them. Fall back to mayor/rig
-	// silently in that case — the fallback is correct and the warning would be noise.
-	refineryRigDir := filepath.Join(m.rig.Path, "refinery", "rig")
-	if _, err := os.Stat(refineryRigDir); os.IsNotExist(err) {
-		bareRepoPath := filepath.Join(m.rig.Path, ".repo.git")
-		_, bareErr := os.Stat(bareRepoPath)
-		standardGitPath := filepath.Join(m.rig.Path, ".git")
-		_, standardGitErr := os.Stat(standardGitPath)
-		if os.IsNotExist(bareErr) && standardGitErr == nil {
-			// Rig uses standard .git layout — worktree repair is not applicable.
-			// Fall back to mayor/rig silently; the fallback works correctly here.
-			refineryRigDir = filepath.Join(m.rig.Path, "mayor", "rig")
-		} else if repairErr := m.repairRefineryWorktree(refineryRigDir); repairErr != nil {
-			// Repair failed — fall back to mayor/rig as last resort.
-			_, _ = fmt.Fprintf(m.output, "⚠ Could not repair refinery worktree: %v (falling back to mayor/rig)\n", repairErr)
-			refineryRigDir = filepath.Join(m.rig.Path, "mayor", "rig")
-		}
+	// The refinery always runs from the canonical dedicated worktree. Startup
+	// repairs missing topology through the rig owner and fails if that repair is
+	// impossible; it must never borrow Mayor's clone as a parallel fallback.
+	refineryRigDir, err := m.ensureCanonicalWorktree()
+	if err != nil {
+		return fmt.Errorf("ensuring canonical refinery worktree: %w", err)
 	}
 
 	// Ensure runtime settings exist in the shared refinery parent directory.
@@ -365,41 +346,18 @@ func (m *Manager) blockForkRigStart(t *tmux.Tmux) error {
 	return err
 }
 
-// repairRefineryWorktree recreates a missing refinery/rig worktree from the
-// shared bare repo (.repo.git). The refinery worktree is created during
-// `gt rig add` but can be lost if `git worktree prune` runs, the directory
-// is deleted, or the .git file becomes corrupted. This self-heals on startup
-// instead of requiring manual intervention.
-func (m *Manager) repairRefineryWorktree(refineryRigDir string) error {
-	bareRepoPath := filepath.Join(m.rig.Path, ".repo.git")
-	if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
-		return fmt.Errorf("bare repo not found at %s", bareRepoPath)
+func (m *Manager) ensureCanonicalWorktree() (string, error) {
+	result, err := rig.EnsureCanonicalRepoTopology(m.rig.Path)
+	if err != nil {
+		return "", err
 	}
-
-	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(refineryRigDir), 0755); err != nil {
-		return fmt.Errorf("creating refinery dir: %w", err)
+	if result.BareRepoCreated {
+		_, _ = fmt.Fprintf(m.output, "✓ Restored shared bare repository at %s\n", result.BareRepoPath)
 	}
-
-	// Prune stale worktree entries so git doesn't reject the add
-	bareGit := git.NewGitWithDir(bareRepoPath, "")
-	_ = bareGit.WorktreePrune()
-
-	// Create worktree on the rig's default branch
-	defaultBranch := m.rig.DefaultBranch()
-	if err := bareGit.WorktreeAddExisting(refineryRigDir, defaultBranch); err != nil {
-		return fmt.Errorf("git worktree add: %w", err)
+	if result.RefineryWorktreeCreated {
+		_, _ = fmt.Fprintf(m.output, "✓ Restored refinery worktree at %s\n", result.RefineryWorktreePath)
 	}
-
-	// Configure hooks path (matches rig add behavior)
-	refineryGit := git.NewGit(refineryRigDir)
-	if err := refineryGit.ConfigureHooksPath(); err != nil {
-		// Non-fatal: worktree is usable without hooks
-		_, _ = fmt.Fprintf(m.output, "⚠ Could not configure hooks for repaired worktree: %v\n", err)
-	}
-
-	_, _ = fmt.Fprintf(m.output, "✓ Auto-repaired missing refinery worktree at %s\n", refineryRigDir)
-	return nil
+	return result.RefineryWorktreePath, nil
 }
 
 // Stop stops the refinery.

--- a/internal/rig/canonical_repo.go
+++ b/internal/rig/canonical_repo.go
@@ -164,6 +164,8 @@ func ensureCanonicalBareRepo(rigPath string, cfg *RigConfig) (*git.Git, string, 
 		if err := bareGit.FetchBranchShallow("origin", branch); err != nil {
 			return nil, "", "", false, fmt.Errorf("fetching integration branch %s into shared bare repository: %w", branch, err)
 		}
+	} else if err := bareGit.FetchBranchTracking("origin", branch); err != nil {
+		return nil, "", "", false, fmt.Errorf("refreshing integration branch %s in shared bare repository: %w", branch, err)
 	}
 
 	branchExists, err := bareGit.BranchExists(branch)
@@ -227,6 +229,10 @@ func ensureCanonicalRefineryWorktree(bareGit *git.Git, barePath, refineryPath, b
 			if strings.TrimSpace(currentBranch) != branch {
 				return false, fmt.Errorf("refinery/rig is on branch %q; canonical integration branch is %q", currentBranch, branch)
 			}
+			remoteBranch := "refs/remotes/origin/" + branch
+			if err := refineryGit.MergeFFOnly(remoteBranch); err != nil {
+				return false, fmt.Errorf("fast-forwarding refinery/rig to %s: %w", remoteBranch, err)
+			}
 			if err := bareGit.InitWorktreeSubmodules(refineryPath); err != nil {
 				return false, fmt.Errorf("initializing canonical refinery submodules: %w", err)
 			}
@@ -244,6 +250,10 @@ func ensureCanonicalRefineryWorktree(bareGit *git.Git, barePath, refineryPath, b
 	}
 	if err := bareGit.WorktreePrune(); err != nil {
 		return false, fmt.Errorf("pruning stale refinery worktree metadata: %w", err)
+	}
+	remoteBranch := "refs/remotes/origin/" + branch
+	if err := bareGit.AdvanceBranchIfBehind(branch, remoteBranch); err != nil {
+		return false, fmt.Errorf("synchronizing refinery integration branch: %w", err)
 	}
 	if err := bareGit.WorktreeAddExisting(refineryPath, branch); err != nil {
 		return false, fmt.Errorf("creating refinery worktree on %s: %w", branch, err)

--- a/internal/rig/canonical_repo.go
+++ b/internal/rig/canonical_repo.go
@@ -1,0 +1,278 @@
+package rig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// CanonicalBareFetchRefspec is the fetch mapping required by the shared bare
+// repository. It keeps remote-tracking refs visible to refinery and polecat
+// worktrees while their local branches remain in the shared repository.
+const CanonicalBareFetchRefspec = "+refs/heads/*:refs/remotes/origin/*"
+
+// CanonicalRepoResult reports which missing parts of a rig's canonical git
+// topology were created.
+type CanonicalRepoResult struct {
+	BareRepoPath             string
+	RefineryWorktreePath     string
+	DefaultBranch            string
+	BareRepoCreated          bool
+	RefineryWorktreeCreated  bool
+}
+
+// EnsureCanonicalRepoTopology creates or validates the shared .repo.git bare
+// repository and the dedicated refinery/rig worktree for a registered rig.
+// It deliberately does not inspect, rewrite, or re-parent mayor and polecat
+// worktrees, so active work in those repositories is preserved.
+func EnsureCanonicalRepoTopology(rigPath string) (*CanonicalRepoResult, error) {
+	cfg, err := LoadRigConfig(rigPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading rig config: %w", err)
+	}
+
+	result, err := ensureCanonicalRepoTopology(rigPath, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.DefaultBranch != result.DefaultBranch {
+		cfg.DefaultBranch = result.DefaultBranch
+		if err := saveRigConfigFile(rigPath, cfg); err != nil {
+			return nil, fmt.Errorf("persisting detected default branch: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func ensureCanonicalRepoTopology(rigPath string, cfg *RigConfig) (*CanonicalRepoResult, error) {
+	rigPath = filepath.Clean(rigPath)
+	if strings.TrimSpace(cfg.GitURL) == "" {
+		return nil, fmt.Errorf("rig config has no git_url; cannot create canonical repository topology")
+	}
+
+	bareGit, barePath, branch, bareCreated, err := ensureCanonicalBareRepo(rigPath, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	refineryPath := filepath.Join(rigPath, "refinery", "rig")
+	refineryCreated, err := ensureCanonicalRefineryWorktree(bareGit, barePath, refineryPath, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CanonicalRepoResult{
+		BareRepoPath:            barePath,
+		RefineryWorktreePath:    refineryPath,
+		DefaultBranch:           branch,
+		BareRepoCreated:         bareCreated,
+		RefineryWorktreeCreated: refineryCreated,
+	}, nil
+}
+
+func ensureCanonicalBareRepo(rigPath string, cfg *RigConfig) (*git.Git, string, string, bool, error) {
+	barePath := filepath.Join(rigPath, ".repo.git")
+	branch := strings.TrimSpace(cfg.DefaultBranch)
+	created := false
+
+	info, statErr := os.Stat(barePath)
+	switch {
+	case os.IsNotExist(statErr):
+		cloneGit := git.NewGit(rigPath)
+		localRepo, _ := resolveLocalRepo(cfg.LocalRepo, cfg.GitURL)
+		var cloneErr error
+		if localRepo != "" {
+			cloneErr = cloneGit.CloneBareWithReferenceAndBranch(cfg.GitURL, barePath, localRepo, branch)
+		} else {
+			cloneErr = cloneGit.CloneBareWithBranch(cfg.GitURL, barePath, branch)
+		}
+		if cloneErr != nil {
+			return nil, "", "", false, fmt.Errorf("creating shared bare repository: %w", cloneErr)
+		}
+		created = true
+	case statErr != nil:
+		return nil, "", "", false, fmt.Errorf("checking shared bare repository: %w", statErr)
+	case !info.IsDir():
+		return nil, "", "", false, fmt.Errorf("shared bare repository path is not a directory: %s", barePath)
+	}
+
+	bareGit := git.NewGitWithDir(barePath, "")
+	if err := bareGit.ValidateBareRepository(); err != nil {
+		return nil, "", "", false, fmt.Errorf("validating shared bare repository %s: %w", barePath, err)
+	}
+
+	remotes, err := bareGit.Remotes()
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("listing shared bare repository remotes: %w", err)
+	}
+	if containsString(remotes, "origin") {
+		originURL, err := bareGit.RemoteURL("origin")
+		if err != nil {
+			return nil, "", "", false, fmt.Errorf("reading shared bare repository origin: %w", err)
+		}
+		if strings.TrimSpace(originURL) != strings.TrimSpace(cfg.GitURL) {
+			if _, err := bareGit.SetRemoteURL("origin", cfg.GitURL); err != nil {
+				return nil, "", "", false, fmt.Errorf("configuring shared bare repository origin: %w", err)
+			}
+		}
+	} else if _, err := bareGit.AddRemote("origin", cfg.GitURL); err != nil {
+		return nil, "", "", false, fmt.Errorf("adding shared bare repository origin: %w", err)
+	}
+
+	refspec, err := bareGit.ConfigGet("remote.origin.fetch")
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("reading shared bare repository refspec: %w", err)
+	}
+	if strings.TrimSpace(refspec) != CanonicalBareFetchRefspec {
+		if err := bareGit.ConfigSet("remote.origin.fetch", CanonicalBareFetchRefspec); err != nil {
+			return nil, "", "", false, fmt.Errorf("configuring shared bare repository refspec: %w", err)
+		}
+	}
+
+	if cfg.PushURL != "" {
+		if err := bareGit.ConfigurePushURL("origin", cfg.PushURL); err != nil {
+			return nil, "", "", false, fmt.Errorf("configuring shared bare repository push URL: %w", err)
+		}
+	}
+	if cfg.UpstreamURL != "" {
+		if err := bareGit.AddUpstreamRemote(cfg.UpstreamURL); err != nil {
+			return nil, "", "", false, fmt.Errorf("configuring shared bare repository upstream: %w", err)
+		}
+	}
+
+	if branch == "" {
+		branch, err = bareGit.CurrentBranch()
+		if err != nil {
+			return nil, "", "", false, fmt.Errorf("detecting shared bare repository default branch: %w", err)
+		}
+		branch = strings.TrimSpace(branch)
+		if branch == "" || branch == "HEAD" {
+			return nil, "", "", false, fmt.Errorf("shared bare repository has no symbolic default branch")
+		}
+	}
+
+	trackingExists, err := bareGit.RemoteTrackingBranchExists("origin", branch)
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("checking origin/%s in shared bare repository: %w", branch, err)
+	}
+	if !trackingExists {
+		if err := bareGit.FetchBranchShallow("origin", branch); err != nil {
+			return nil, "", "", false, fmt.Errorf("fetching integration branch %s into shared bare repository: %w", branch, err)
+		}
+	}
+
+	branchExists, err := bareGit.BranchExists(branch)
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("checking local integration branch %s: %w", branch, err)
+	}
+	if !branchExists {
+		if err := bareGit.CreateBranchFrom(branch, "refs/remotes/origin/"+branch); err != nil {
+			return nil, "", "", false, fmt.Errorf("creating local integration branch %s: %w", branch, err)
+		}
+	}
+
+	return bareGit, barePath, branch, created, nil
+}
+
+func ensureCanonicalRefineryWorktree(bareGit *git.Git, barePath, refineryPath, branch string) (bool, error) {
+	info, statErr := os.Lstat(refineryPath)
+	if statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return false, fmt.Errorf("canonical refinery worktree path is not a directory: %s", refineryPath)
+		}
+
+		gitEntry := filepath.Join(refineryPath, ".git")
+		gitInfo, err := os.Lstat(gitEntry)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return false, fmt.Errorf("checking refinery worktree git entry: %w", err)
+			}
+			entries, readErr := os.ReadDir(refineryPath)
+			if readErr != nil {
+				return false, fmt.Errorf("reading incomplete refinery worktree: %w", readErr)
+			}
+			if len(entries) != 0 {
+				return false, fmt.Errorf("refinery worktree path exists without .git and is not empty: %s", refineryPath)
+			}
+			if err := os.Remove(refineryPath); err != nil {
+				return false, fmt.Errorf("removing empty refinery worktree directory: %w", err)
+			}
+		} else {
+			if gitInfo.Mode()&os.ModeSymlink != 0 || !gitInfo.Mode().IsRegular() {
+				return false, fmt.Errorf("refinery/rig must be a worktree linked to %s", barePath)
+			}
+			gitDir, err := resolveWorktreeGitDir(refineryPath, gitEntry)
+			if err != nil {
+				return false, err
+			}
+			worktreesRoot := filepath.Join(barePath, "worktrees")
+			rel, err := filepath.Rel(worktreesRoot, gitDir)
+			if err != nil || rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return false, fmt.Errorf("refinery/rig is not linked to canonical bare repository %s", barePath)
+			}
+
+			refineryGit := git.NewGit(refineryPath)
+			if !refineryGit.IsRepo() {
+				return false, fmt.Errorf("refinery/rig has an unusable worktree link to %s", gitDir)
+			}
+			currentBranch, err := refineryGit.CurrentBranch()
+			if err != nil {
+				return false, fmt.Errorf("reading refinery integration branch: %w", err)
+			}
+			if strings.TrimSpace(currentBranch) != branch {
+				return false, fmt.Errorf("refinery/rig is on branch %q; canonical integration branch is %q", currentBranch, branch)
+			}
+			if err := refineryGit.ConfigureHooksPath(); err != nil {
+				return false, fmt.Errorf("configuring refinery hooks: %w", err)
+			}
+			return false, nil
+		}
+	} else if !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("checking refinery worktree path: %w", statErr)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(refineryPath), 0755); err != nil {
+		return false, fmt.Errorf("creating refinery directory: %w", err)
+	}
+	if err := bareGit.WorktreePrune(); err != nil {
+		return false, fmt.Errorf("pruning stale refinery worktree metadata: %w", err)
+	}
+	if err := bareGit.WorktreeAddExisting(refineryPath, branch); err != nil {
+		return false, fmt.Errorf("creating refinery worktree on %s: %w", branch, err)
+	}
+	refineryGit := git.NewGit(refineryPath)
+	if err := refineryGit.ConfigureHooksPath(); err != nil {
+		return false, fmt.Errorf("configuring refinery hooks: %w", err)
+	}
+	return true, nil
+}
+
+func resolveWorktreeGitDir(worktreePath, gitEntry string) (string, error) {
+	data, err := os.ReadFile(gitEntry)
+	if err != nil {
+		return "", fmt.Errorf("reading refinery worktree git entry: %w", err)
+	}
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return "", fmt.Errorf("invalid refinery worktree git entry: %s", gitEntry)
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(line, "gitdir: "))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	return filepath.Clean(gitDir), nil
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rig/canonical_repo.go
+++ b/internal/rig/canonical_repo.go
@@ -17,11 +17,11 @@ const CanonicalBareFetchRefspec = "+refs/heads/*:refs/remotes/origin/*"
 // CanonicalRepoResult reports which missing parts of a rig's canonical git
 // topology were created.
 type CanonicalRepoResult struct {
-	BareRepoPath             string
-	RefineryWorktreePath     string
-	DefaultBranch            string
-	BareRepoCreated          bool
-	RefineryWorktreeCreated  bool
+	BareRepoPath            string
+	RefineryWorktreePath    string
+	DefaultBranch           string
+	BareRepoCreated         bool
+	RefineryWorktreeCreated bool
 }
 
 // EnsureCanonicalRepoTopology creates or validates the shared .repo.git bare

--- a/internal/rig/canonical_repo.go
+++ b/internal/rig/canonical_repo.go
@@ -227,6 +227,9 @@ func ensureCanonicalRefineryWorktree(bareGit *git.Git, barePath, refineryPath, b
 			if strings.TrimSpace(currentBranch) != branch {
 				return false, fmt.Errorf("refinery/rig is on branch %q; canonical integration branch is %q", currentBranch, branch)
 			}
+			if err := bareGit.InitWorktreeSubmodules(refineryPath); err != nil {
+				return false, fmt.Errorf("initializing canonical refinery submodules: %w", err)
+			}
 			if err := refineryGit.ConfigureHooksPath(); err != nil {
 				return false, fmt.Errorf("configuring refinery hooks: %w", err)
 			}

--- a/internal/rig/canonical_repo_test.go
+++ b/internal/rig/canonical_repo_test.go
@@ -121,6 +121,12 @@ func TestEnsureCanonicalRepoTopologyRestoresMissingRefineryWorktree(t *testing.T
 	if err := git.NewGit(rigPath).CloneBareWithBranch(remote, barePath, "main"); err != nil {
 		t.Fatalf("create existing bare repo: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(remote, "after-bare-clone.txt"), []byte("advance integration branch\n"), 0644); err != nil {
+		t.Fatalf("write integration advance: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "-C", remote, "add", "after-bare-clone.txt")
+	runGitForCanonicalRepoTest(t, "-C", remote, "commit", "-m", "advance integration branch")
+	advancedCommit := gitOutputForCanonicalRepoTest(t, "-C", remote, "rev-parse", "HEAD")
 
 	result, err := EnsureCanonicalRepoTopology(rigPath)
 	if err != nil {
@@ -133,14 +139,17 @@ func TestEnsureCanonicalRepoTopologyRestoresMissingRefineryWorktree(t *testing.T
 		t.Fatal("missing refinery worktree was not reported as restored")
 	}
 	assertCanonicalRepoTopology(t, rigPath, remote, "main")
+	if got := gitOutputForCanonicalRepoTest(t, "-C", filepath.Join(rigPath, "refinery", "rig"), "rev-parse", "HEAD"); got != advancedCommit {
+		t.Fatalf("restored refinery HEAD = %q, want advanced integration commit %q", got, advancedCommit)
+	}
 }
 
-func TestEnsureCanonicalRepoTopologyRetriesIncompleteSubmodules(t *testing.T) {
+func TestEnsureCanonicalRepoTopologyRetriesAfterForwardSubmoduleRepair(t *testing.T) {
 	t.Setenv("GIT_CONFIG_COUNT", "1")
 	t.Setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
 	t.Setenv("GIT_CONFIG_VALUE_0", "always")
 
-	remote, submoduleWorktree, pinnedCommit := createCanonicalRepoWithUnpublishedSubmodule(t)
+	remote, parentWorktree, submoduleWorktree, pinnedCommit, publishedCommit := createCanonicalRepoWithUnpublishedSubmodule(t)
 	rigPath := filepath.Join(t.TempDir(), "submodule-retry")
 	if err := os.MkdirAll(rigPath, 0755); err != nil {
 		t.Fatalf("create rig: %v", err)
@@ -174,17 +183,26 @@ func TestEnsureCanonicalRepoTopologyRetriesIncompleteSubmodules(t *testing.T) {
 		t.Fatalf("retry error = %q, want canonical submodule failure", err)
 	}
 
-	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "push", "origin", "HEAD:main")
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "checkout", "--detach", publishedCommit)
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "add", "libs/sub")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "commit", "-m", "repair dangling submodule pin")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "push", "origin", "main")
+	repairedParentCommit := gitOutputForCanonicalRepoTest(t, "-C", parentWorktree, "rev-parse", "HEAD")
+
 	result, err := EnsureCanonicalRepoTopology(rigPath)
 	if err != nil {
-		t.Fatalf("ensure after publishing pinned submodule: %v", err)
+		t.Fatalf("ensure after forward parent repair: %v", err)
 	}
 	if result.BareRepoCreated || result.RefineryWorktreeCreated {
 		t.Fatalf("retry recreated existing canonical topology: %+v", result)
 	}
+	gotParentCommit := gitOutputForCanonicalRepoTest(t, "-C", filepath.Join(rigPath, "refinery", "rig"), "rev-parse", "HEAD")
+	if gotParentCommit != repairedParentCommit {
+		t.Fatalf("refinery HEAD = %q, want repaired parent commit %q", gotParentCommit, repairedParentCommit)
+	}
 	gotCommit := gitOutputForCanonicalRepoTest(t, "-C", filepath.Join(rigPath, "refinery", "rig", "libs", "sub"), "rev-parse", "HEAD")
-	if gotCommit != pinnedCommit {
-		t.Fatalf("submodule HEAD = %q, want pinned commit %q", gotCommit, pinnedCommit)
+	if gotCommit != publishedCommit {
+		t.Fatalf("submodule HEAD = %q, want repaired published commit %q (dangling pin was %q)", gotCommit, publishedCommit, pinnedCommit)
 	}
 }
 
@@ -280,7 +298,7 @@ func gitOutputForCanonicalRepoTest(t *testing.T, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func createCanonicalRepoWithUnpublishedSubmodule(t *testing.T) (string, string, string) {
+func createCanonicalRepoWithUnpublishedSubmodule(t *testing.T) (string, string, string, string, string) {
 	t.Helper()
 	root := t.TempDir()
 	submoduleRemote := filepath.Join(root, "submodule.git")
@@ -297,6 +315,7 @@ func createCanonicalRepoWithUnpublishedSubmodule(t *testing.T) (string, string, 
 	}
 	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "add", "lib.txt")
 	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "commit", "-m", "published")
+	publishedCommit := gitOutputForCanonicalRepoTest(t, "-C", submoduleWorktree, "rev-parse", "HEAD")
 	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "remote", "add", "origin", submoduleRemote)
 	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "push", "-u", "origin", "main")
 
@@ -327,5 +346,5 @@ func createCanonicalRepoWithUnpublishedSubmodule(t *testing.T) (string, string, 
 	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "commit", "-m", "pin unpublished submodule")
 	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "push", "origin", "main")
 
-	return parentRemote, submoduleCheckout, pinnedCommit
+	return parentRemote, parentWorktree, submoduleCheckout, pinnedCommit, publishedCommit
 }

--- a/internal/rig/canonical_repo_test.go
+++ b/internal/rig/canonical_repo_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,6 +135,59 @@ func TestEnsureCanonicalRepoTopologyRestoresMissingRefineryWorktree(t *testing.T
 	assertCanonicalRepoTopology(t, rigPath, remote, "main")
 }
 
+func TestEnsureCanonicalRepoTopologyRetriesIncompleteSubmodules(t *testing.T) {
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+	t.Setenv("GIT_CONFIG_VALUE_0", "always")
+
+	remote, submoduleWorktree, pinnedCommit := createCanonicalRepoWithUnpublishedSubmodule(t)
+	rigPath := filepath.Join(t.TempDir(), "submodule-retry")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("create rig: %v", err)
+	}
+	if err := saveRigConfigFile(rigPath, &RigConfig{
+		Type:          "rig",
+		Version:       CurrentRigConfigVersion,
+		Name:          "submodule_retry",
+		GitURL:        remote,
+		DefaultBranch: "main",
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("write rig config: %v", err)
+	}
+
+	if _, err := EnsureCanonicalRepoTopology(rigPath); err == nil {
+		t.Fatal("first ensure succeeded with an unpublished pinned submodule commit")
+	} else if !strings.Contains(err.Error(), "initializing submodules") {
+		t.Fatalf("first ensure error = %q, want submodule initialization failure", err)
+	}
+	if err := git.NewGitWithDir(filepath.Join(rigPath, ".repo.git"), "").ValidateBareRepository(); err != nil {
+		t.Fatalf("first ensure did not leave a valid retryable bare repo: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, "refinery", "rig", ".git")); err != nil {
+		t.Fatalf("first ensure did not leave a retryable refinery worktree: %v", err)
+	}
+
+	if _, err := EnsureCanonicalRepoTopology(rigPath); err == nil {
+		t.Fatal("retry accepted a refinery worktree with incomplete submodules")
+	} else if !strings.Contains(err.Error(), "initializing canonical refinery submodules") {
+		t.Fatalf("retry error = %q, want canonical submodule failure", err)
+	}
+
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "push", "origin", "HEAD:main")
+	result, err := EnsureCanonicalRepoTopology(rigPath)
+	if err != nil {
+		t.Fatalf("ensure after publishing pinned submodule: %v", err)
+	}
+	if result.BareRepoCreated || result.RefineryWorktreeCreated {
+		t.Fatalf("retry recreated existing canonical topology: %+v", result)
+	}
+	gotCommit := gitOutputForCanonicalRepoTest(t, "-C", filepath.Join(rigPath, "refinery", "rig", "libs", "sub"), "rev-parse", "HEAD")
+	if gotCommit != pinnedCommit {
+		t.Fatalf("submodule HEAD = %q, want pinned commit %q", gotCommit, pinnedCommit)
+	}
+}
+
 func assertCanonicalRepoTopology(t *testing.T, rigPath, remote, branch string) {
 	t.Helper()
 	barePath := filepath.Join(rigPath, ".repo.git")
@@ -214,4 +268,64 @@ func runGitForCanonicalRepoTest(t *testing.T, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
+}
+
+func gitOutputForCanonicalRepoTest(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func createCanonicalRepoWithUnpublishedSubmodule(t *testing.T) (string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	submoduleRemote := filepath.Join(root, "submodule.git")
+	submoduleWorktree := filepath.Join(root, "submodule-work")
+	parentRemote := filepath.Join(root, "parent.git")
+	parentWorktree := filepath.Join(root, "parent-work")
+
+	runGitForCanonicalRepoTest(t, "init", "--bare", "--initial-branch=main", submoduleRemote)
+	runGitForCanonicalRepoTest(t, "init", "--initial-branch=main", submoduleWorktree)
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "config", "user.email", "canonical@example.com")
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "config", "user.name", "Canonical Test")
+	if err := os.WriteFile(filepath.Join(submoduleWorktree, "lib.txt"), []byte("published\n"), 0644); err != nil {
+		t.Fatalf("write published submodule file: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "add", "lib.txt")
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "commit", "-m", "published")
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "remote", "add", "origin", submoduleRemote)
+	runGitForCanonicalRepoTest(t, "-C", submoduleWorktree, "push", "-u", "origin", "main")
+
+	runGitForCanonicalRepoTest(t, "init", "--bare", "--initial-branch=main", parentRemote)
+	runGitForCanonicalRepoTest(t, "init", "--initial-branch=main", parentWorktree)
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "config", "user.email", "canonical@example.com")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "config", "user.name", "Canonical Test")
+	if err := os.WriteFile(filepath.Join(parentWorktree, "README.md"), []byte("parent\n"), 0644); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "add", "README.md")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "commit", "-m", "parent")
+	runGitForCanonicalRepoTest(t, "-c", "protocol.file.allow=always", "-C", parentWorktree, "submodule", "add", submoduleRemote, "libs/sub")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "commit", "-am", "add submodule")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "remote", "add", "origin", parentRemote)
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "push", "-u", "origin", "main")
+
+	submoduleCheckout := filepath.Join(parentWorktree, "libs", "sub")
+	runGitForCanonicalRepoTest(t, "-C", submoduleCheckout, "config", "user.email", "canonical@example.com")
+	runGitForCanonicalRepoTest(t, "-C", submoduleCheckout, "config", "user.name", "Canonical Test")
+	if err := os.WriteFile(filepath.Join(submoduleCheckout, "unpublished.txt"), []byte("unpublished\n"), 0644); err != nil {
+		t.Fatalf("write unpublished submodule file: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "-C", submoduleCheckout, "add", "unpublished.txt")
+	runGitForCanonicalRepoTest(t, "-C", submoduleCheckout, "commit", "-m", "unpublished")
+	pinnedCommit := gitOutputForCanonicalRepoTest(t, "-C", submoduleCheckout, "rev-parse", "HEAD")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "add", "libs/sub")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "commit", "-m", "pin unpublished submodule")
+	runGitForCanonicalRepoTest(t, "-C", parentWorktree, "push", "origin", "main")
+
+	return parentRemote, submoduleCheckout, pinnedCommit
 }

--- a/internal/rig/canonical_repo_test.go
+++ b/internal/rig/canonical_repo_test.go
@@ -1,0 +1,217 @@
+package rig
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+func TestRegisterRigBootstrapsCanonicalTopologyWithoutTouchingExistingWIP(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	remote := createTestGitRepoForRig(t, "adopt-source")
+
+	rigName := "adopted"
+	rigPath := filepath.Join(root, rigName)
+	mayorPath := filepath.Join(rigPath, "mayor", "rig")
+	polecatPath := filepath.Join(rigPath, "polecats", "worker", rigName)
+	if err := os.MkdirAll(filepath.Dir(mayorPath), 0755); err != nil {
+		t.Fatalf("create Mayor parent: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "clone", remote, mayorPath)
+	if err := os.MkdirAll(filepath.Dir(polecatPath), 0755); err != nil {
+		t.Fatalf("create polecat parent: %v", err)
+	}
+	runGitForCanonicalRepoTest(t, "-C", mayorPath, "worktree", "add", "-b", "polecat/worker", polecatPath)
+
+	if err := os.WriteFile(filepath.Join(mayorPath, "README.md"), []byte("Mayor WIP\n"), 0644); err != nil {
+		t.Fatalf("write Mayor WIP: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorPath, "mayor-untracked.txt"), []byte("keep Mayor bytes\n"), 0644); err != nil {
+		t.Fatalf("write Mayor untracked WIP: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(polecatPath, "README.md"), []byte("Polecat WIP\n"), 0644); err != nil {
+		t.Fatalf("write polecat WIP: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(polecatPath, "polecat-untracked.txt"), []byte("keep polecat bytes\n"), 0644); err != nil {
+		t.Fatalf("write polecat untracked WIP: %v", err)
+	}
+
+	if err := manager.saveRigConfig(rigPath, &RigConfig{
+		Type:          "rig",
+		Version:       CurrentRigConfigVersion,
+		Name:          rigName,
+		GitURL:        remote,
+		LocalRepo:     mayorPath,
+		DefaultBranch: "main",
+		CreatedAt:     time.Now(),
+		Beads:         &BeadsConfig{Prefix: "adp"},
+	}); err != nil {
+		t.Fatalf("write adopted config: %v", err)
+	}
+
+	before := snapshotCanonicalRepoTestTrees(t, map[string]string{
+		"mayor":   mayorPath,
+		"polecat": polecatPath,
+	})
+
+	result, err := manager.RegisterRig(RegisterRigOptions{Name: rigName})
+	if err != nil {
+		t.Fatalf("RegisterRig: %v", err)
+	}
+	if !result.FromConfig {
+		t.Fatal("RegisterRig did not use the existing adopted-rig config")
+	}
+	if result.DefaultBranch != "main" {
+		t.Fatalf("default branch = %q, want main", result.DefaultBranch)
+	}
+
+	assertCanonicalRepoTopology(t, rigPath, remote, "main")
+	after := snapshotCanonicalRepoTestTrees(t, map[string]string{
+		"mayor":   mayorPath,
+		"polecat": polecatPath,
+	})
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("canonical bootstrap changed Mayor or polecat WIP\nbefore: %#v\nafter:  %#v", before, after)
+	}
+
+	second, err := EnsureCanonicalRepoTopology(rigPath)
+	if err != nil {
+		t.Fatalf("second EnsureCanonicalRepoTopology: %v", err)
+	}
+	if second.BareRepoCreated || second.RefineryWorktreeCreated {
+		t.Fatalf("idempotent ensure reported new topology: %+v", second)
+	}
+	if got := snapshotCanonicalRepoTestTrees(t, map[string]string{
+		"mayor":   mayorPath,
+		"polecat": polecatPath,
+	}); !reflect.DeepEqual(before, got) {
+		t.Fatalf("idempotent ensure changed Mayor or polecat WIP\nbefore: %#v\nafter:  %#v", before, got)
+	}
+}
+
+func TestEnsureCanonicalRepoTopologyRestoresMissingRefineryWorktree(t *testing.T) {
+	remote := createTestGitRepoForRig(t, "refinery-source")
+	rigPath := filepath.Join(t.TempDir(), "repair")
+	manager := NewManager(filepath.Dir(rigPath), nil, git.NewGit(filepath.Dir(rigPath)))
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("create rig: %v", err)
+	}
+	if err := manager.saveRigConfig(rigPath, &RigConfig{
+		Type:          "rig",
+		Version:       CurrentRigConfigVersion,
+		Name:          "repair",
+		GitURL:        remote,
+		DefaultBranch: "main",
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("write rig config: %v", err)
+	}
+
+	barePath := filepath.Join(rigPath, ".repo.git")
+	if err := git.NewGit(rigPath).CloneBareWithBranch(remote, barePath, "main"); err != nil {
+		t.Fatalf("create existing bare repo: %v", err)
+	}
+
+	result, err := EnsureCanonicalRepoTopology(rigPath)
+	if err != nil {
+		t.Fatalf("EnsureCanonicalRepoTopology: %v", err)
+	}
+	if result.BareRepoCreated {
+		t.Fatal("existing bare repository was reported as newly created")
+	}
+	if !result.RefineryWorktreeCreated {
+		t.Fatal("missing refinery worktree was not reported as restored")
+	}
+	assertCanonicalRepoTopology(t, rigPath, remote, "main")
+}
+
+func assertCanonicalRepoTopology(t *testing.T, rigPath, remote, branch string) {
+	t.Helper()
+	barePath := filepath.Join(rigPath, ".repo.git")
+	bareGit := git.NewGitWithDir(barePath, "")
+	if err := bareGit.ValidateBareRepository(); err != nil {
+		t.Fatalf("bare repo invalid: %v", err)
+	}
+	if got, err := bareGit.RemoteURL("origin"); err != nil || got != remote {
+		t.Fatalf("origin = %q, %v; want %q", got, err, remote)
+	}
+	if got, err := bareGit.ConfigGet("remote.origin.fetch"); err != nil || got != CanonicalBareFetchRefspec {
+		t.Fatalf("origin refspec = %q, %v; want %q", got, err, CanonicalBareFetchRefspec)
+	}
+	if exists, err := bareGit.RemoteTrackingBranchExists("origin", branch); err != nil || !exists {
+		t.Fatalf("origin/%s exists = %v, %v", branch, exists, err)
+	}
+
+	refineryPath := filepath.Join(rigPath, "refinery", "rig")
+	gitInfo, err := os.Stat(filepath.Join(refineryPath, ".git"))
+	if err != nil {
+		t.Fatalf("refinery worktree .git: %v", err)
+	}
+	if !gitInfo.Mode().IsRegular() {
+		t.Fatal("refinery/rig .git is not a worktree link")
+	}
+	if got, err := git.NewGit(refineryPath).CurrentBranch(); err != nil || got != branch {
+		t.Fatalf("refinery branch = %q, %v; want %q", got, err, branch)
+	}
+}
+
+func snapshotCanonicalRepoTestTrees(t *testing.T, roots map[string]string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	for label, root := range roots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			key := filepath.Join(label, rel)
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				snapshot[key] = "dir:" + info.Mode().String()
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				target, err := os.Readlink(path)
+				if err != nil {
+					return err
+				}
+				snapshot[key] = "symlink:" + target
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			hash := sha256.Sum256(data)
+			snapshot[key] = fmt.Sprintf("%s:%x", info.Mode(), hash)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("snapshot %s: %v", label, err)
+		}
+	}
+	return snapshot
+}
+
+func runGitForCanonicalRepoTest(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1031,6 +1031,10 @@ func (m *Manager) verifyRigIdentity(rigPath, rigName string) error {
 
 // saveRigConfig writes the rig configuration to config.json.
 func (m *Manager) saveRigConfig(rigPath string, cfg *RigConfig) error {
+	return saveRigConfigFile(rigPath, cfg)
+}
+
+func saveRigConfigFile(rigPath string, cfg *RigConfig) error {
 	configPath := filepath.Join(rigPath, "config.json")
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -1701,92 +1705,53 @@ func (m *Manager) RegisterRig(opts RegisterRigOptions) (*RegisterRigResult, erro
 	}
 
 	// Determine push URL: explicit option > existing config > auto-detect from remotes.
-	// Only explicit option and config.json with non-empty push_url are "authoritative"
-	// (trusted for clearing decisions). Auto-detection runs when no authoritative source
-	// provides a push URL — this covers both fresh adopts and legacy configs that predate
-	// the push_url feature. Auto-detection may fail silently (returns empty on git errors)
-	// and must not trigger stale URL clearing.
+	// Detection happens before canonical bootstrap so legacy Mayor clones can provide
+	// the value without being modified.
 	pushURL := ""
-	pushURLAuthoritative := false // whether the source can be trusted for clearing decisions
 	if opts.PushURL != "" {
 		pushURL = opts.PushURL
-		pushURLAuthoritative = true
 	} else if existingConfig != nil && existingConfig.PushURL != "" {
-		// Config.json has an explicit push URL — use it as authoritative
 		pushURL = existingConfig.PushURL
-		pushURLAuthoritative = true
 	} else {
-		// No authoritative push URL source: either no config.json (fresh adopt) or
-		// legacy config without push_url field. Auto-detect from existing git remotes.
 		pushURL = m.detectPushURL(rigPath)
-		// Not authoritative — only use for positive detection, never for clearing
 	}
 
-	// Apply push URL to existing repos (mirrors AddRig behavior).
-	bareRepoPath := filepath.Join(rigPath, ".repo.git")
-	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
-	if pushURL != "" {
-		if _, err := os.Stat(bareRepoPath); err == nil {
-			bareGit := git.NewGitWithDir(bareRepoPath, "")
-			if cfgErr := bareGit.ConfigurePushURL("origin", pushURL); cfgErr != nil {
-				return nil, fmt.Errorf("configuring push URL on bare repo: %w", cfgErr)
-			}
-		}
-		if _, err := os.Stat(mayorRigPath); err == nil {
-			mayorGit := git.NewGit(mayorRigPath)
-			if cfgErr := mayorGit.ConfigurePushURL("origin", pushURL); cfgErr != nil {
-				return nil, fmt.Errorf("configuring mayor push URL: %w", cfgErr)
-			}
-		}
-	} else if pushURLAuthoritative {
-		// Clear stale push URLs only when an authoritative source says "no push URL".
-		// Auto-detection returning empty could be a git error — don't clear in that case.
-		// Note: currently unreachable — authoritative sources always set non-empty pushURL.
-		// Retained for future --no-push-url flag support.
-		if _, err := os.Stat(bareRepoPath); err == nil {
-			bareGit := git.NewGitWithDir(bareRepoPath, "")
-			if clrErr := bareGit.ClearPushURL("origin"); clrErr != nil {
-				return nil, fmt.Errorf("clearing stale push URL on bare repo: %w", clrErr)
-			}
-		}
-		if _, err := os.Stat(mayorRigPath); err == nil {
-			mayorGit := git.NewGit(mayorRigPath)
-			if clrErr := mayorGit.ClearPushURL("origin"); clrErr != nil {
-				return nil, fmt.Errorf("clearing stale mayor push URL: %w", clrErr)
-			}
-		}
+	upstreamURL := opts.UpstreamURL
+	if upstreamURL == "" && existingConfig != nil {
+		upstreamURL = existingConfig.UpstreamURL
 	}
 
-	// Sync push URL to config.json so doctor check sees it
-	if existingConfig != nil && existingConfig.PushURL != pushURL {
-		existingConfig.PushURL = pushURL
-		if saveErr := m.saveRigConfig(rigPath, existingConfig); saveErr != nil {
-			// Non-fatal: town.json has the value, but doctor may flag a mismatch
-			fmt.Fprintf(os.Stderr, "Warning: could not update config.json with push URL: %v\n", saveErr)
-		}
+	effectiveConfig := &RigConfig{}
+	if existingConfig != nil {
+		copied := *existingConfig
+		effectiveConfig = &copied
+	}
+	effectiveConfig.Type = "rig"
+	effectiveConfig.Version = CurrentRigConfigVersion
+	effectiveConfig.Name = opts.Name
+	effectiveConfig.GitURL = result.GitURL
+	effectiveConfig.PushURL = pushURL
+	effectiveConfig.UpstreamURL = upstreamURL
+	if effectiveConfig.CreatedAt.IsZero() {
+		effectiveConfig.CreatedAt = time.Now()
+	}
+	effectiveConfig.Beads = &BeadsConfig{Prefix: result.BeadsPrefix}
+	if err := m.saveRigConfig(rigPath, effectiveConfig); err != nil {
+		return nil, fmt.Errorf("saving adopted rig config: %w", err)
 	}
 
-	// Configure upstream remote if provided (for fork workflows)
-	if opts.UpstreamURL != "" {
-		if _, err := os.Stat(bareRepoPath); err == nil {
-			bareGit := git.NewGitWithDir(bareRepoPath, "")
-			if upErr := bareGit.AddUpstreamRemote(opts.UpstreamURL); upErr != nil {
-				return nil, fmt.Errorf("configuring upstream remote on bare repo: %w", upErr)
-			}
-		}
-		if _, err := os.Stat(mayorRigPath); err == nil {
-			mayorGit := git.NewGit(mayorRigPath)
-			if upErr := mayorGit.AddUpstreamRemote(opts.UpstreamURL); upErr != nil {
-				return nil, fmt.Errorf("configuring mayor upstream remote: %w", upErr)
-			}
-		}
+	topology, err := EnsureCanonicalRepoTopology(rigPath)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrapping canonical repository topology: %w", err)
 	}
+	result.DefaultBranch = topology.DefaultBranch
 
 	// Register in town config
 	m.config.Rigs[opts.Name] = config.RigEntry{
 		GitURL:      result.GitURL,
 		PushURL:     pushURL,
-		UpstreamURL: opts.UpstreamURL,
+		UpstreamURL: upstreamURL,
+		LocalRepo:   effectiveConfig.LocalRepo,
 		AddedAt:     time.Now(),
 		BeadsConfig: &config.BeadsConfig{
 			Prefix: result.BeadsPrefix,

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1549,10 +1549,10 @@ func TestRegisterRig_DetectsAndPersistsCustomPushURL(t *testing.T) {
 		t.Fatalf("mkdir rig path: %v", err)
 	}
 
-	upstreamURL := filepath.Join(root, "upstream.git")
+	upstreamURL := createTestGitRepoForRig(t, "upstream")
 	forkURL := filepath.Join(root, "fork.git")
 
-	for _, args := range [][]string{{"git", "init", "--bare", upstreamURL}, {"git", "init", "--bare", forkURL}} {
+	for _, args := range [][]string{{"git", "init", "--bare", forkURL}} {
 		cmd := exec.Command(args[0], args[1:]...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("%v failed: %v\n%s", args, err, string(out))
@@ -1600,11 +1600,7 @@ func TestRegisterRig_DetectPushURLEmptyWhenPushEqualsFetch(t *testing.T) {
 		t.Fatalf("mkdir rig path: %v", err)
 	}
 
-	url := filepath.Join(root, "upstream-same.git")
-	cmd := exec.Command("git", "init", "--bare", url)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("init bare repo failed: %v\n%s", err, string(out))
-	}
+	url := createTestGitRepoForRig(t, "upstream-same")
 
 	cmds := [][]string{
 		{"git", "init", "--initial-branch=main"},
@@ -1639,11 +1635,7 @@ func TestDetectGitURL_MayorRigFallback(t *testing.T) {
 	rigPath := filepath.Join(root, rigName)
 
 	// Create mayor/rig as a clone (but do NOT create a git repo at rigPath itself)
-	upstreamURL := filepath.Join(root, "detect-upstream.git")
-	cmd := exec.Command("git", "init", "--bare", upstreamURL)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("init bare repo failed: %v\n%s", err, string(out))
-	}
+	upstreamURL := createTestGitRepoForRig(t, "detect-upstream")
 	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
 	if err := os.MkdirAll(filepath.Dir(mayorRigPath), 0755); err != nil {
 		t.Fatalf("mkdir mayor dir: %v", err)
@@ -1674,9 +1666,9 @@ func TestRegisterRig_LegacyConfigPreservesExistingPushURL(t *testing.T) {
 	rigName := "legacyrig"
 	rigPath := filepath.Join(root, rigName)
 
-	upstreamURL := filepath.Join(root, "upstream-legacy.git")
+	upstreamURL := createTestGitRepoForRig(t, "upstream-legacy")
 	forkURL := filepath.Join(root, "fork-legacy.git")
-	for _, u := range []string{upstreamURL, forkURL} {
+	for _, u := range []string{forkURL} {
 		cmd := exec.Command("git", "init", "--bare", u)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("init bare repo %s failed: %v\n%s", u, err, string(out))

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Fixture subprocesses must inherit the test-controlled PATH. Operator shell
+# startup hooks can otherwise replace it and make the harness call live tools.
+unset BASH_ENV ENV
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$ROOT_DIR/plugins/stuck-agent-dog/run.sh"
 ORIGINAL_PATH="$PATH"


### PR DESCRIPTION
## Summary

- add one rig-owned recovery path for the canonical shared bare repository and dedicated Refinery worktree
- route adopted-rig registration, doctor repair, and Refinery startup through that owner, with no Mayor-clone fallback
- preserve active Mayor and polecat work while restoring origin/refspec/integration-branch invariants
- refresh and fast-forward existing canonical topology so a forward parent/gitlink repair can unblock retry
- keep recursive-submodule retries fail-closed after a partial first checkout
- document the recovered topology and harden two ambient-environment test fixtures discovered during validation

## Validation

- `go test ./internal/rig -run '^(TestEnsureCanonicalRepoTopologyRestoresMissingRefineryWorktree|TestEnsureCanonicalRepoTopologyRetriesAfterForwardSubmoduleRepair)$' -count=1 -v` — pass; covers both missing-worktree ref advance and existing-worktree forward repair
- `go test ./internal/git ./internal/rig ./internal/doctor ./internal/refinery -count=1` — pass (`33.462s`, `12.936s`, `19.054s`, `136.498s`)
- `go vet ./...` — pass
- `make build` — pass; all three binaries built with `BuiltProperly=1`
- inherited-environment stuck-agent-dog harness — 93 passed, 0 failed
- repository-wide `make test` is not green: shell gates pass, while the Go run collided with concurrent shared Dolt/tmux state across active Gas Town worktrees. Exact failures and follow-up tracking are recorded on `gtf-ye6`; this PR does not claim a full-suite pass.

## Live FLEXT evidence

- canonical `.repo.git` and `refinery/rig` were created on configured branch `0.12.0-dev`, with the correct origin and fetch refspec
- Git-semantic byte snapshots of Mayor and all three polecat umbrellas, including recursive submodules and untracked files, matched exactly before and after recovery attempts
- the new built CLI rejects both the first partial checkout and subsequent retries while the pinned submodule object is unavailable; no Mayor fallback occurs
- merge-queue read succeeds (`null`, queue length zero)
- an older installed lifecycle later auto-restarted `flext-refinery` from the canonical directory and status/session health report running/healthy, but recursive `git submodule status` contains `+` mismatches (including `flext-api` at `70f80b...` while the parent pins absent `a2a3fbb...`). That process is not valid acceptance of this change.

The PR remains draft because FLEXT integration commit `09a4199...` pins `flext-api` at `a2a3fbb...`, which is absent from GitHub and every known local clone (`not our ref`; GitHub HTTP 422). The repository-integrity repair is tracked as P0 `flext-zab8b` and escalated as `hq-wisp-51k6lu`. Once FLEXT advances the parent branch with a reachable gitlink (or restores the exact object), the tested canonical retry path can fast-forward and complete live Refinery acceptance.

Tracking: gtf-ye6
