### PR TITLE
fix(doctor): validate town-root prefix against dolt.database owner

### DIFF
--- a/internal/doctor/beads_check.go
+++ b/internal/doctor/beads_check.go
@@ -416,10 +416,7 @@ func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
 	var problems []string
 
 	for _, route := range routes {
-		// Skip town root route
-		if route.Path == "." || route.Path == "" {
-			continue
-		}
+		isTownRootRoute := route.Path == "." || route.Path == ""
 
 		rigPath := filepath.Join(ctx.TownRoot, route.Path)
 		rigBeadsDir := beads.ResolveBeadsDir(rigPath)
@@ -433,9 +430,18 @@ func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
 		// These rigs share the town DB; the prefix is owned by the town root
 		// route, not by this rig. "Fixing" them would overwrite the shared
 		// database's issue_prefix with the rig's route prefix.
-		absRigBeadsDir, _ := filepath.Abs(rigBeadsDir)
-		if absRigBeadsDir == townBeadsDir {
-			continue
+		//
+		// The town root route itself is NOT exempted from this check (gtf-k2k):
+		// it IS the shared database, and its own routes.jsonl entry is the sole
+		// declaration of who owns it. A rig rename that overwrites the town
+		// root's .beads/config.yaml issue-prefix (as happened in commit
+		// 3e341231, hq -> dcdoc) must be caught here instead of silently
+		// skipped, or the town root can drift from its declared prefix forever.
+		if !isTownRootRoute {
+			absRigBeadsDir, _ := filepath.Abs(rigBeadsDir)
+			if absRigBeadsDir == townBeadsDir {
+				continue
+			}
 		}
 
 		dbPrefix, err := getter.GetDBPrefix(rigPath)

--- a/internal/doctor/beads_check_test.go
+++ b/internal/doctor/beads_check_test.go
@@ -448,6 +448,86 @@ func TestDatabasePrefixCheck_DetectsMismatchForOwnDB(t *testing.T) {
 	}
 }
 
+func TestDatabasePrefixCheck_DetectsTownRootPrefixContamination(t *testing.T) {
+	// Regression test for gtf-k2k: commit 3e341231 overwrote the TOWN root's
+	// .beads/config.yaml issue-prefix from "hq" to "dcdoc" while routes.jsonl
+	// (and the Dolt database itself) still declared "hq" as the town root's
+	// owner. The check used to skip the town root route unconditionally, so
+	// this exact contamination went undetected until it broke gt sling.
+
+	tmpDir := t.TempDir()
+
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"gt-","path":"gastown/mayor/rig"}`
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			tmpDir: "dcdoc", // contaminated prefix, as observed live in gtf-k2k
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning for town root prefix contamination, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.mismatches) != 1 {
+		t.Fatalf("expected 1 mismatch for town root, got %d: %+v", len(check.mismatches), check.mismatches)
+	}
+	m := check.mismatches[0]
+	if m.rigPath != "." || m.routesPrefix != "hq" || m.dbPrefix != "dcdoc" {
+		t.Errorf("unexpected mismatch data: %+v", m)
+	}
+}
+
+func TestDatabasePrefixCheck_TownRootMatchesIsClean(t *testing.T) {
+	// Sanity counterpart to TestDatabasePrefixCheck_DetectsTownRootPrefixContamination:
+	// when the town root's database prefix agrees with routes.jsonl, checking
+	// the town root route must not introduce a false positive.
+
+	tmpDir := t.TempDir()
+
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(`{"prefix":"hq-","path":"."}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			tmpDir: "hq",
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK for matching town root prefix, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.mismatches) != 0 {
+		t.Errorf("expected 0 mismatches, got %d: %+v", len(check.mismatches), check.mismatches)
+	}
+}
+
 func TestDatabasePrefixCheck_UsesMetadataDatabaseEnv(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake bd stub is shell-specific")


### PR DESCRIPTION
## Summary
- `DatabasePrefixCheck` (internal/doctor/beads_check.go) unconditionally skipped the town root's own `routes.jsonl` entry (`route.Path == "."`), so it could never catch the town root's `.beads/config.yaml` `issue-prefix` diverging from the Dolt database's actual `issue_prefix` — exactly the failure mode from commit 3e341231, which silently overwrote the town root prefix from `hq` to `dcdoc` and broke `gt sling`.
- Fix distinguishes the town-root route from "rig redirects to the shared town DB" routes: the latter keep their existing skip (avoids false-positive fixes on redirecting rigs), but the town root route is now validated like any other route, since it IS the shared database and its own `routes.jsonl` entry is the sole declaration of its owner.
- Adds two regression tests: one reproducing the exact `dcdoc` contamination scenario (expects `StatusWarning` + mismatch), and a clean-state counterpart (expects `StatusOK`, no false positive).

Closes the remaining acceptance-criteria gap on gtf-k2k (item 5: "regression test that fails when the bd prefix diverges from the declared owner of dolt.database"). The rest of that bead's scope (WIP integration, prefix correction, `gt sling` subprocess fix) was already resolved by prior work / gtf-g1p (#4754).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/doctor/beads_check.go internal/doctor/beads_check_test.go` (clean)
- [x] `golangci-lint run ./internal/doctor/...` (0 issues)
- [x] `go test ./internal/doctor/... -run TestDatabasePrefixCheck -v` (all 11 pass, 2 new)
- [x] Confirmed `TestGetServerAddr_UsesConfigYAMLPort` failure in the full package run is pre-existing/unrelated (reproduces identically against the unmodified tree via stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)