### PR TITLE
fix(dog): gt dog done no longer hits the polecat-only guard

### DIFF
--- a/internal/cmd/done_worktree_guard_test.go
+++ b/internal/cmd/done_worktree_guard_test.go
@@ -298,6 +298,33 @@ func TestIsDoneCommand(t *testing.T) {
 	}
 }
 
+// Regression: `gt dog done` is a different command from the top-level
+// `gt done` and must not inherit the polecat-only worktree guard. Matching
+// any ancestor named "done" made every dog unable to mark itself done, so
+// dogs stayed pinned in "working" forever and the Deacon ran out of
+// dispatchable workers.
+func TestIsDoneCommandIgnoresNestedDoneSubcommands(t *testing.T) {
+	root := &cobra.Command{Use: "gt"}
+
+	topLevelDone := &cobra.Command{Use: "done"}
+	root.AddCommand(topLevelDone)
+
+	dog := &cobra.Command{Use: "dog"}
+	dogDone := &cobra.Command{Use: "done"}
+	dog.AddCommand(dogDone)
+	root.AddCommand(dog)
+
+	if !isDoneCommand(topLevelDone) {
+		t.Fatal("gt done should be detected as the done command")
+	}
+	if isDoneCommand(dogDone) {
+		t.Fatal("gt dog done must NOT be treated as the polecat done command")
+	}
+	if isDoneCommand(dog) {
+		t.Fatal("gt dog should not be detected as the done command")
+	}
+}
+
 func TestPersistentPreRunDoneRejectsBeforeRegistryFallback(t *testing.T) {
 	townRoot, _ := setupDoneGuardWorktree(t, "nested", "shiny")
 	initDoneGuardGitRepo(t, townRoot)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -190,10 +190,19 @@ func isRoleCommand(cmd *cobra.Command) bool {
 }
 
 func isDoneCommand(cmd *cobra.Command) bool {
+	// Only the top-level `gt done` (the polecat completion command) may trigger
+	// the polecat worktree guard. Subcommands that happen to be named "done" —
+	// notably `gt dog done` — are different commands with their own semantics
+	// and must not inherit the polecat-only BD_ACTOR/GT_ROLE check.
 	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "done" {
+		if c.Name() != "done" {
+			continue
+		}
+		parent := c.Parent()
+		if parent == nil || !parent.HasParent() {
 			return true
 		}
+		return false
 	}
 	return false
 }


### PR DESCRIPTION
## Problem

`isDoneCommand` in `internal/cmd/root.go` walked the entire command ancestry matching **any** command named `done`:

```go
for c := cmd; c != nil; c = c.Parent() {
    if c.Name() == "done" { return true }
}
```

So `gt dog done` matched on its own name and triggered `resolveDonePolecatWorktree()` in `persistentPreRun` — the guard intended only for the top-level `gt done` polecat completion command.

Result:

```
$ gt dog done bravo
Error: gt done is for polecats only (BD_ACTOR=mayor)
```

`gt dog done --help` documents it as the command dogs should call, so the guard is misapplied rather than the usage being wrong.

## Impact

Dogs could never mark themselves done. Every dog that finished an assignment stayed pinned in `working` forever, so the Deacon eventually had no dispatchable worker. In our town all 3 dogs (bravo, charlie, delta) were stuck simultaneously with 0 idle — each had genuinely completed its plugin run.

Neither the dog nor the Mayor could clear it; the only workaround was `gt dog clear <name> --force`.

## Fix

Only the top-level `gt done` triggers the polecat worktree guard. A `done` whose parent is itself a subcommand (i.e. `dog`) is a different command with its own semantics and must not inherit the polecat-only BD_ACTOR/GT_ROLE check.

## Testing

Added `TestIsDoneCommandIgnoresNestedDoneSubcommands`, verified to **fail against the pre-fix implementation** and pass with the fix (not a tautological test).

Existing `TestIsDoneCommand` and the `TestDone*`/`TestDog*` suites still pass.

Manually verified on a live town:

- `gt dog done charlie` → `✓ Dog charlie returned to kennel (idle)`, session terminated cleanly
- `gt done` → still correctly rejects non-polecats with `gt done is for polecats only`

Found while repairing a town on v1.2.1-305.