### PR TITLE
fix: check-recovery MUST emit named blockers on NEEDS_RECOVERY

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1115,6 +1115,25 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 		if hookBlocker != "" {
 			input.HookBead = hookBead
 		}
+		// gtf-kom: check-recovery built WorkstateInput without ever setting
+		// ActiveWorkBlocker (unlike the inventory listing path), so a
+		// stalled/review-needed/stuck polecat fell through DecideWorkstate's
+		// not-idle branch with no named predicate. Wire the same evidence
+		// inventory uses so the verdict is actionable, not just non-empty.
+		if p.State != polecat.StateIdle && p.State != polecat.StateDone && p.State != polecat.StateWorking {
+			var assignedIssue *beads.Issue
+			if status.Issue != "" {
+				assignedIssue, _ = bd.Show(status.Issue)
+			}
+			activeWorkEvidence := assessPolecatAssignedIssueWork(assignedIssue)
+			if !activeWorkEvidence.BlocksCleanup {
+				activeWorkEvidence = assessPolecatAgentStateWork(beads.AgentState(strings.TrimSpace(fields.AgentState)))
+			}
+			if activeWorkEvidence.Blocker != "" {
+				input.ActiveWorkBlocker = activeWorkEvidence.Blocker
+				input.ActiveWorkCountsTowardCapacity = activeWorkEvidence.CountsTowardCapacity
+			}
+		}
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
 		assignee := fmt.Sprintf("%s/polecats/%s", rigName, polecatName)
@@ -1452,12 +1471,19 @@ func recoveryGitStateBlocker(worktreePath string, gitState *GitState, gitErr err
 }
 
 func recoveryActionsForBlockers(blockers []string) []string {
+	if len(blockers) == 0 {
+		return nil
+	}
 	for _, blocker := range blockers {
 		if strings.HasPrefix(blocker, "git_state=has_stash") {
 			return []string{"preserve branch-owned stash entries to auditable recovery refs before cleanup, then rerun check-recovery"}
 		}
 	}
-	return nil
+	// gtf-kom: every named blocker must pair with a recovery action so
+	// NEEDS_RECOVERY is never an unfalsifiable refusal — fall back to a
+	// generic investigate-then-recheck action when no predicate-specific
+	// action applies.
+	return []string{"investigate the named predicate(s) above, resolve or confirm no work is at risk, then rerun check-recovery"}
 }
 
 func activeMRBlocker(bd issueShower, mrID, sourceHint string, requireGitSafe, gitSafe bool) string {

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -85,6 +85,17 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		}
 		if in.ActiveWorkBlocker != "" {
 			d.Blockers = append(d.Blockers, in.ActiveWorkBlocker)
+		} else if needsRecovery {
+			// A NEEDS_RECOVERY verdict must always name a predicate (gtf-kom):
+			// an empty Blockers slice here printed as "unknown recovery
+			// predicate", which Witness/Mayor could not act on and which
+			// deadlocked recovery town-wide. Name the state itself when the
+			// caller didn't wire a richer ActiveWorkBlocker.
+			blocker := "state=" + string(in.State)
+			if in.State == "" {
+				blocker = "state=<missing>"
+			}
+			d.Blockers = append(d.Blockers, blocker)
 		}
 		return d
 	}

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -123,6 +123,24 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			in:   WorkstateInput{State: StateStalled, CleanupStatus: CleanupClean, ActiveWorkBlocker: "assigned_work=gt-open status=open", ActiveWorkCountsTowardCapacity: true},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true, Blockers: []string{"assigned_work=gt-open status=open"}},
 		},
+		{
+			// gtf-kom: a caller that never wires ActiveWorkBlocker must still get a
+			// named predicate instead of the unfalsifiable "unknown recovery
+			// predicate" refusal that deadlocked town-wide recovery.
+			name: "stalled without wired blocker names the state instead of refusing blindly",
+			in:   WorkstateInput{State: StateStalled, CleanupStatus: CleanupClean},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true, Blockers: []string{"state=stalled"}},
+		},
+		{
+			name: "review-needed without wired blocker names the state",
+			in:   WorkstateInput{State: StateReviewNeeded, CleanupStatus: CleanupClean},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true, Blockers: []string{"state=review-needed"}},
+		},
+		{
+			name: "missing state without wired blocker still names a predicate",
+			in:   WorkstateInput{State: "", CleanupStatus: CleanupClean},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true, Blockers: []string{"state=<missing>"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,5 +160,28 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDecideWorkstateNeedsRecoveryAlwaysNamesABlocker guards the gtf-kom
+// invariant structurally: no matter which State a caller passes and no
+// matter whether the caller wired ActiveWorkBlocker, a NEEDS_RECOVERY
+// verdict must always carry at least one named predicate. An empty
+// Blockers slice here prints as "unknown recovery predicate," which is
+// unfalsifiable and unactionable — it deadlocked polecat recovery
+// town-wide because neither the Witness nor the Mayor could act on it.
+func TestDecideWorkstateNeedsRecoveryAlwaysNamesABlocker(t *testing.T) {
+	states := []State{
+		StateWorking, StateIdle, StateDone, StateReviewNeeded,
+		StateStuck, StateStalled, StateZombie, State("future-unknown-state"), State(""),
+	}
+	for _, state := range states {
+		for _, activeWorkBlocker := range []string{"", "assigned_work=gt-1 status=open"} {
+			in := WorkstateInput{State: state, CleanupStatus: CleanupClean, ActiveWorkBlocker: activeWorkBlocker}
+			got := DecideWorkstate(in)
+			if got.Verdict == WorkstateVerdictNeedsRecovery && len(got.Blockers) == 0 {
+				t.Fatalf("DecideWorkstate(State=%q, ActiveWorkBlocker=%q) = NEEDS_RECOVERY with empty Blockers — unfalsifiable refusal (gtf-kom)", state, activeWorkBlocker)
+			}
+		}
 	}
 }


### PR DESCRIPTION
P0: check-recovery refuses cleanup with empty Blockers - 'unknown recovery predicate' deadlocks polecat recovery town-wide

NEEDS_RECOVERY now always populates status.Blockers before returning.
Regression test ensures non-empty Blockers on every NEEDS_RECOVERY verdict.