### PR TITLE
fix: gt->bd BEADS_DIR pin must mirror bd's own ancestor walk

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -25,7 +25,28 @@ import (
 // Circular redirect detection: If the resolved path equals the original beads directory,
 // this indicates an errant redirect file that should be removed. The function logs a
 // warning and returns the original beads directory.
+//
+// If workDir has no .beads directory at all (no redirect, nothing on disk), a plain
+// `bd` call from workDir would still succeed by walking up ancestor directories
+// looking for one that does (bd's own findDatabaseInTree). Callers that pin
+// BEADS_DIR to this function's result must resolve to that same ancestor, or they
+// short-circuit bd's fallback and fail where a direct bd call would succeed
+// (gtf-g1p). So when the direct resolution doesn't exist on disk, this also walks
+// up workDir's ancestors before giving up.
 func ResolveBeadsDir(workDir string) string {
+	beadsDir := resolveBeadsDirLocal(workDir)
+	if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
+		return beadsDir
+	}
+	if ancestor := findAncestorBeadsDir(workDir); ancestor != "" {
+		return ancestor
+	}
+	return beadsDir
+}
+
+// resolveBeadsDirLocal resolves workDir's own .beads directory, following any
+// redirect chain, without walking up to ancestor directories.
+func resolveBeadsDirLocal(workDir string) string {
 	if filepath.Base(workDir) == ".beads" {
 		workDir = filepath.Dir(workDir)
 	}
@@ -69,6 +90,25 @@ func ResolveBeadsDir(workDir string) string {
 	// This is intentional for the rig-level redirect architecture.
 	// Limit depth to prevent infinite loops from misconfigured redirects.
 	return resolveBeadsDirWithDepth(resolved, 3)
+}
+
+// findAncestorBeadsDir walks up from workDir's parent looking for a directory
+// whose .beads/ (or its redirect target) exists on disk, mirroring the ancestor
+// search a direct `bd` call performs when BEADS_DIR is unset. Returns "" if no
+// ancestor has one, all the way up to the filesystem root.
+func findAncestorBeadsDir(workDir string) string {
+	dir := filepath.Dir(filepath.Clean(workDir))
+	for {
+		candidate := resolveBeadsDirLocal(dir)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // resolveBeadsDirWithDepth follows redirect chains with a depth limit.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3036,6 +3036,30 @@ func TestResolveBeadsDir(t *testing.T) {
 		}
 	})
 
+	t.Run("no local beads directory falls back to ancestor (gtf-g1p)", func(t *testing.T) {
+		// Reproduces gtf-g1p: gt sling resolves formulaWorkDir from a target's
+		// tmux pane cwd, which may be a subdirectory with no .beads of its own
+		// (e.g. townRoot/deacon). A direct `bd` call from that cwd walks up and
+		// finds townRoot/.beads; ResolveBeadsDir must resolve to the same
+		// directory so the gt->bd subprocess pins BEADS_DIR to a real database
+		// instead of a nonexistent path.
+		townRoot := filepath.Join(tmpDir, "ancestor-town")
+		townBeadsDir := filepath.Join(townRoot, ".beads")
+		if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		workDir := filepath.Join(townRoot, "deacon")
+		if err := os.MkdirAll(workDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		got := ResolveBeadsDir(workDir)
+		want := townBeadsDir
+		if got != want {
+			t.Errorf("ResolveBeadsDir() = %q, want %q (should walk up to ancestor .beads, matching a direct bd call)", got, want)
+		}
+	})
+
 	t.Run("empty redirect file", func(t *testing.T) {
 		// Redirect file exists but is empty - should fall back to local
 		workDir := filepath.Join(tmpDir, "empty-redirect")


### PR DESCRIPTION
## Summary

Fixes gtf-g1p: `gt sling` (and any gt->bd subprocess call) failed with
`Error: no beads database found` from a cwd whose direct `bd` invocation
of the identical query succeeds.

**Root cause:** `bd`'s own `FindDatabasePath()` short-circuits (returns `""`)
when `BEADS_DIR` is explicitly set to a directory with no database — it only
performs its ancestor walk when `BEADS_DIR` is unset. gt's `runWithStdin()`
always pins `BEADS_DIR` via `ResolveBeadsDir(workDir)`, which previously did
pure path arithmetic (`filepath.Join(workDir, ".beads")`) with no existence
check. For a workDir like `/home/marlonsc/gt/deacon` (no local `.beads`),
gt pinned `BEADS_DIR` to a nonexistent path, silently disabling bd's own
successful ancestor-walk fallback that a direct `bd` call performs.

**Fix:** `ResolveBeadsDir` in `internal/beads/beads_redirect.go` now checks
whether its direct resolution exists on disk; if not, it walks up ancestor
directories (new `findAncestorBeadsDir`), mirroring bd's own
`findDatabaseInTree`. This lives entirely in the shared resolver used by
every bd subprocess dispatch path — no `BEADS_DIR` fallback/shim was added
at any call site, per the bead's acceptance criteria.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint` — 0 issues
- [x] `go test ./internal/beads/...` — all 89 tests pass
- [x] New regression test `no local beads directory falls back to ancestor (gtf-g1p)` in `beads_test.go`
- [x] Live-verified against the real town filesystem: `ResolveBeadsDir(/home/marlonsc/gt/deacon)` now returns `/home/marlonsc/gt/.beads`, matching a direct `bd` call

Fixes gtf-g1p.