### PR TITLE
fix: converge agent bead identity across ledgers

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -46,6 +46,10 @@ created there by older releases. State and patrol-await commands write back to
 the ledger that supplied the winning identity rather than assuming the caller's
 current ledger.
 
+Within the same ledger and storage class, a record whose structured `role_type`
+and `rig` fields match outranks an ID-only compatibility match. Equal-confidence
+duplicates remain an error so ambiguous lifecycle state cannot be mutated.
+
 | Agent Type | Scope | Bead Location | Bead ID Format |
 |------------|-------|---------------|----------------|
 | Mayor | Town | `~/gt/.beads/` | `hq-mayor` |

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -34,6 +34,18 @@ Project chain for implementation work:
 Agent beads track lifecycle state for each agent. Storage location depends on
 the agent's scope.
 
+Every durable agent identity uses `issue_type=agent` together with the
+`gt:agent` label. The only supported migration form is the former
+`issue_type=task` plus `gt:agent` representation; `gt doctor --fix` updates that
+record in place so its lifecycle fields, labels, and history remain attached to
+the same identity.
+
+For rig-scoped roles, resolution checks the registered rig ledger first and the
+town ledger second. The town lookup is a compatibility boundary for identities
+created there by older releases. State and patrol-await commands write back to
+the ledger that supplied the winning identity rather than assuming the caller's
+current ledger.
+
 | Agent Type | Scope | Bead Location | Bead ID Format |
 |------------|-------|---------------|----------------|
 | Mayor | Town | `~/gt/.beads/` | `hq-mayor` |

--- a/internal/beads/agent_ids.go
+++ b/internal/beads/agent_ids.go
@@ -47,8 +47,8 @@ var ValidAgentRoles = []string{
 	"dog",                  // Town-level with name: gt-dog-<name>
 	constants.RoleWitness,  // Per-rig: gt-<rig>-witness
 	constants.RoleRefinery, // Per-rig: gt-<rig>-refinery
-	constants.RoleCrew,    // Per-rig with name: gt-<rig>-crew-<name>
-	constants.RolePolecat, // Per-rig with name: gt-<rig>-polecat-<name>
+	constants.RoleCrew,     // Per-rig with name: gt-<rig>-crew-<name>
+	constants.RolePolecat,  // Per-rig with name: gt-<rig>-polecat-<name>
 }
 
 // TownLevelRoles are agent roles that don't have a rig.
@@ -371,9 +371,8 @@ func PolecatBeadID(rig, name string) string {
 //   - "ff-polecat-nux" → rig="ff", role="polecat", name="nux"
 func ParseAgentBeadID(id string) (rig, role, name string, ok bool) {
 	// Find the prefix (everything before the first hyphen)
-	// Valid prefixes are 2-3 characters (e.g., "gt", "bd", "hq")
 	hyphenIdx := strings.Index(id, "-")
-	if hyphenIdx < 2 || hyphenIdx > 3 {
+	if hyphenIdx <= 0 || !prefixRe.MatchString(id[:hyphenIdx]) {
 		return "", "", "", false
 	}
 

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -30,6 +30,15 @@ var (
 	ErrFlagTitle    = errors.New("title looks like a CLI flag (starts with '-'); use --title=\"...\" to set flag-like titles intentionally")
 )
 
+// Agent bead identity contract. AgentIssueType and AgentLabel are both
+// required on newly-created agent beads. Legacy task+gt:agent records remain
+// recognizable only long enough for doctor to migrate them in place.
+const (
+	AgentIssueType       = "agent"
+	LegacyAgentIssueType = "task"
+	AgentLabel           = "gt:agent"
+)
+
 // bdAllowStale caches whether the installed bd supports --allow-stale.
 // The cache is keyed by the resolved bd path so tests and subprocess stubs that
 // replace bd on PATH get re-probed instead of reusing stale capability state.
@@ -317,19 +326,32 @@ func HasUncheckedCriteria(issue *Issue) int {
 	return count
 }
 
-// IsAgentBead checks if an issue is an agent bead by checking for the gt:agent
-// label (preferred) or the legacy type == "agent" field. This handles the migration
-// from type-based to label-based agent identification (see gt-vja7b).
+// IsAgentBead reports whether issue satisfies the canonical agent identity
+// predicate or its single supported migration form. Arbitrary issue types with
+// a gt:agent label are not agent beads.
 func IsAgentBead(issue *Issue) bool {
 	if issue == nil {
 		return false
 	}
-	// Check legacy type field first for backward compatibility
-	if issue.Type == "agent" {
-		return true
-	}
-	// Check for gt:agent label (current standard)
-	return HasLabel(issue, "gt:agent")
+	issueType := strings.ToLower(strings.TrimSpace(issue.Type))
+	return issueType == AgentIssueType ||
+		(issueType == LegacyAgentIssueType && HasLabel(issue, AgentLabel))
+}
+
+// IsCanonicalAgentBead reports whether issue has the complete durable agent
+// identity: the canonical type and label.
+func IsCanonicalAgentBead(issue *Issue) bool {
+	return issue != nil &&
+		strings.EqualFold(strings.TrimSpace(issue.Type), AgentIssueType) &&
+		HasLabel(issue, AgentLabel)
+}
+
+// IsLegacyAgentBead reports whether issue is the sole supported pre-migration
+// representation for an agent bead.
+func IsLegacyAgentBead(issue *Issue) bool {
+	return issue != nil &&
+		strings.EqualFold(strings.TrimSpace(issue.Type), LegacyAgentIssueType) &&
+		HasLabel(issue, AgentLabel)
 }
 
 // IsProtectedBead checks if a bead has any protection labels that should
@@ -527,6 +549,7 @@ type CreateOptions struct {
 // UpdateOptions specifies options for updating an issue.
 type UpdateOptions struct {
 	Title        *string
+	Type         *string
 	Status       *string
 	Priority     *int
 	Description  *string
@@ -632,6 +655,24 @@ func (b *Beads) agentBeadTarget() *Beads {
 		return b
 	}
 	return b.ForAgentBead()
+}
+
+// pinnedToCurrentLedger returns a wrapper that operates on b's configured
+// ledger without applying issue-prefix routing. This is used for in-place
+// repairs discovered while explicitly scanning a town or rig ledger.
+func (b *Beads) pinnedToCurrentLedger() *Beads {
+	if b.noRoute {
+		return b
+	}
+	return &Beads{
+		workDir:    b.workDir,
+		beadsDir:   b.beadsDir,
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+		store:      b.store,
+		townRoot:   b.townRoot,
+		noRoute:    true,
+	}
 }
 
 // getActor returns the BD_ACTOR value for this context.
@@ -1978,6 +2019,9 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 
 	if opts.Title != nil {
 		args = append(args, "--title="+*opts.Title)
+	}
+	if opts.Type != nil {
+		args = append(args, "--type="+*opts.Type)
 	}
 	if opts.Status != nil {
 		args = append(args, "--status="+*opts.Status)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -657,10 +657,10 @@ func (b *Beads) agentBeadTarget() *Beads {
 	return b.ForAgentBead()
 }
 
-// pinnedToCurrentLedger returns a wrapper that operates on b's configured
+// ForCurrentLedger returns a wrapper that operates on b's configured
 // ledger without applying issue-prefix routing. This is used for in-place
 // repairs discovered while explicitly scanning a town or rig ledger.
-func (b *Beads) pinnedToCurrentLedger() *Beads {
+func (b *Beads) ForCurrentLedger() *Beads {
 	if b.noRoute {
 		return b
 	}

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -235,8 +235,8 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 			"--id=" + id,
 			"--title=" + title,
 			"--description=" + description,
-			"--type=task",
-			"--labels=gt:agent",
+			"--type=" + AgentIssueType,
+			"--labels=" + AgentLabel,
 		}
 		if NeedsForceForID(id) {
 			a = append(a, "--force")
@@ -283,11 +283,11 @@ func (b *Beads) createAgentBeadViaStore(ctx context.Context, id, title, descript
 		Description: description,
 		Status:      beadsdk.StatusOpen,
 		Priority:    2,
-		IssueType:   beadsdk.TypeTask,
+		IssueType:   beadsdk.IssueType(AgentIssueType),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 		CreatedBy:   actor,
-		Labels:      []string{"gt:agent"},
+		Labels:      []string{AgentLabel},
 	}
 	if err := store.CreateIssue(ctx, issue, actor); err != nil {
 		return nil, err
@@ -350,12 +350,12 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 		}
 	}
 
-	// Update the bead with new fields and ensure gt:agent label is set.
-	// Agent beads use type=task (a valid built-in type) and are identified
-	// by the gt:agent label, not by type (see IsAgentBead).
+	// Update the bead with new fields and restore its canonical identity.
 	description := FormatAgentDescription(title, fields)
+	issueType := AgentIssueType
 	updateOpts := UpdateOptions{
 		Title:       &title,
+		Type:        &issueType,
 		Description: &description,
 		SetLabels:   labelsForAgentBeadReuse(existing.Labels),
 	}
@@ -371,8 +371,8 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 }
 
 func labelsForAgentBeadReuse(existing []string) []string {
-	labels := []string{"gt:agent"}
-	seen := map[string]bool{"gt:agent": true}
+	labels := []string{AgentLabel}
+	seen := map[string]bool{AgentLabel: true}
 	for _, label := range existing {
 		if !strings.HasPrefix(label, "safety_stop:") || seen[label] {
 			continue
@@ -381,6 +381,43 @@ func labelsForAgentBeadReuse(existing []string) []string {
 		seen[label] = true
 	}
 	return labels
+}
+
+// EnsureCanonicalAgentBead migrates an agent bead in its current ledger
+// without changing any lifecycle fields, status, or existing labels. The
+// normal bd/SDK update path records the type transition in issue history.
+// It returns true when a repair was written.
+func (b *Beads) EnsureCanonicalAgentBead(issue *Issue) (bool, error) {
+	if !IsAgentBead(issue) {
+		return false, fmt.Errorf("issue %s is not an agent bead", issueID(issue))
+	}
+
+	target := b.pinnedToCurrentLedger()
+	changed := false
+	if IsLegacyAgentBead(issue) {
+		if err := EnsureCustomTypes(target.getResolvedBeadsDir()); err != nil {
+			return false, fmt.Errorf("configuring canonical agent type in %s: %w", target.getResolvedBeadsDir(), err)
+		}
+		issueType := AgentIssueType
+		if err := target.Update(issue.ID, UpdateOptions{Type: &issueType}); err != nil {
+			return false, fmt.Errorf("migrating agent bead %s to type %s: %w", issue.ID, AgentIssueType, err)
+		}
+		changed = true
+	}
+	if !HasLabel(issue, AgentLabel) {
+		if err := target.Update(issue.ID, UpdateOptions{AddLabels: []string{AgentLabel}}); err != nil {
+			return changed, fmt.Errorf("adding %s label to agent bead %s: %w", AgentLabel, issue.ID, err)
+		}
+		changed = true
+	}
+	return changed, nil
+}
+
+func issueID(issue *Issue) string {
+	if issue == nil {
+		return "<nil>"
+	}
+	return issue.ID
 }
 
 // ResetAgentBeadForReuse clears all mutable fields on an agent bead without closing it.
@@ -701,28 +738,16 @@ func (b *Beads) GetAgentBead(id string) (*Issue, *AgentFields, error) {
 	return issue, fields, nil
 }
 
-// ListAgentBeads returns all agent beads in a single query.
+// ListAgentBeads returns all agent beads from durable issues and wisps.
 // Returns a map of agent bead ID to Issue.
 //
 // Queries both the issues table (authoritative metadata source) and the
 // wisps table (fallback existence source). Issues take precedence for duplicate
 // IDs so labels/type are preserved for doctor validation.
 func (b *Beads) ListAgentBeads() (map[string]*Issue, error) {
-	// Query issues table first. Issues include labels and type metadata used by
-	// doctor checks (for example, validating gt:agent labels).
-	// Agent beads are type=agent (infrastructure), hidden by bd list default filter.
-	// Use --include-infra so they appear in results.
-	out, err := b.run("list", "--label=gt:agent", "--include-infra", "--json", "--flat", "--no-pager")
+	issuesByID, err := b.ListAgentBeadsFromIssues()
 	if err != nil {
 		return nil, err
-	}
-	issuesByID := make(map[string]*Issue)
-	var issues []*Issue
-	if jsonErr := json.Unmarshal(out, &issues); jsonErr != nil {
-		return nil, fmt.Errorf("parsing bd list --json output: %w (raw output %d bytes)", jsonErr, len(out))
-	}
-	for _, issue := range issues {
-		issuesByID[issue.ID] = issue
 	}
 
 	// Query wisps table as a fallback source.
@@ -731,6 +756,35 @@ func (b *Beads) ListAgentBeads() (map[string]*Issue, error) {
 	wispBeads, _ := b.ListAgentBeadsFromWisps()
 
 	return mergeAgentBeadSources(issuesByID, wispBeads), nil
+}
+
+// ListAgentBeadsFromIssues queries both sides of the explicit migration
+// boundary: canonical type=agent records and legacy task+gt:agent records.
+// Results are filtered through IsAgentBead so doctor and resolver share the
+// same identity predicate.
+func (b *Beads) ListAgentBeadsFromIssues() (map[string]*Issue, error) {
+	queries := [][]string{
+		{"list", "--type=" + AgentIssueType, "--include-infra", "--status=all", "--json", "--flat", "--no-pager", "--limit=0"},
+		{"list", "--label=" + AgentLabel, "--include-infra", "--status=all", "--json", "--flat", "--no-pager", "--limit=0"},
+	}
+
+	issuesByID := make(map[string]*Issue)
+	for _, args := range queries {
+		out, err := b.run(args...)
+		if err != nil {
+			return nil, err
+		}
+		var issues []*Issue
+		if err := json.Unmarshal(out, &issues); err != nil {
+			return nil, fmt.Errorf("parsing bd list --json output: %w (raw output %d bytes)", err, len(out))
+		}
+		for _, issue := range issues {
+			if IsAgentBead(issue) {
+				issuesByID[issue.ID] = issue
+			}
+		}
+	}
+	return issuesByID, nil
 }
 
 // mergeAgentBeadSources merges issue-backed and wisp-backed agent bead maps.

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -392,11 +392,13 @@ func (b *Beads) EnsureCanonicalAgentBead(issue *Issue) (bool, error) {
 		return false, fmt.Errorf("issue %s is not an agent bead", issueID(issue))
 	}
 
-	target := b.pinnedToCurrentLedger()
+	target := b.ForCurrentLedger()
 	changed := false
 	if IsLegacyAgentBead(issue) {
-		if err := EnsureCustomTypes(target.getResolvedBeadsDir()); err != nil {
-			return false, fmt.Errorf("configuring canonical agent type in %s: %w", target.getResolvedBeadsDir(), err)
+		if target.store == nil {
+			if err := EnsureCustomTypes(target.getResolvedBeadsDir()); err != nil {
+				return false, fmt.Errorf("configuring canonical agent type in %s: %w", target.getResolvedBeadsDir(), err)
+			}
 		}
 		issueType := AgentIssueType
 		if err := target.Update(issue.ID, UpdateOptions{Type: &issueType}); err != nil {

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
 )
 
 func installMockBDFixedShowOutput(t *testing.T, showOutput string) {
@@ -547,8 +550,56 @@ func TestCreateAgentBead_UsesTownRootForCrossRigRoutes(t *testing.T) {
 	if !strings.Contains(logOutput, "create --json --id=pt-imported-polecat-shiny") {
 		t.Fatalf("mock bd log missing create call:\n%s", logOutput)
 	}
+	if !strings.Contains(logOutput, "--type="+AgentIssueType) || !strings.Contains(logOutput, "--labels="+AgentLabel) {
+		t.Fatalf("create did not use canonical agent identity:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "--type="+LegacyAgentIssueType) {
+		t.Fatalf("create used legacy agent type:\n%s", logOutput)
+	}
 	// Note: hook_bead slot is no longer set — bd slot removed in v0.62 (hq-l6mm5).
 	// Work bead status=hooked and assignee=<agent> is now the authoritative source.
+}
+
+func TestEnsureCanonicalAgentBeadPreservesRecord(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+
+	store.CreateIssue(context.Background(), &beadsdk.Issue{
+		Title:       "Witness",
+		Description: "role_type: witness\nrig: gastown\nagent_state: working",
+		IssueType:   beadsdk.TypeTask,
+		Priority:    1,
+		Assignee:    "gastown/witness",
+	}, "creator")
+	store.issues["test-1"].Status = beadsdk.StatusInProgress
+	store.labels["test-1"] = []string{AgentLabel, "idle:4", "safety_stop:hq-guard"}
+
+	before, err := b.Show("test-1")
+	if err != nil {
+		t.Fatalf("Show before migration: %v", err)
+	}
+	changed, err := b.EnsureCanonicalAgentBead(before)
+	if err != nil {
+		t.Fatalf("EnsureCanonicalAgentBead: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected legacy record to be migrated")
+	}
+
+	after, err := b.Show("test-1")
+	if err != nil {
+		t.Fatalf("Show after migration: %v", err)
+	}
+	if !IsCanonicalAgentBead(after) {
+		t.Fatalf("migrated record is not canonical: %#v", after)
+	}
+	if after.Title != before.Title || after.Description != before.Description || after.Status != before.Status ||
+		after.Priority != before.Priority || after.Assignee != before.Assignee {
+		t.Fatalf("migration changed record fields: before=%#v after=%#v", before, after)
+	}
+	if strings.Join(after.Labels, ",") != strings.Join(before.Labels, ",") {
+		t.Fatalf("migration changed labels: before=%v after=%v", before.Labels, after.Labels)
+	}
 }
 
 func TestCreateAgentBead_ParsesMockCreateOutput(t *testing.T) {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -4687,8 +4687,8 @@ func TestResetAgentBeadForReuse_NukeRespawnCycle(t *testing.T) {
 	t.Log("LIFECYCLE TEST PASSED: spawn → reset → respawn works without close/reopen")
 }
 
-// TestIsAgentBead verifies the IsAgentBead function correctly identifies agent
-// beads by checking both the gt:agent label (preferred) and the legacy type field.
+// TestIsAgentBead verifies the canonical predicate and its explicit legacy
+// task+gt:agent migration boundary.
 func TestIsAgentBead(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -4701,7 +4701,7 @@ func TestIsAgentBead(t *testing.T) {
 			want:  false,
 		},
 		{
-			name: "agent with legacy type",
+			name: "canonical type is recognizable before label repair",
 			issue: &Issue{
 				ID:     "gt-gastown-polecat-toast",
 				Type:   "agent",
@@ -4726,6 +4726,15 @@ func TestIsAgentBead(t *testing.T) {
 				Labels: []string{"gt:agent", "other-label"},
 			},
 			want: true,
+		},
+		{
+			name: "other type with agent label is rejected",
+			issue: &Issue{
+				ID:     "gt-gastown-polecat-toast",
+				Type:   "bug",
+				Labels: []string{"gt:agent"},
+			},
+			want: false,
 		},
 		{
 			name: "not an agent - task type without label",
@@ -4763,6 +4772,22 @@ func TestIsAgentBead(t *testing.T) {
 				t.Errorf("IsAgentBead() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAgentBeadCanonicalPredicates(t *testing.T) {
+	canonical := &Issue{Type: AgentIssueType, Labels: []string{AgentLabel}}
+	legacy := &Issue{Type: LegacyAgentIssueType, Labels: []string{AgentLabel, "idle:2"}}
+	missingLabel := &Issue{Type: AgentIssueType}
+
+	if !IsCanonicalAgentBead(canonical) || IsLegacyAgentBead(canonical) {
+		t.Fatalf("canonical predicates disagree for %#v", canonical)
+	}
+	if !IsLegacyAgentBead(legacy) || IsCanonicalAgentBead(legacy) {
+		t.Fatalf("legacy predicates disagree for %#v", legacy)
+	}
+	if !IsAgentBead(missingLabel) || IsCanonicalAgentBead(missingLabel) {
+		t.Fatalf("type-only agent must be recognizable for label repair: %#v", missingLabel)
 	}
 }
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3177,9 +3177,13 @@ func TestParseAgentBeadID(t *testing.T) {
 		{"bd-beads-witness", "beads", "witness", "", true},            // bd prefix rig-level singleton
 		{"bd-beads-polecat-pearl", "beads", "polecat", "pearl", true}, // bd prefix rig-level named
 		{"hq-mayor", "", "mayor", "", true},                           // hq prefix town-level
+		// Prefixes follow the shared 1-20 character Beads prefix contract.
+		{"x-mayor", "", "mayor", "", true},
+		{"flext-refinery", "flext", "refinery", "", true},
+		{"CLIProxyAPI-witness", "CLIProxyAPI", "witness", "", true},
 		// Truly invalid patterns
-		{"x-mayor", "", "", "", false},    // Prefix too short (1 char)
-		{"abcd-mayor", "", "", "", false}, // Prefix too long (4 chars)
+		{"1x-mayor", "", "", "", false},                    // Prefix must start with a letter
+		{"abcdefghijklmnopqrstu-mayor", "", "", "", false}, // Prefix too long (21 chars)
 		{"", "", "", "", false},
 	}
 

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -423,6 +423,11 @@ func (b *Beads) storeUpdate(id string, opts UpdateOptions) error {
 	}
 
 	actor := b.getActor()
+	if opts.Type != nil {
+		if err := b.store.UpdateIssueType(ctx, id, *opts.Type, actor); err != nil {
+			return fmt.Errorf("store update: type for %s: %w", id, err)
+		}
+	}
 
 	// Apply updates if there are field changes
 	if len(updates) > 0 {

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -130,6 +130,19 @@ func (m *mockStorage) UpdateIssue(_ context.Context, id string, updates map[stri
 	return nil
 }
 
+func (m *mockStorage) UpdateIssueType(_ context.Context, id, issueType, _ string) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	issue, ok := m.issues[id]
+	if !ok {
+		return fmt.Errorf("issue %s not found", id)
+	}
+	issue.IssueType = beadsdk.IssueType(issueType)
+	issue.UpdatedAt = time.Now()
+	return nil
+}
+
 func (m *mockStorage) CloseIssue(_ context.Context, id, reason, actor, session string) error {
 	if m.closeErr != nil {
 		return m.closeErr
@@ -610,6 +623,20 @@ func TestStoreUpdate(t *testing.T) {
 	}
 	if store.issues["test-1"].Title != "updated" {
 		t.Fatalf("expected 'updated', got %q", store.issues["test-1"].Title)
+	}
+}
+
+func TestStoreUpdateType(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+
+	store.CreateIssue(context.Background(), &beadsdk.Issue{Title: "agent", IssueType: beadsdk.TypeTask}, "test")
+	issueType := AgentIssueType
+	if err := b.Update("test-1", UpdateOptions{Type: &issueType}); err != nil {
+		t.Fatalf("Update type: %v", err)
+	}
+	if got := string(store.issues["test-1"].IssueType); got != AgentIssueType {
+		t.Fatalf("issue type = %q, want %q", got, AgentIssueType)
 	}
 }
 

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -94,7 +94,7 @@ type agentStateResult struct {
 func runAgentState(cmd *cobra.Command, args []string) error {
 	agentBead := args[0]
 
-	beadsDir, err := resolveAgentTrackingBeadsDir()
+	beadsDir, err := resolveAgentTrackingBeadsDirForID(agentBead)
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}

--- a/internal/cmd/agent_tracking_beads.go
+++ b/internal/cmd/agent_tracking_beads.go
@@ -52,3 +52,42 @@ func resolveAgentTrackingBeadsDir() (string, error) {
 	}
 	return beadsDir, nil
 }
+
+// resolveAgentTrackingBeadsDirForID locates an agent identity across its
+// registered rig ledger and the town ledger, preferring the rig record. State
+// and await commands use the returned source so a resolver result remains
+// writable regardless of which ledger currently owns the identity.
+func resolveAgentTrackingBeadsDirForID(agentBead string) (string, error) {
+	currentBeadsDir, err := resolveAgentTrackingBeadsDir()
+	if err != nil {
+		return "", err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	rigName := ""
+	if parsedRig, _, _, ok := beads.ParseAgentBeadID(agentBead); ok {
+		rigName = parsedRig
+	}
+	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir, rigName)
+	if err != nil {
+		return "", err
+	}
+
+	matches := make([]agentBeadCandidate, 0, 1)
+	for _, candidate := range candidates {
+		if candidate.ID == agentBead {
+			matches = append(matches, candidate)
+		}
+	}
+	match, err := pickBestAgentBead(matches)
+	if err != nil {
+		return "", err
+	}
+	if match == nil {
+		return "", fmt.Errorf("agent bead not found in rig or town ledgers: %s", agentBead)
+	}
+	return match.BeadsDir, nil
+}

--- a/internal/cmd/agent_tracking_beads_test.go
+++ b/internal/cmd/agent_tracking_beads_test.go
@@ -93,6 +93,12 @@ func TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
 	bdScript := `#!/bin/sh
 printf 'cmd=%s BEADS_DIR=%s DB=%s READONLY=%s AUTO=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" "${BD_READONLY-}" "${BD_DOLT_AUTO_COMMIT-}" >> "$BD_LOG"
 case "$1" in
+  list)
+    printf '[{"id":"gt-gastown-refinery","issue_type":"agent","status":"open","labels":["gt:agent","idle:2"],"description":"role_type: refinery\\nrig: gastown"}]\n'
+    ;;
+  mol)
+    printf '{"wisps":[]}\n'
+    ;;
   show)
     printf '[{"labels":["gt:agent","idle:2"]}]\n'
     ;;
@@ -172,5 +178,64 @@ esac
 				t.Fatalf("bd mutation was not mutation pinned: %s\nfull log:\n%s", line, log)
 			}
 		}
+	}
+}
+
+func TestRunAgentStatePersistsTwoCyclesInTownFallbackLedger(t *testing.T) {
+	townRoot, rigBeads := setupAgentLedgerTown(t, "ccs", "ccs")
+	townBeads := filepath.Join(townRoot, ".beads")
+	currentWorkDir := filepath.Join(townRoot, "other", "refinery", "rig")
+	currentBeads := filepath.Join(currentWorkDir, ".beads")
+	if err := os.MkdirAll(currentBeads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := installAgentLedgerBD(t)
+	t.Setenv("TEST_RIG_BEADS", rigBeads)
+	t.Setenv("TEST_TOWN_BEADS", townBeads)
+	t.Setenv("TEST_RIG_LIST", `[]`)
+	townRecord := `[{"id":"ccs-witness","issue_type":"agent","labels":["gt:agent","idle:0"],"status":"open","description":"role_type: witness\nrig: ccs"}]`
+	t.Setenv("TEST_TOWN_LIST", townRecord)
+	t.Setenv("TEST_TOWN_SHOW", townRecord)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(currentWorkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	oldSet, oldIncr, oldDel, oldJSON := agentStateSet, agentStateIncr, agentStateDel, agentStateJSON
+	t.Cleanup(func() {
+		agentStateSet, agentStateIncr, agentStateDel, agentStateJSON = oldSet, oldIncr, oldDel, oldJSON
+	})
+	agentStateIncr, agentStateDel, agentStateJSON = "", nil, false
+	for _, cycle := range []string{"1", "2"} {
+		agentStateSet = []string{"idle=" + cycle}
+		if err := runAgentState(nil, []string{"ccs-witness"}); err != nil {
+			t.Fatalf("runAgentState cycle %s: %v", cycle, err)
+		}
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updates := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "cmd=update") {
+			continue
+		}
+		updates++
+		if !strings.Contains(line, "BEADS_DIR="+townBeads) {
+			t.Fatalf("state update escaped town source ledger: %s", line)
+		}
+	}
+	if updates != 2 {
+		t.Fatalf("town state updates = %d, want 2; log:\n%s", updates, data)
+	}
+	if strings.Contains(string(data), "cmd=create") {
+		t.Fatalf("state persistence created a patrol/identity wisp:\n%s", data)
 	}
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -48,11 +48,12 @@ const (
 )
 
 type agentBeadCandidate struct {
-	ID       string
-	Source   agentBeadSource
-	BeadsDir string
-	Status   string
-	Issue    *beads.Issue
+	ID           string
+	Source       agentBeadSource
+	BeadsDir     string
+	Status       string
+	Issue        *beads.Issue
+	IdentityRank int
 }
 
 type agentsResolveResult struct {
@@ -85,7 +86,8 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 
 	var matches []agentBeadCandidate
 	for _, candidate := range candidates {
-		if agentBeadMatches(candidate.Issue, role, rig) {
+		if identityRank, ok := agentBeadMatchRank(candidate.Issue, role, rig); ok {
+			candidate.IdentityRank = identityRank
 			matches = append(matches, candidate)
 		}
 	}
@@ -193,25 +195,30 @@ func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSou
 }
 
 func agentBeadMatches(issue *beads.Issue, role, rig string) bool {
+	_, ok := agentBeadMatchRank(issue, role, rig)
+	return ok
+}
+
+func agentBeadMatchRank(issue *beads.Issue, role, rig string) (int, bool) {
 	if issue == nil {
-		return false
+		return 0, false
 	}
 
 	fields := beads.ParseAgentFields(issue.Description)
 	if fields.RoleType == role {
 		if rig == "" || fields.Rig == rig {
-			return true
+			return 0, true
 		}
 	}
 
 	idRig, idRole, _, ok := beads.ParseAgentBeadID(issue.ID)
 	if !ok || idRole != role {
-		return false
+		return 0, false
 	}
 	if rig == "" {
-		return idRig == ""
+		return 1, idRig == ""
 	}
-	return idRig == rig
+	return 1, idRig == rig
 }
 
 func pickBestAgentBead(candidates []agentBeadCandidate) (*agentBeadCandidate, error) {
@@ -232,13 +239,17 @@ func pickBestAgentBead(candidates []agentBeadCandidate) (*agentBeadCandidate, er
 		if leftRank != rightRank {
 			return leftRank < rightRank
 		}
+		if open[i].IdentityRank != open[j].IdentityRank {
+			return open[i].IdentityRank < open[j].IdentityRank
+		}
 		return open[i].ID < open[j].ID
 	})
 
-	bestRank := agentBeadSourceRank(open[0].Source)
+	bestSourceRank := agentBeadSourceRank(open[0].Source)
+	bestIdentityRank := open[0].IdentityRank
 	var sameRank []string
 	for _, candidate := range open {
-		if agentBeadSourceRank(candidate.Source) != bestRank {
+		if agentBeadSourceRank(candidate.Source) != bestSourceRank || candidate.IdentityRank != bestIdentityRank {
 			break
 		}
 		sameRank = append(sameRank, candidate.ID)

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -78,7 +78,7 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir)
+	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir, rig)
 	if err != nil {
 		return err
 	}
@@ -108,10 +108,6 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 		}
 		return fmt.Errorf("%s", message)
 	}
-	if rig != "" && agentBeadSourceIsTown(match.Source) && !agentsResolveJSON {
-		return fmt.Errorf("agent bead %s was found only in %s; patrol await/state commands require a rig-local agent bead", match.ID, match.Source)
-	}
-
 	if agentsResolveJSON {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(agentsResolveResult{
 			ID:       match.ID,
@@ -125,21 +121,31 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func findAgentBeadCandidates(cwd, currentBeadsDir string) ([]agentBeadCandidate, error) {
+func findAgentBeadCandidates(cwd, currentBeadsDir, requestedRig string) ([]agentBeadCandidate, error) {
 	var candidates []agentBeadCandidate
+	townRoot := beads.FindTownRoot(cwd)
 
-	rigCandidates, err := loadAgentBeadsFromDir(currentBeadsDir, agentSourceRigIssues, agentSourceRigWisps)
+	// --rig selects the registered rig's ledger, not merely a filter over the
+	// caller's current ledger. This lets town-level patrol launchers resolve a
+	// Witness or Refinery identity stored in any registered rig.
+	rigBeadsDir := currentBeadsDir
+	if requestedRig != "" && townRoot != "" {
+		if resolved, ok := beads.ResolveRepoAliasBeadsDir(townRoot, requestedRig); ok {
+			rigBeadsDir = resolved
+		}
+	}
+
+	rigCandidates, err := loadAgentBeadsFromDir(rigBeadsDir, agentSourceRigIssues, agentSourceRigWisps)
 	if err != nil {
 		return nil, err
 	}
 	candidates = append(candidates, rigCandidates...)
 
-	townRoot := beads.FindTownRoot(cwd)
 	if townRoot == "" {
 		return candidates, nil
 	}
 	townBeadsDir := beads.ResolveBeadsDir(beads.GetTownBeadsPath(townRoot))
-	if townBeadsDir == "" || filepath.Clean(townBeadsDir) == filepath.Clean(currentBeadsDir) {
+	if townBeadsDir == "" || filepath.Clean(townBeadsDir) == filepath.Clean(rigBeadsDir) {
 		return candidates, nil
 	}
 
@@ -155,7 +161,7 @@ func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSou
 	db := beads.NewWithBeadsDir(filepath.Dir(beadsDir), beadsDir)
 	var candidates []agentBeadCandidate
 
-	issues, err := listAgentIssues(db)
+	issues, err := db.ListAgentBeadsFromIssues()
 	if err != nil {
 		return nil, fmt.Errorf("listing agent issues in %s: %w", beadsDir, err)
 	}
@@ -169,35 +175,21 @@ func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSou
 		})
 	}
 
-	if wisps, err := db.List(beads.ListOptions{Ephemeral: true, Label: "gt:agent", Status: "all"}); err == nil {
-		for _, wisp := range wisps {
-			candidates = append(candidates, agentBeadCandidate{
-				ID:       wisp.ID,
-				Source:   wispSource,
-				BeadsDir: beadsDir,
-				Status:   wisp.Status,
-				Issue:    wisp,
-			})
-		}
+	wisps, err := db.ListAgentBeadsFromWisps()
+	if err != nil {
+		return nil, fmt.Errorf("listing agent wisps in %s: %w", beadsDir, err)
+	}
+	for _, wisp := range wisps {
+		candidates = append(candidates, agentBeadCandidate{
+			ID:       wisp.ID,
+			Source:   wispSource,
+			BeadsDir: beadsDir,
+			Status:   wisp.Status,
+			Issue:    wisp,
+		})
 	}
 
 	return candidates, nil
-}
-
-func listAgentIssues(db *beads.Beads) ([]*beads.Issue, error) {
-	out, err := db.Run("list", "--label=gt:agent", "--include-infra", "--status=all", "--json", "--flat", "--no-pager", "--limit=0")
-	if err != nil {
-		return nil, err
-	}
-	if len(out) == 0 || !json.Valid(out) {
-		return nil, nil
-	}
-
-	var issues []*beads.Issue
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return nil, fmt.Errorf("parsing bd list output: %w", err)
-	}
-	return issues, nil
 }
 
 func agentBeadMatches(issue *beads.Issue, role, rig string) bool {
@@ -271,8 +263,4 @@ func agentBeadSourceRank(source agentBeadSource) int {
 	default:
 		return 99
 	}
-}
-
-func agentBeadSourceIsTown(source agentBeadSource) bool {
-	return source == agentSourceTownWisps || source == agentSourceTownIssues
 }

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -1,11 +1,95 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 )
+
+func installAgentLedgerBD(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+printf 'cmd=%s BEADS_DIR=%s args=%s\n' "$cmd" "${BEADS_DIR-}" "$*" >> "$AGENT_LEDGER_LOG"
+case "$cmd" in
+  version)
+    printf 'bd test\n'
+    ;;
+  list)
+    if [ "${BEADS_DIR-}" = "${TEST_RIG_BEADS-}" ]; then
+      printf '%s\n' "${TEST_RIG_LIST-[]}"
+    elif [ "${BEADS_DIR-}" = "${TEST_TOWN_BEADS-}" ]; then
+      printf '%s\n' "${TEST_TOWN_LIST-[]}"
+    else
+      printf '[]\n'
+    fi
+    ;;
+  mol)
+    printf '{"wisps":[]}\n'
+    ;;
+  show)
+    if [ "${BEADS_DIR-}" = "${TEST_RIG_BEADS-}" ]; then
+      printf '%s\n' "${TEST_RIG_SHOW-${TEST_RIG_LIST-[]}}"
+    elif [ "${BEADS_DIR-}" = "${TEST_TOWN_BEADS-}" ]; then
+      printf '%s\n' "${TEST_TOWN_SHOW-${TEST_TOWN_LIST-[]}}"
+    else
+      printf '[]\n'
+    fi
+    ;;
+  update)
+    ;;
+  *)
+    printf 'unexpected bd command: %s\n' "$cmd" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_LEDGER_LOG", logPath)
+	beads.ResetBdAllowStaleCacheForTest()
+	return logPath
+}
+
+func setupAgentLedgerTown(t *testing.T, rigName, prefix string) (townRoot, rigBeads string) {
+	t.Helper()
+	townRoot = filepath.Join(t.TempDir(), "gt")
+	rigDir := filepath.Join(townRoot, rigName, "mayor", "rig")
+	rigBeads = filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads"), rigBeads} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	route := `{"prefix":"` + prefix + `-","path":"` + rigName + `/mayor/rig"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(route), 0o644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	return townRoot, rigBeads
+}
 
 func TestAgentBeadMatchesDescriptionAndIDFallback(t *testing.T) {
 	tests := []struct {
@@ -120,6 +204,70 @@ func TestPickBestAgentBeadRejectsSameRankDuplicates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "multiple matching agent beads") {
 		t.Fatalf("error = %q, want duplicate diagnostic", err)
+	}
+}
+
+func TestFindAgentBeadCandidatesSelectsRequestedRigLedger(t *testing.T) {
+	townRoot, rigBeads := setupAgentLedgerTown(t, "ccs", "ccs")
+	currentBeads := filepath.Join(townRoot, "other", ".beads")
+	if err := os.MkdirAll(currentBeads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installAgentLedgerBD(t)
+	t.Setenv("TEST_RIG_BEADS", rigBeads)
+	t.Setenv("TEST_TOWN_BEADS", filepath.Join(townRoot, ".beads"))
+	t.Setenv("TEST_RIG_LIST", `[{"id":"ccs-witness","issue_type":"task","labels":["gt:agent","idle:2"],"status":"open","description":"role_type: witness\nrig: ccs"}]`)
+	t.Setenv("TEST_TOWN_LIST", `[{"id":"hq-mayor","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: mayor\nrig: null"}]`)
+
+	candidates, err := findAgentBeadCandidates(townRoot, currentBeads, "ccs")
+	if err != nil {
+		t.Fatalf("findAgentBeadCandidates: %v", err)
+	}
+	var matches []agentBeadCandidate
+	for _, candidate := range candidates {
+		if agentBeadMatches(candidate.Issue, "witness", "ccs") {
+			matches = append(matches, candidate)
+		}
+	}
+	match, err := pickBestAgentBead(matches)
+	if err != nil {
+		t.Fatalf("pickBestAgentBead: %v", err)
+	}
+	if match == nil || match.ID != "ccs-witness" || match.Source != agentSourceRigIssues || match.BeadsDir != rigBeads {
+		t.Fatalf("match = %#v, want ccs rig issue in %s", match, rigBeads)
+	}
+}
+
+func TestRunAgentsResolveAllowsTownFallback(t *testing.T) {
+	townRoot, rigBeads := setupAgentLedgerTown(t, "ccs", "ccs")
+	installAgentLedgerBD(t)
+	t.Setenv("TEST_RIG_BEADS", rigBeads)
+	t.Setenv("TEST_TOWN_BEADS", filepath.Join(townRoot, ".beads"))
+	t.Setenv("TEST_RIG_LIST", `[]`)
+	t.Setenv("TEST_TOWN_LIST", `[{"id":"ccs-witness","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: witness\nrig: ccs"}]`)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRole, oldRig, oldJSON, oldQuiet := agentsResolveRole, agentsResolveRig, agentsResolveJSON, agentsResolveQuiet
+	t.Cleanup(func() {
+		agentsResolveRole, agentsResolveRig, agentsResolveJSON, agentsResolveQuiet = oldRole, oldRig, oldJSON, oldQuiet
+	})
+	agentsResolveRole, agentsResolveRig, agentsResolveJSON, agentsResolveQuiet = "witness", "ccs", false, false
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := runAgentsResolve(cmd, nil); err != nil {
+		t.Fatalf("runAgentsResolve rejected town fallback: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "ccs-witness" {
+		t.Fatalf("output = %q, want ccs-witness", got)
 	}
 }
 

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -217,6 +217,45 @@ func TestPickBestAgentBeadRejectsSameRankDuplicates(t *testing.T) {
 	}
 }
 
+func TestPickBestAgentBeadPrefersStructuredIdentityOverIDFallback(t *testing.T) {
+	candidates := []agentBeadCandidate{
+		{
+			ID:     "flext-cemk3",
+			Source: agentSourceRigIssues,
+			Status: "open",
+			Issue: &beads.Issue{
+				ID:          "flext-cemk3",
+				Description: "role_type: witness\nrig: flext",
+			},
+		},
+		{
+			ID:     "flext-witness",
+			Source: agentSourceRigIssues,
+			Status: "open",
+			Issue: &beads.Issue{
+				ID:          "flext-witness",
+				Description: `role_type: witness\nrig: flext`,
+			},
+		},
+	}
+
+	var matches []agentBeadCandidate
+	for _, candidate := range candidates {
+		if identityRank, ok := agentBeadMatchRank(candidate.Issue, "witness", "flext"); ok {
+			candidate.IdentityRank = identityRank
+			matches = append(matches, candidate)
+		}
+	}
+
+	got, err := pickBestAgentBead(matches)
+	if err != nil {
+		t.Fatalf("pickBestAgentBead returned error: %v", err)
+	}
+	if got == nil || got.ID != "flext-cemk3" {
+		t.Fatalf("pickBestAgentBead picked %v, want structured flext-cemk3 identity", got)
+	}
+}
+
 func TestFindAgentBeadCandidatesSelectsRequestedRigLedger(t *testing.T) {
 	townRoot, rigBeads := setupAgentLedgerTown(t, "ccs", "ccs")
 	currentBeads := filepath.Join(townRoot, "other", ".beads")

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -128,6 +128,16 @@ func TestAgentBeadMatchesDescriptionAndIDFallback(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "registered long prefix ID fallback matches legacy metadata",
+			issue: &beads.Issue{
+				ID:          "flext-refinery",
+				Description: `role_type: refinery\nrig: flext`,
+			},
+			role: "refinery",
+			rig:  "flext",
+			want: true,
+		},
+		{
 			name: "role mismatch",
 			issue: &beads.Issue{
 				ID:          "gt-gastown-witness",

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -160,7 +160,7 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	var beadsDir string
 	if awaitEventAgentBead != "" {
 		var wdErr error
-		beadsDir, wdErr = resolveAgentTrackingBeadsDir()
+		beadsDir, wdErr = resolveAgentTrackingBeadsDirForID(awaitEventAgentBead)
 		if wdErr == nil {
 			labels, labErr := getAgentLabels(awaitEventAgentBead, beadsDir)
 			if labErr != nil {

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -582,9 +582,26 @@ func runAwaitEventBackoffTest(t *testing.T, labels []string, timeout, contextChe
 	if err != nil {
 		t.Fatalf("marshal labels: %v", err)
 	}
+	listJSON, err := json.Marshal([]map[string]any{{
+		"id":         "gt-agent",
+		"issue_type": "agent",
+		"status":     "open",
+		"labels":     labels,
+	}})
+	if err != nil {
+		t.Fatalf("marshal agent: %v", err)
+	}
 	script := fmt.Sprintf(`#!/bin/sh
 printf '%%s\n' "$*" >> %q
 case "$1" in
+list)
+cat <<'JSON'
+%s
+JSON
+;;
+mol)
+printf '{"wisps":[]}\n'
+;;
 show)
 cat <<'JSON'
 %s
@@ -597,7 +614,7 @@ exit 0
 exit 0
 ;;
 esac
-`, logPath, string(showJSON))
+`, logPath, string(listJSON), string(showJSON))
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
 		t.Fatalf("write bd stub: %v", err)
 	}

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -137,6 +137,12 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
+	if awaitSignalAgentBead != "" {
+		beadsDir, err = resolveAgentTrackingBeadsDirForID(awaitSignalAgentBead)
+		if err != nil {
+			return fmt.Errorf("resolving agent bead ledger: %w", err)
+		}
+	}
 
 	// Find town root for events file (events are always at <townRoot>/.events.jsonl)
 	townRoot, err := workspace.FindFromCwdOrError()

--- a/internal/cmd/molecule_await_signal_test.go
+++ b/internal/cmd/molecule_await_signal_test.go
@@ -351,6 +351,16 @@ func TestRunMoleculeAwaitSignalAgentBeadUsesCwdRigBeadsDirWhenBeadsDirPointsTown
 	bdScript := `#!/bin/sh
 printf 'cmd=%s BEADS_DIR=%s DB=%s READONLY=%s AUTO=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" "${BD_READONLY-}" "${BD_DOLT_AUTO_COMMIT-}" >> "$BD_LOG"
 case "$1" in
+  list)
+    if [ "${BEADS_DIR-}" = "${TEST_RIG_BEADS-}" ]; then
+      printf '[{"id":"gt-gastown-refinery","issue_type":"agent","status":"open","labels":["gt:agent","idle:0"],"description":"role_type: refinery\\nrig: gastown"}]\n'
+    else
+      printf '[]\n'
+    fi
+    ;;
+  mol)
+    printf '{"wisps":[]}\n'
+    ;;
   show)
     printf '[{"labels":["gt:agent","idle:0"]}]\n'
     ;;
@@ -368,6 +378,7 @@ esac
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("BD_LOG", logPath)
+	t.Setenv("TEST_RIG_BEADS", rigBeads)
 	t.Setenv("BEADS_DIR", townBeads)
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "town")
 	t.Setenv("BD_READONLY", "true")
@@ -420,7 +431,13 @@ esac
 		t.Fatal("fake bd was not invoked")
 	}
 
+	var sawRigDiscovery, sawTownDiscovery, sawShow, sawUpdate bool
 	for _, line := range strings.Split(log, "\n") {
+		if strings.Contains(line, "cmd=list") || strings.Contains(line, "cmd=mol") {
+			sawRigDiscovery = sawRigDiscovery || strings.Contains(line, "BEADS_DIR="+rigBeads)
+			sawTownDiscovery = sawTownDiscovery || strings.Contains(line, "BEADS_DIR="+townBeads)
+			continue
+		}
 		if !strings.Contains(line, "BEADS_DIR="+rigBeads) {
 			t.Fatalf("bd call was not pinned to rig beads %q: %s\nfull log:\n%s", rigBeads, line, log)
 		}
@@ -434,11 +451,13 @@ esac
 			t.Fatalf("bd call used inherited town database: %s\nfull log:\n%s", line, log)
 		}
 		if strings.Contains(line, "cmd=show") {
+			sawShow = true
 			if !strings.Contains(line, "READONLY=true") || !strings.Contains(line, "AUTO=off") {
 				t.Fatalf("bd read was not read-only pinned: %s\nfull log:\n%s", line, log)
 			}
 		}
 		if strings.Contains(line, "cmd=update") {
+			sawUpdate = true
 			if !strings.Contains(line, "READONLY= ") && !strings.HasSuffix(line, "READONLY= AUTO=on") {
 				t.Fatalf("bd mutation inherited read-only mode: %s\nfull log:\n%s", line, log)
 			}
@@ -446,5 +465,11 @@ esac
 				t.Fatalf("bd mutation was not auto-commit pinned: %s\nfull log:\n%s", line, log)
 			}
 		}
+	}
+	if !sawRigDiscovery || !sawTownDiscovery {
+		t.Fatalf("resolver did not scan both rig and town ledgers:\n%s", log)
+	}
+	if !sawShow || !sawUpdate {
+		t.Fatalf("await-signal did not read and update the resolved rig identity:\n%s", log)
 	}
 }

--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -75,7 +74,7 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	var missing []string
-	var missingLabel []string
+	var nonCanonical []string
 	var checked int
 
 	// Build combined sets of known agent beads from both issues and wisps tables.
@@ -115,14 +114,12 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// checkAgentBead verifies an agent bead exists (in issues or wisps table).
-	// Label checking only applies to beads found in the issues table (wisps
-	// don't expose labels in their list output).
+	// checkAgentBead verifies an agent bead exists and uses the same canonical
+	// identity predicate as the resolver.
 	checkAgentBead := func(id string) {
 		if issue, exists := allAgentBeads[id]; exists {
-			// Found in issues table — check label
-			if !beads.HasLabel(issue, "gt:agent") {
-				missingLabel = append(missingLabel, id)
+			if !beads.IsCanonicalAgentBead(issue) {
+				nonCanonical = append(nonCanonical, id)
 			}
 		} else if !allWispIDs[id] {
 			// Not in issues or wisps
@@ -137,25 +134,6 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 
 	checkAgentBead(deaconID)
 	checkAgentBead(mayorID)
-
-	if len(prefixToRig) == 0 {
-		// No rigs to check, but we still checked global agents
-		if len(missing) == 0 && len(missingLabel) == 0 {
-			return &CheckResult{
-				Name:    c.Name(),
-				Status:  StatusOK,
-				Message: fmt.Sprintf("All %d agent beads exist with gt:agent label", checked),
-			}
-		}
-		details := append(missing, missingLabel...)
-		return &CheckResult{
-			Name:    c.Name(),
-			Status:  StatusError,
-			Message: fmt.Sprintf("%d agent bead(s) missing, %d missing gt:agent label", len(missing), len(missingLabel)),
-			Details: details,
-			FixHint: "Run 'gt doctor --fix' to create missing agent beads and add labels",
-		}
-	}
 
 	// Check each rig for its agents
 	for prefix, info := range prefixToRig {
@@ -183,11 +161,11 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	if len(missing) == 0 && len(missingLabel) == 0 {
+	if len(missing) == 0 && len(nonCanonical) == 0 {
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusOK,
-			Message: fmt.Sprintf("All %d agent beads exist with gt:agent label", checked),
+			Message: fmt.Sprintf("All %d agent beads use canonical type %s with %s label", checked, beads.AgentIssueType, beads.AgentLabel),
 		}
 	}
 
@@ -204,18 +182,20 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 	return &CheckResult{
 		Name:    c.Name(),
 		Status:  StatusWarning,
-		Message: fmt.Sprintf("%d agent bead(s) missing gt:agent label", len(missingLabel)),
-		Details: missingLabel,
-		FixHint: "Run 'gt doctor --fix' to add missing labels",
+		Message: fmt.Sprintf("%d agent bead(s) require canonical type/label migration", len(nonCanonical)),
+		Details: nonCanonical,
+		FixHint: "Run 'gt doctor --fix' to migrate agent beads in place",
 	}
 }
 
-// Fix creates missing agent beads and adds gt:agent labels to beads missing them.
+// Fix creates missing agent beads and migrates existing agent identities in
+// place to the canonical type/label contract.
 func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	// Pre-load all known agent bead IDs (from both issues and wisps tables)
 	// so we can check existence without per-bead Show() calls that miss ephemeral wisps.
 	allAgentBeads := make(map[string]*beads.Issue) // from issues table
 	allWispIDs := make(map[string]bool)            // from wisps table
+	agentSources := make(map[string]*beads.Beads)  // ledger containing each issue
 
 	// Collect errors instead of failing on first — one broken rig shouldn't
 	// block fixes for all other rigs.
@@ -225,49 +205,61 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	townBeadsPath := beads.GetTownBeadsPath(ctx.TownRoot)
 	townBd := beads.New(townBeadsPath)
 
-	// Load existing town agent beads
-	if townAgents, err := townBd.ListAgentBeads(); err == nil {
-		for id, issue := range townAgents {
-			allAgentBeads[id] = issue
+	loadAgentLedger := func(db *beads.Beads, ledger string) {
+		agents, err := db.ListAgentBeads()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("listing agent beads in %s: %w", ledger, err))
+		} else {
+			for id, issue := range agents {
+				if beads.IsAgentBead(issue) {
+					changed, migrateErr := db.EnsureCanonicalAgentBead(issue)
+					if migrateErr != nil {
+						errs = append(errs, fmt.Errorf("migrating %s in %s: %w", id, ledger, migrateErr))
+					} else if changed {
+						issue.Type = beads.AgentIssueType
+						if !beads.HasLabel(issue, beads.AgentLabel) {
+							issue.Labels = append(issue.Labels, beads.AgentLabel)
+						}
+					}
+				}
+				allAgentBeads[id] = issue
+				agentSources[id] = db.ForCurrentLedger()
+			}
 		}
-	}
-	if townWisps, _ := townBd.ListWispIDs(); townWisps != nil {
-		for id := range townWisps {
-			allWispIDs[id] = true
+		if wisps, wispErr := db.ListWispIDs(); wispErr == nil {
+			for id := range wisps {
+				allWispIDs[id] = true
+			}
 		}
 	}
 
+	loadAgentLedger(townBd, "town")
+
 	// fixAgentBead ensures an agent bead exists and is open.
 	// Logic:
-	//   1. If in issues table → ensure gt:agent label
-	//   2. If in wisps table (open) → ensure gt:agent label
+	//   1. If in issues table → migrate type/label in the source ledger
+	//   2. If in wisps table (open) → preserve it in the source ledger
 	//   3. If exists but closed → REOPEN it (don't recreate)
 	//   4. If truly missing → CREATE it
 	// Uses CreateAgentBead which creates durable agent beads (not wisps)
 	// so they survive wisp GC (GH#2768).
-	// workDir is the rig directory for direct SQL fallback when bd update
-	// fails silently (e.g., legacy prefixes that can't be routed — GH#2127).
-	fixAgentBead := func(bd *beads.Beads, workDir, id, desc string, fields *beads.AgentFields) error {
+	fixAgentBead := func(bd *beads.Beads, id, desc string, fields *beads.AgentFields) error {
 		// Check issues table first
 		if issue, exists := allAgentBeads[id]; exists {
-			// In issues table — ensure it has the gt:agent label.
-			if !beads.HasLabel(issue, "gt:agent") {
-				// Try bd update first (works for well-routed beads).
-				err := bd.Update(id, beads.UpdateOptions{AddLabels: []string{"gt:agent"}})
-				if err != nil {
-					// bd update failed explicitly — fall back to direct SQL.
-					sqlErr := addLabelSQL(workDir, id, "gt:agent")
-					if sqlErr != nil {
-						return fmt.Errorf("adding gt:agent label to %s: bd update: %w; SQL fallback: %v", id, err, sqlErr)
-					}
-				}
-				// Verify the label was actually added — bd update can exit 0
-				// without modifying beads with unroutable legacy prefixes (GH#2127).
-				if err == nil && !verifyLabelAdded(workDir, id, "gt:agent") {
-					sqlErr := addLabelSQL(workDir, id, "gt:agent")
-					if sqlErr != nil {
-						return fmt.Errorf("adding gt:agent label to %s: bd update was no-op, SQL fallback: %w", id, sqlErr)
-					}
+			if !beads.IsAgentBead(issue) && allWispIDs[id] {
+				return nil // sparse wisp metadata; existence is authoritative here
+			}
+			source := agentSources[id]
+			if source == nil {
+				source = bd.ForCurrentLedger()
+			}
+			if _, err := source.EnsureCanonicalAgentBead(issue); err != nil {
+				return err
+			}
+			if strings.EqualFold(issue.Status, "closed") {
+				openStatus := "open"
+				if err := source.Update(id, beads.UpdateOptions{Status: &openStatus}); err != nil {
+					return fmt.Errorf("reopening closed agent bead %s: %w", id, err)
 				}
 			}
 			return nil
@@ -275,46 +267,18 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 
 		// Check wisps table (only open wisps are listed)
 		if allWispIDs[id] {
-			// Exists as open wisp — ensure it has gt:agent label
-			// (ListWispIDs doesn't return labels, so we need to check)
-			if issue, err := bd.Show(id); err == nil && issue != nil {
-				if !beads.HasLabel(issue, "gt:agent") {
-					_ = bd.Update(id, beads.UpdateOptions{AddLabels: []string{"gt:agent"}})
-				}
-			}
 			return nil
 		}
 
-		// Not in issues or open wisps — check if it exists but is CLOSED
-		if issue, err := bd.Show(id); err == nil && issue != nil {
-			// Bead exists but is closed — REOPEN it instead of recreating
-			if issue.Status == "closed" {
-				openStatus := "open"
-				if err := bd.Update(id, beads.UpdateOptions{Status: &openStatus}); err != nil {
-					return fmt.Errorf("reopening closed agent bead %s: %w", id, err)
-				}
-				// Also ensure it has the gt:agent label
-				if !beads.HasLabel(issue, "gt:agent") {
-					_ = bd.Update(id, beads.UpdateOptions{AddLabels: []string{"gt:agent"}})
-				}
-				return nil
-			}
-		}
-
-		// Bead truly missing — create it (CreateAgentBead handles ephemeral fallback)
+		// Bead truly missing — create a durable canonical identity.
 		if _, err := bd.CreateAgentBead(id, desc, fields); err != nil {
 			return fmt.Errorf("creating %s: %w", id, err)
 		}
-		// Also insert into wisp_labels — CreateAgentBead may create a wisp-backed
-		// bead where bd create --labels only writes to the labels table, not
-		// wisp_labels. Doctor checks query wisps via JOIN wisp_labels, so the label
-		// must exist there or the check still reports the bead as missing. See gt-3vx.
-		_ = addWispLabelSQL(workDir, id, "gt:agent")
 		return nil
 	}
 
 	deaconID := beads.DeaconBeadIDTown()
-	if err := fixAgentBead(townBd, townBeadsPath, deaconID,
+	if err := fixAgentBead(townBd, deaconID,
 		"Deacon (daemon beacon) - receives mechanical heartbeats, runs town plugins and monitoring.",
 		&beads.AgentFields{RoleType: "deacon", AgentState: "idle"},
 	); err != nil {
@@ -322,7 +286,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	}
 
 	mayorID := beads.MayorBeadIDTown()
-	if err := fixAgentBead(townBd, townBeadsPath, mayorID,
+	if err := fixAgentBead(townBd, mayorID,
 		"Mayor - global coordinator, handles cross-rig communication and escalations.",
 		&beads.AgentFields{RoleType: "mayor", AgentState: "idle"},
 	); err != nil {
@@ -361,16 +325,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	for _, info := range prefixToRig {
 		rigBeadsPath := filepath.Join(ctx.TownRoot, info.beadsPath)
 		bd := beads.New(rigBeadsPath)
-		if rigAgents, err := bd.ListAgentBeads(); err == nil {
-			for id, issue := range rigAgents {
-				allAgentBeads[id] = issue
-			}
-		}
-		if rigWisps, _ := bd.ListWispIDs(); rigWisps != nil {
-			for id := range rigWisps {
-				allWispIDs[id] = true
-			}
-		}
+		loadAgentLedger(bd, info.name)
 	}
 
 	// Fix agents for each rig
@@ -380,7 +335,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 		rigName := info.name
 
 		witnessID := beads.WitnessBeadIDWithPrefix(prefix, rigName)
-		if err := fixAgentBead(bd, rigBeadsPath, witnessID,
+		if err := fixAgentBead(bd, witnessID,
 			fmt.Sprintf("Witness for %s - monitors polecat health and progress.", rigName),
 			&beads.AgentFields{RoleType: "witness", Rig: rigName, AgentState: "idle"},
 		); err != nil {
@@ -388,7 +343,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 		}
 
 		refineryID := beads.RefineryBeadIDWithPrefix(prefix, rigName)
-		if err := fixAgentBead(bd, rigBeadsPath, refineryID,
+		if err := fixAgentBead(bd, refineryID,
 			fmt.Sprintf("Refinery for %s - processes merge queue.", rigName),
 			&beads.AgentFields{RoleType: "refinery", Rig: rigName, AgentState: "idle"},
 		); err != nil {
@@ -398,7 +353,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 		crewWorkers := listCrewWorkers(ctx.TownRoot, rigName)
 		for _, workerName := range crewWorkers {
 			crewID := beads.CrewBeadIDWithPrefix(prefix, rigName, workerName)
-			if err := fixAgentBead(bd, rigBeadsPath, crewID,
+			if err := fixAgentBead(bd, crewID,
 				fmt.Sprintf("Crew worker %s in %s - human-managed persistent workspace.", workerName, rigName),
 				&beads.AgentFields{RoleType: "crew", Rig: rigName, AgentState: "idle"},
 			); err != nil {
@@ -409,7 +364,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 		polecatWorkers := listPolecats(ctx.TownRoot, rigName)
 		for _, polecatName := range polecatWorkers {
 			polecatID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
-			if err := fixAgentBead(bd, rigBeadsPath, polecatID,
+			if err := fixAgentBead(bd, polecatID,
 				fmt.Sprintf("Polecat worker %s in %s - autonomous worker with persistent identity.", polecatName, rigName),
 				&beads.AgentFields{RoleType: "polecat", Rig: rigName, AgentState: "idle"},
 			); err != nil {
@@ -448,44 +403,6 @@ func listCrewWorkers(townRoot, rigName string) []string {
 		workers = append(workers, entry.Name())
 	}
 	return workers
-}
-
-// addLabelSQL adds a label to a bead via direct SQL INSERT.
-// This bypasses bd's prefix routing, which silently fails for beads with
-// legacy/unroutable prefixes (GH#2127).
-func addLabelSQL(workDir, beadID, label string) error {
-	escapedID := strings.ReplaceAll(beadID, "'", "''")
-	escapedLabel := strings.ReplaceAll(label, "'", "''")
-	query := fmt.Sprintf("INSERT IGNORE INTO labels (issue_id, label) VALUES ('%s', '%s')", escapedID, escapedLabel)
-	return execBdSQLWrite(workDir, query)
-}
-
-// addWispLabelSQL adds a label to a wisp bead via direct SQL INSERT into wisp_labels.
-// This is needed because bd create --labels=X only inserts into the labels table,
-// not wisp_labels. Doctor checks and bd list for wisps join on wisp_labels to resolve
-// labels, so the label must be present there for wisp-backed beads to be visible.
-// See gt-3vx.
-func addWispLabelSQL(workDir, beadID, label string) error {
-	escapedID := strings.ReplaceAll(beadID, "'", "''")
-	escapedLabel := strings.ReplaceAll(label, "'", "''")
-	query := fmt.Sprintf("INSERT IGNORE INTO wisp_labels (issue_id, label) VALUES ('%s', '%s')", escapedID, escapedLabel)
-	return execBdSQLWrite(workDir, query)
-}
-
-// verifyLabelAdded checks whether a label exists on a bead by querying labels table.
-// Returns false if the label is not found or the query fails.
-func verifyLabelAdded(workDir, beadID, label string) bool {
-	escapedID := strings.ReplaceAll(beadID, "'", "''")
-	escapedLabel := strings.ReplaceAll(label, "'", "''")
-	query := fmt.Sprintf("SELECT 1 FROM labels WHERE issue_id = '%s' AND label = '%s' LIMIT 1", escapedID, escapedLabel)
-	cmd := exec.Command("bd", "sql", query) //nolint:gosec // G204: query uses escaped internal values
-	cmd.Dir = workDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false
-	}
-	// bd sql returns header + data rows; if we got more than just a header, the label exists
-	return strings.Contains(string(output), "1")
 }
 
 // listPolecats returns the names of canonical polecat directories in a rig.

--- a/internal/doctor/agent_beads_check_test.go
+++ b/internal/doctor/agent_beads_check_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -47,6 +48,52 @@ func TestAgentBeadsExistCheck_NoRigs(t *testing.T) {
 	// With empty routes, only global agents (deacon, mayor) are checked
 	// They won't exist without Dolt, so we expect error or warning
 	t.Logf("Result: status=%v, message=%s", result.Status, result.Message)
+}
+
+func TestAgentBeadsExistCheckReportsLegacyTaskType(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version) printf 'bd test\n' ;;
+  list) printf '[{"id":"hq-deacon","issue_type":"task","labels":["gt:agent"],"status":"open"},{"id":"hq-mayor","issue_type":"task","labels":["gt:agent"],"status":"open"}]\n' ;;
+  mol) printf '{"wisps":[]}\n' ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	result := NewAgentBeadsCheck().Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(result.Message, "require canonical type/label migration") {
+		t.Fatalf("message = %q", result.Message)
+	}
+	if got := strings.Join(result.Details, ","); !strings.Contains(got, "hq-deacon") || !strings.Contains(got, "hq-mayor") {
+		t.Fatalf("details = %v, want both legacy global agents", result.Details)
+	}
 }
 
 // TestAgentBeadsExistCheck_ExpectedIDs verifies the check looks for correct agent bead IDs.
@@ -337,23 +384,6 @@ func TestListCrewWorkers_FiltersWorktrees(t *testing.T) {
 		if !found {
 			t.Errorf("listCrewWorkers should include canonical worker %q, got: %v", name, workers)
 		}
-	}
-}
-
-// TestAddWispLabelSQL_ErrorsGracefully verifies addWispLabelSQL doesn't panic
-// and returns an error when bd is unavailable (no Dolt server).
-// This is a regression guard for gt-3vx: after CreateAgentBead, the gt:agent
-// label must also be inserted into wisp_labels so doctor checks that join
-// wisp_labels can find the bead.
-func TestAddWispLabelSQL_ErrorsGracefully(t *testing.T) {
-	tmpDir := t.TempDir()
-	err := addWispLabelSQL(tmpDir, "gt-gastown-witness", "gt:agent")
-	// bd sql will fail without a Dolt server — just verify no panic and that the
-	// function returns an error (not silently discarding the failure).
-	if err == nil {
-		t.Log("addWispLabelSQL succeeded (Dolt server is running)")
-	} else {
-		t.Logf("addWispLabelSQL returned expected error without Dolt: %v", err)
 	}
 }
 

--- a/internal/doctor/migration_check.go
+++ b/internal/doctor/migration_check.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 var verifyExpectedDatabasesAtConfig = doltserver.VerifyExpectedDatabasesAtConfig
@@ -483,7 +483,7 @@ func (c *DoltServerReachableCheck) getServerAddr(beadsDir string, townRoot strin
 		// precedence over GT_DOLT_PORT env var, which takes precedence over
 		// daemon.json, which falls back to DefaultPort (3307). This ensures
 		// the doctor probes the same port that the server actually uses.
-		port = doltserver.DefaultConfig(townRoot).Port
+		port = config.ResolveConfiguredDoltPort(townRoot)
 	}
 	if port == 0 {
 		port = doltserver.DefaultPort

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -2356,6 +2356,8 @@ func TestIsDoltRetryableError_CatalogRace(t *testing.T) {
 }
 
 func TestWaitForCatalog_NoServer(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "")
+
 	// When no Dolt server is reachable, waitForCatalog should fail.
 	// Use port 13399 (unlikely to be in use) to ensure no server responds.
 	townRoot := t.TempDir()
@@ -2912,6 +2914,8 @@ func TestFindBrokenWorkspaces_SqliteNotBroken(t *testing.T) {
 }
 
 func TestFindBrokenWorkspaces_MultipleRigs(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "")
+
 	townRoot := t.TempDir()
 
 	// Isolate from real Dolt server on default port

--- a/internal/tmux/cycle_bindings_test.go
+++ b/internal/tmux/cycle_bindings_test.go
@@ -84,7 +84,7 @@ func TestSetCycleBindings_RefreshesStalePattern(t *testing.T) {
 
 	// Verify the binding was updated with the current pattern
 	currentPattern := sessionPrefixPattern()
-	output, err := tm.run("list-keys", "-T", "prefix", "n")
+	output, err := tm.rawKeyBinding("prefix", "n")
 	if err != nil {
 		t.Fatalf("listing keys: %v", err)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3899,7 +3899,7 @@ func (t *Tmux) SetTownCycleBindings(session string) error {
 //  2. Unguarded form (set by EnsureBindingsOnSocket): direct run-shell
 //     invoking "gt agents menu" or "gt feed --window".
 func (t *Tmux) isGTBinding(table, key string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.rawKeyBinding(table, key)
 	if err != nil || output == "" {
 		return false
 	}
@@ -3917,7 +3917,7 @@ func (t *Tmux) isGTBinding(table, key string) bool {
 // --client for multi-client support. Older GT bindings without --client cause
 // switch-client to target the wrong client when multiple clients are attached.
 func (t *Tmux) isGTBindingWithClient(table, key string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.rawKeyBinding(table, key)
 	if err != nil || output == "" {
 		return false
 	}
@@ -3929,11 +3929,29 @@ func (t *Tmux) isGTBindingWithClient(table, key string) bool {
 // current prefix pattern. Returns false if the binding is stale (e.g., after
 // gt rig add introduces a new prefix not yet in the grep pattern).
 func (t *Tmux) isGTBindingCurrent(table, key, currentPattern string) bool {
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.rawKeyBinding(table, key)
 	if err != nil || output == "" {
 		return false
 	}
 	return strings.Contains(output, currentPattern)
+}
+
+// rawKeyBinding returns the command bound to key in table. Query the complete
+// table using tmux's documented key formats and select the exact key here.
+// tmux 3.7 accepts a positional key filter for list-keys but can return an
+// empty result with exit status 0, which makes freshness checks fail open.
+func (t *Tmux) rawKeyBinding(table, key string) (string, error) {
+	output, err := t.run("list-keys", "-T", table, "-F", "#{key_string}\t#{key_command}")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		bindingKey, command, ok := strings.Cut(line, "\t")
+		if ok && bindingKey == key {
+			return command, nil
+		}
+	}
+	return "", nil
 }
 
 // getKeyBinding returns the current tmux command bound to the given key in the
@@ -3948,15 +3966,7 @@ func (t *Tmux) isGTBindingCurrent(table, key, currentPattern string) bool {
 // the presence of both "if-shell" and "gt " in the output), it is treated as
 // no prior binding to avoid recursive wrapping on repeated calls.
 func (t *Tmux) getKeyBinding(table, key string) string {
-	// tmux list-keys -T <table> <key> outputs a line like:
-	//   bind-key -T prefix g if-shell "..." "run-shell 'gt agents menu'" ":"
-	// We need to extract just the command portion.
-	//
-	// Assumed format (tested with tmux 3.3+):
-	//   bind-key [-r] -T <table> <key> <command...>
-	// If tmux changes this format, parsing fails safely (returns ""),
-	// which causes the caller to use its default fallback.
-	output, err := t.run("list-keys", "-T", table, key)
+	output, err := t.rawKeyBinding(table, key)
 	if err != nil || output == "" {
 		return ""
 	}
@@ -3972,36 +3982,7 @@ func (t *Tmux) getKeyBinding(table, key string) string {
 		return ""
 	}
 
-	// Parse the binding command from list-keys output.
-	// Format: "bind-key [-r] -T <table> <key> <command...>"
-	// We need everything after the key name.
-	// Find the key in the output and take everything after it.
-	fields := strings.Fields(output)
-	keyIdx := -1
-	for i, f := range fields {
-		if f == "-T" && i+2 < len(fields) {
-			// Skip table name, the next field is the key
-			keyIdx = i + 2
-			break
-		}
-	}
-	if keyIdx < 0 || keyIdx >= len(fields)-1 {
-		return ""
-	}
-
-	// Everything after the key is the command
-	// Rejoin from keyIdx+1 onward, but we need to preserve the original spacing.
-	// Find the key token in the original string and take everything after it.
-	idx := strings.Index(output, " "+fields[keyIdx]+" ")
-	if idx < 0 {
-		return ""
-	}
-	cmd := strings.TrimSpace(output[idx+len(" "+fields[keyIdx]+" "):])
-	if cmd == "" {
-		return ""
-	}
-
-	return cmd
+	return output
 }
 
 // safePrefixRe matches the character set guaranteed by beadsPrefixRegexp in

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2708,7 +2708,7 @@ func TestSetBindings_PreserveFallbackOnRepeatedCalls(t *testing.T) {
 		"display-message custom-user-cmd")
 
 	// Record the binding after first configuration
-	firstRaw, _ := tm.run("list-keys", "-T", "prefix", "F11")
+	firstRaw, _ := tm.rawKeyBinding("prefix", "F11")
 
 	// isGTBinding should return true, causing Set*Binding to skip
 	if !tm.isGTBinding("prefix", "F11") {

--- a/internal/tui/feed/stuck_test.go
+++ b/internal/tui/feed/stuck_test.go
@@ -563,8 +563,8 @@ func TestDeriveSessionName(t *testing.T) {
 // TestCheckAll_InvalidBeadID tests that invalid bead IDs are skipped
 func TestCheckAll_InvalidBeadID(t *testing.T) {
 	mock := newMockHealthSource()
-	mock.agents["invalid-id"] = &beads.Issue{
-		ID:        "invalid-id",
+	mock.agents["1-invalid"] = &beads.Issue{
+		ID:        "1-invalid",
 		UpdatedAt: time.Now().Format(time.RFC3339),
 	}
 
@@ -574,8 +574,7 @@ func TestCheckAll_InvalidBeadID(t *testing.T) {
 		t.Fatalf("CheckAll: %v", err)
 	}
 
-	// Invalid bead ID should be skipped (ParseAgentBeadID returns ok=false for single-char prefix)
-	// "invalid-id" has prefix "invalid" which is > 3 chars, so ParseAgentBeadID will return false
+	// Invalid bead ID should be skipped because Beads prefixes must start with a letter.
 	if len(agents) != 0 {
 		t.Errorf("expected 0 agents for invalid bead ID, got %d", len(agents))
 	}

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -316,7 +316,9 @@ add_polecat_in_rig() {
 }
 
 run_script() {
-  bash "$SCRIPT" > "$TEST_STATE/output.log" 2>&1
+	# Keep non-interactive shell startup hooks from rewriting PATH ahead of the
+	# fixture bin directory and silently invoking the live gt/tmux/bd commands.
+	env -u BASH_ENV bash "$SCRIPT" > "$TEST_STATE/output.log" 2>&1
 }
 
 test_healthy_runtime() {


### PR DESCRIPTION
## Summary

- create durable agent beads as canonical issue_type=agent plus gt:agent and migrate task+gt:agent records in place
- resolve registered rig identities rig-first with town fallback, then pin state and patrol-await writes to the winning ledger
- share the agent predicate across resolver and doctor, support registered 1-20 character prefixes, and fail closed on equal-confidence duplicates
- repair deterministic canonical-gate failures in shell isolation, managed Dolt port selection, and tmux 3.7 binding lookup

## Verification

- make test (exit 0; install-path 3/3, stuck-agent-dog 93/93, go test ./... all green)
- make build (exit 0)
- local gt agents resolve matrix for Witness and Refinery across all 10 registered rigs (20/20 exit 0)
- git diff --check (exit 0)

Tracker: gtf-5xe