### PR TITLE
fix: check-up-to-date accepts fork-backed descendant, not just exact match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,15 @@ ifndef SKIP_UPDATE_CHECK
 	LOCAL=$$(git rev-parse HEAD 2>/dev/null); \
 	REMOTE=$$(git rev-parse "$$UPSTREAM" 2>/dev/null); \
 	if [ -n "$$REMOTE" ] && [ "$$LOCAL" != "$$REMOTE" ]; then \
-		echo "ERROR: Local branch is not up to date with $$UPSTREAM"; \
-		echo "  Local:  $$(git rev-parse --short HEAD)"; \
-		echo "  Remote: $$(git rev-parse --short $$UPSTREAM)"; \
-		echo "Run 'git pull' first, or use SKIP_UPDATE_CHECK=1 to override"; \
-		exit 1; \
+		if git merge-base --is-ancestor "$$REMOTE" "$$LOCAL" 2>/dev/null; then \
+			echo "Local branch is ahead of $$UPSTREAM (descendant) - OK for fork-backed source"; \
+		else \
+			echo "ERROR: Local branch is not up to date with $$UPSTREAM"; \
+			echo "  Local:  $$(git rev-parse --short HEAD)"; \
+			echo "  Remote: $$(git rev-parse --short $$UPSTREAM)"; \
+			echo "Run 'git pull' first, or use SKIP_UPDATE_CHECK=1 to override"; \
+			exit 1; \
+		fi; \
 	fi
 endif
 
@@ -184,6 +188,7 @@ test: test-makefile
 
 test-makefile:
 	bash scripts/check-install-path_test.sh
+	bash scripts/check-up-to-date_test.sh
 	bash -n plugins/stuck-agent-dog/run.sh
 	bash -n plugins/stuck-agent-dog/run_test.sh
 	bash plugins/stuck-agent-dog/run_test.sh

--- a/scripts/check-up-to-date_test.sh
+++ b/scripts/check-up-to-date_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Regression tests for Makefile check-up-to-date, incl. fork-backed asymmetric
+# fetch/push origins where local HEAD legitimately runs ahead of upstream.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MAKE_BIN="$(command -v "${MAKE:-make}")"
+TMPDIR=""
+PASS=0
+FAIL=0
+
+cleanup() {
+  if [[ -n "$TMPDIR" && -d "$TMPDIR" ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+# Minimal Makefile stand-in that pulls in only the target under test, so the
+# test doesn't depend on the rest of this repo's build graph.
+write_check_target() {
+  local dir="$1"
+  awk '/^check-up-to-date:/,/^endif$/' "$REPO_ROOT/Makefile" > "$dir/Makefile"
+}
+
+setup_repo() {
+  TMPDIR="$(mktemp -d)"
+  UPSTREAM="$TMPDIR/upstream"
+  LOCAL="$TMPDIR/local"
+
+  git init --quiet -b main "$UPSTREAM"
+  git -C "$UPSTREAM" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m base
+
+  git clone --quiet "$UPSTREAM" "$LOCAL"
+  git -C "$LOCAL" -c user.email=t@t -c user.name=t config user.email t@t
+  git -C "$LOCAL" -c user.email=t@t -c user.name=t config user.name t
+  write_check_target "$LOCAL"
+}
+
+run_check() {
+  (cd "$LOCAL" && "$MAKE_BIN" --no-print-directory check-up-to-date 2>&1)
+}
+
+# set -e treats a failing command substitution in a plain assignment as fatal,
+# so route through if/else to capture non-zero exits without aborting the run.
+capture() {
+  if output="$(run_check)"; then rc=0; else rc=$?; fi
+}
+
+assert_pass() {
+  local test_name="$1" output="$2" rc="$3"
+  if [[ "$rc" -eq 0 ]]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name (expected exit 0, got $rc)"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local test_name="$1" output="$2" rc="$3"
+  if [[ "$rc" -ne 0 ]] && [[ "$output" == *"not up to date"* ]]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name (expected non-zero exit + 'not up to date', got rc=$rc)"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== check-up-to-date tests ==="
+
+# Case 1: local == upstream -> pass
+setup_repo
+capture
+assert_pass "local equal to upstream" "$output" "$rc"
+cleanup
+
+# Case 2: local behind upstream -> fail
+setup_repo
+git -C "$UPSTREAM" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "upstream-ahead"
+git -C "$LOCAL" fetch --quiet origin main
+capture
+assert_fail "local behind upstream" "$output" "$rc"
+cleanup
+
+# Case 3: local diverged from upstream -> fail
+setup_repo
+git -C "$UPSTREAM" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "upstream-diverge"
+git -C "$LOCAL" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "local-diverge"
+git -C "$LOCAL" fetch --quiet origin main
+capture
+assert_fail "local diverged from upstream" "$output" "$rc"
+cleanup
+
+# Case 4: fork-backed asymmetric origin — local is a descendant of upstream
+# (fork carries extra downstream commits, e.g. origin fetch=upstream repo,
+# push=fork repo) -> must pass, not be treated as stale.
+setup_repo
+git -C "$LOCAL" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "fork-only-commit-1"
+git -C "$LOCAL" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "fork-only-commit-2"
+capture
+assert_pass "local ahead of upstream (fork-backed descendant)" "$output" "$rc"
+cleanup
+
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- `make safe-install`'s `check-up-to-date` step compared local `HEAD` against the tracking upstream ref with strict equality (`LOCAL != REMOTE`). In fork-backed rigs where `origin` fetches from an upstream repo but pushes to a fork, a local `HEAD` that legitimately carries downstream fork commits ahead of the fetched upstream ref was rejected as "not up to date" — blocking `safe-install` entirely short of the forbidden `SKIP_UPDATE_CHECK=1` bypass, even though the source was a clean fast-forward descendant.
- Switched the check to an ancestor test: accept when the tracked remote ref is an ancestor of local `HEAD` (equal or ahead), still reject when it is not (behind or diverged).

Fixes gtf-stt.

## Test plan
- [x] `bash scripts/check-up-to-date_test.sh` — new regression suite covering equal / behind / diverged / fork-ahead cases, all pass
- [x] `make test-makefile` — new test wired in and passing (pre-existing unrelated failures in `plugins/stuck-agent-dog/run_test.sh`, untouched by this change)
- [x] `go build ./cmd/gt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)