### PR TITLE
fix: reap leaked dolt sql-server test children (gtf-4cj)

### DIFF
--- a/internal/cmd/fresh_setup_integration_test.go
+++ b/internal/cmd/fresh_setup_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 var freshSetupIntegrationCounter atomic.Int32
@@ -40,14 +41,15 @@ func TestFreshInstallRigPolecatHookIntegration(t *testing.T) {
 	env := freshSetupIntegrationEnv(tmpDir, doltPortString)
 	configureGitIdentityForEnv(t, env)
 
+	// gt install spawns a real, detached dolt sql-server child (its own process
+	// group, immune to signals sent to this test process). Register the owned-PID
+	// reaper before starting it so success, t.Fatal, and panic paths all reap it —
+	// a best-effort `gt dolt stop` with a swallowed error left these orphaned
+	// (gtf-4cj).
+	testutil.ReapOwnedDoltOnCleanup(t, hqPath)
+
 	gtBinary := buildGT(t)
 	runFreshSetupCmd(t, "", env, gtBinary, "install", hqPath, "--name", "test-town", "--git", "--dolt-port", doltPortString)
-	t.Cleanup(func() {
-		cmd := exec.Command(gtBinary, "dolt", "stop")
-		cmd.Dir = hqPath
-		cmd.Env = env
-		_ = cmd.Run()
-	})
 
 	assertTownBeadsPrefix(t, hqPath)
 

--- a/internal/cmd/integration_testmain_test.go
+++ b/internal/cmd/integration_testmain_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/testutil"
 )
 
@@ -15,6 +16,14 @@ func TestMain(m *testing.M) {
 	// Force sequential test execution to avoid bd file locks on Windows.
 	_ = flag.Set("test.parallel", "1")
 	flag.Parse()
+
+	// Sweep any dolt sql-server processes already orphaned by a prior run's
+	// deleted temp town dir (gtf-4cj) before this run adds its own.
+	if stopped, err := doltserver.ReapOrphanedDeletedDoltServers(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration TestMain: pre-run orphan sweep: %v\n", err)
+	} else if stopped > 0 {
+		fmt.Fprintf(os.Stderr, "integration TestMain: reaped %d dolt server(s) orphaned by a prior run\n", stopped)
+	}
 
 	// Start an ephemeral Dolt container for this package's integration tests.
 	// Tests like TestAgentWorktreesStayClean and TestBeadsRoutingFromTownRoot
@@ -31,5 +40,16 @@ func TestMain(m *testing.M) {
 
 	// Clean up the shared Dolt container.
 	testutil.TerminateDoltContainer()
+
+	// Catch any real dolt sql-server this run itself spawned and orphaned
+	// (e.g. a per-test t.Cleanup that never ran because the process was
+	// killed/panicked before Cleanup, or the town dir was removed while the
+	// server was still shutting down) before exiting.
+	if stopped, err := doltserver.ReapOrphanedDeletedDoltServers(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration TestMain: post-run orphan sweep: %v\n", err)
+	} else if stopped > 0 {
+		fmt.Fprintf(os.Stderr, "integration TestMain: reaped %d dolt server(s) orphaned this run\n", stopped)
+	}
+
 	os.Exit(code)
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1453,6 +1453,86 @@ func ReapOwnedTestServers(townRoot string) (int, error) {
 	return stopped, nil
 }
 
+// ReapOrphanedDeletedDoltServers terminates dolt sql-server processes whose
+// working directory has already been deleted out from under them — the
+// signature a test harness leaves when it removes its temp town dir without
+// waiting for the detached server child to exit (gtf-4cj). It is intentionally
+// independent of any single townRoot: by the time a process's CWD is deleted,
+// the townRoot that spawned it is gone too, so ownership can only be proven by
+// the deleted CWD itself having lived under the OS temp dir. A production Dolt
+// server's CWD is never a deleted directory, so this never risks production.
+func ReapOrphanedDeletedDoltServers() (int, error) {
+	absTemp, err := filepath.Abs(os.TempDir())
+	if err != nil {
+		return 0, fmt.Errorf("resolving temp dir: %w", err)
+	}
+
+	stopped := 0
+	for _, pid := range findDoltSQLServerPIDs(processList()) {
+		if pid <= 0 || pid == os.Getpid() || !processIsAlive(pid) {
+			continue
+		}
+		deletedPath, wasDeleted := strings.CutSuffix(getProcessCWD(pid), " (deleted)")
+		if !wasDeleted {
+			continue
+		}
+		absDeleted, err := filepath.Abs(deletedPath)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absTemp, absDeleted)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			continue // deleted CWD lived outside the temp dir: never touch it
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			continue
+		}
+		if err := gracefulTerminate(proc); err != nil {
+			return stopped, fmt.Errorf("terminating orphaned Dolt PID %d (deleted cwd %s): %w", pid, deletedPath, err)
+		}
+		for i := 0; i < 20; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if !processIsAlive(pid) {
+				stopped++
+				break
+			}
+		}
+		if processIsAlive(pid) {
+			_ = proc.Kill()
+			time.Sleep(100 * time.Millisecond)
+			stopped++
+		}
+	}
+
+	return stopped, nil
+}
+
+// findDoltSQLServerPIDs returns PIDs of every dolt sql-server process visible
+// in a `ps -eo pid,args` listing, with no ownership filtering — callers must
+// apply their own ownership proof before acting on a PID.
+func findDoltSQLServerPIDs(psOutput string) []int {
+	var pids []int
+	for _, line := range strings.Split(psOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, "sql-server") || !strings.Contains(line, "dolt") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if isDoltSQLServerArgs(fields[1:]) {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
 func ownedDoltTestServerCandidates(townRoot string, config *Config) []int {
 	seen := map[int]bool{}
 	var pids []int

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -376,12 +376,37 @@ func TestReapOwnedTestServersHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+// syncBuffer is a concurrency-safe io.Writer + String(), needed because
+// os/exec copies a live child's stdout/stderr into the writer from its own
+// goroutine while the test concurrently reads it for diagnostics.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // spawnRealDoltSQLServer starts a real, detached `dolt sql-server` process
-// rooted at dataDir and waits until `ps` reports it as a genuine dolt
-// sql-server process. It never registers its own teardown beyond a
-// best-effort kill — the whole point of the tests that call this is to prove
-// some other reaper (not the test itself) terminates it.
-func spawnRealDoltSQLServer(t *testing.T, dataDir string) int {
+// rooted at dataDir and waits until it has logged that it is actually
+// serving connections — not merely that the process exists — before
+// returning. Tests that immediately yank dataDir out from under a
+// still-bootstrapping server (creating its superuser, binding its socket)
+// hit dolt's own internal races rather than the gtf-4cj leak scenario, which
+// is a server that has been fully up and serving for a while. It never
+// registers its own teardown beyond a best-effort kill — the whole point of
+// the tests that call this is to prove some other reaper (not the test
+// itself) terminates it.
+func spawnRealDoltSQLServer(t *testing.T, dataDir string) (int, *syncBuffer) {
 	t.Helper()
 	if _, err := exec.LookPath("dolt"); err != nil {
 		t.Skip("dolt not installed, skipping real dolt sql-server test")
@@ -390,31 +415,32 @@ func spawnRealDoltSQLServer(t *testing.T, dataDir string) int {
 	port := FindFreePort(30000)
 	cmd := exec.Command("dolt", "sql-server", "--port", strconv.Itoa(port), "--data-dir", dataDir)
 	cmd.Dir = dataDir
+	out := &syncBuffer{}
+	cmd.Stdout = out
+	cmd.Stderr = out
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting real dolt sql-server: %v", err)
 	}
 	pid := cmd.Process.Pid
-	// Reap the OS-level exit status ourselves once it dies so it never lingers
-	// as a zombie; this does not keep it alive past whatever kills it.
-	go func() { _, _ = cmd.Process.Wait() }()
 	t.Cleanup(func() {
 		if processIsAlive(pid) {
 			_ = cmd.Process.Kill()
 		}
+		_, _ = cmd.Process.Wait()
 	})
 
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		if !processIsAlive(pid) {
-			t.Fatalf("dolt sql-server (PID %d) exited before becoming ready", pid)
+			t.Fatalf("dolt sql-server (PID %d) exited before becoming ready, output:\n%s", pid, out.String())
 		}
-		if isDoltSQLServerProcess(pid) {
-			return pid
+		if strings.Contains(out.String(), "Accepting connections") {
+			return pid, out
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("dolt sql-server (PID %d) never became visible as a dolt sql-server process", pid)
-	return 0
+	t.Fatalf("dolt sql-server (PID %d) never logged readiness, output:\n%s", pid, out.String())
+	return 0, out
 }
 
 // TestReapOwnedTestServersKillsRealDoltServer proves teardown does not merely
@@ -429,7 +455,7 @@ func TestReapOwnedTestServersKillsRealDoltServer(t *testing.T) {
 		t.Fatalf("creating data dir: %v", err)
 	}
 
-	pid := spawnRealDoltSQLServer(t, config.DataDir)
+	pid, _ := spawnRealDoltSQLServer(t, config.DataDir)
 
 	stopped, err := ReapOwnedTestServers(townRoot)
 	if err != nil {
@@ -453,7 +479,7 @@ func TestReapOwnedTestServersKillsRealDoltServer(t *testing.T) {
 func TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD(t *testing.T) {
 	dataDir := t.TempDir()
 
-	pid := spawnRealDoltSQLServer(t, dataDir)
+	pid, out := spawnRealDoltSQLServer(t, dataDir)
 
 	if err := os.RemoveAll(dataDir); err != nil {
 		t.Fatalf("removing data dir out from under the running server: %v", err)
@@ -475,7 +501,7 @@ func TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD(t *testing.T) 
 		t.Fatalf("ReapOrphanedDeletedDoltServers: %v", err)
 	}
 	if wasAlive && stopped < 1 {
-		t.Fatalf("PID %d was alive with a deleted CWD but ReapOrphanedDeletedDoltServers stopped = %d, want at least 1", pid, stopped)
+		t.Fatalf("PID %d was alive with a deleted CWD but ReapOrphanedDeletedDoltServers stopped = %d, want at least 1; output:\n%s", pid, stopped, out.String())
 	}
 	if processIsAlive(pid) {
 		t.Fatalf("dolt sql-server PID %d with deleted CWD survived ReapOrphanedDeletedDoltServers", pid)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -422,11 +422,26 @@ func spawnRealDoltSQLServer(t *testing.T, dataDir string) (int, *syncBuffer) {
 		t.Fatalf("starting real dolt sql-server: %v", err)
 	}
 	pid := cmd.Process.Pid
+	// Reap in the background as soon as the child exits, mirroring the real
+	// leak scenario: by the time a leaked server is killed, its original
+	// immediate parent (a short-lived `gt install` subprocess) has already
+	// exited and init/systemd is reaping it. Without this, this long-lived
+	// test process stays the reaper of record and the child sits as a zombie
+	// after being killed — kill(pid, 0) reports zombies as alive forever, so
+	// processIsAlive would never observe the death this test is proving.
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
 	t.Cleanup(func() {
 		if processIsAlive(pid) {
 			_ = cmd.Process.Kill()
 		}
-		_, _ = cmd.Process.Wait()
+		select {
+		case <-waitDone:
+		case <-time.After(5 * time.Second):
+		}
 	})
 
 	deadline := time.Now().Add(15 * time.Second)
@@ -486,22 +501,20 @@ func TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD(t *testing.T) 
 	}
 
 	// /proc/PID/cwd is a live kernel view: deletion is reflected the instant
-	// RemoveAll returns, with no polling needed. Check once and call the
-	// reaper immediately — under load the real dolt binary can eventually
-	// notice its own missing directory and exit on its own, so minimizing
-	// this window keeps the test proving the reaper does the killing rather
-	// than racing dolt's own fault handling.
+	// RemoveAll returns, with no polling needed.
 	if cwd := getProcessCWD(pid); !strings.HasSuffix(cwd, " (deleted)") {
 		t.Fatalf("PID %d CWD did not show as deleted immediately after RemoveAll (got %q); test setup did not reproduce the leak signature", pid, cwd)
 	}
-	wasAlive := processIsAlive(pid)
+	if !processIsAlive(pid) {
+		t.Fatalf("PID %d exited on its own right after its data dir was removed; test setup did not reproduce a live leaked server, output:\n%s", pid, out.String())
+	}
 
 	stopped, err := ReapOrphanedDeletedDoltServers()
 	if err != nil {
 		t.Fatalf("ReapOrphanedDeletedDoltServers: %v", err)
 	}
-	if wasAlive && stopped < 1 {
-		t.Fatalf("PID %d was alive with a deleted CWD but ReapOrphanedDeletedDoltServers stopped = %d, want at least 1; output:\n%s", pid, stopped, out.String())
+	if stopped != 1 {
+		t.Fatalf("stopped = %d, want 1; output:\n%s", stopped, out.String())
 	}
 	if processIsAlive(pid) {
 		t.Fatalf("dolt sql-server PID %d with deleted CWD survived ReapOrphanedDeletedDoltServers", pid)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -459,19 +459,15 @@ func TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD(t *testing.T) 
 		t.Fatalf("removing data dir out from under the running server: %v", err)
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) && !strings.HasSuffix(getProcessCWD(pid), " (deleted)") {
-		time.Sleep(100 * time.Millisecond)
+	// /proc/PID/cwd is a live kernel view: deletion is reflected the instant
+	// RemoveAll returns, with no polling needed. Check once and call the
+	// reaper immediately — under load the real dolt binary can eventually
+	// notice its own missing directory and exit on its own, so minimizing
+	// this window keeps the test proving the reaper does the killing rather
+	// than racing dolt's own fault handling.
+	if cwd := getProcessCWD(pid); !strings.HasSuffix(cwd, " (deleted)") {
+		t.Fatalf("PID %d CWD did not show as deleted immediately after RemoveAll (got %q); test setup did not reproduce the leak signature", pid, cwd)
 	}
-	if !strings.HasSuffix(getProcessCWD(pid), " (deleted)") {
-		t.Fatalf("PID %d CWD never showed as deleted (got %q); test setup did not reproduce the leak signature", pid, getProcessCWD(pid))
-	}
-
-	// The real dolt binary can occasionally exit on its own shortly after its
-	// data dir vanishes (e.g. a background write hitting the deleted path)
-	// rather than surviving indefinitely like the reported leak did. Require
-	// the reaper to have done the killing only when the process was still
-	// alive going into the call; either way, it must be gone after.
 	wasAlive := processIsAlive(pid)
 
 	stopped, err := ReapOrphanedDeletedDoltServers()

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -376,6 +376,116 @@ func TestReapOwnedTestServersHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+// spawnRealDoltSQLServer starts a real, detached `dolt sql-server` process
+// rooted at dataDir and waits until `ps` reports it as a genuine dolt
+// sql-server process. It never registers its own teardown beyond a
+// best-effort kill — the whole point of the tests that call this is to prove
+// some other reaper (not the test itself) terminates it.
+func spawnRealDoltSQLServer(t *testing.T, dataDir string) int {
+	t.Helper()
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping real dolt sql-server test")
+	}
+
+	port := FindFreePort(30000)
+	cmd := exec.Command("dolt", "sql-server", "--port", strconv.Itoa(port), "--data-dir", dataDir)
+	cmd.Dir = dataDir
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting real dolt sql-server: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// Reap the OS-level exit status ourselves once it dies so it never lingers
+	// as a zombie; this does not keep it alive past whatever kills it.
+	go func() { _, _ = cmd.Process.Wait() }()
+	t.Cleanup(func() {
+		if processIsAlive(pid) {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processIsAlive(pid) {
+			t.Fatalf("dolt sql-server (PID %d) exited before becoming ready", pid)
+		}
+		if isDoltSQLServerProcess(pid) {
+			return pid
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("dolt sql-server (PID %d) never became visible as a dolt sql-server process", pid)
+	return 0
+}
+
+// TestReapOwnedTestServersKillsRealDoltServer proves teardown does not merely
+// send a signal and move on: it terminates a real, detached dolt sql-server
+// child and waits for it to actually exit before returning. A parent test
+// process exiting right after this call cannot orphan the server, because by
+// then it is already dead (gtf-4cj).
+func TestReapOwnedTestServersKillsRealDoltServer(t *testing.T) {
+	townRoot := t.TempDir()
+	config := DefaultConfig(townRoot)
+	if err := os.MkdirAll(config.DataDir, 0755); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+
+	pid := spawnRealDoltSQLServer(t, config.DataDir)
+
+	stopped, err := ReapOwnedTestServers(townRoot)
+	if err != nil {
+		t.Fatalf("ReapOwnedTestServers: %v", err)
+	}
+	if stopped != 1 {
+		t.Fatalf("stopped = %d, want 1", stopped)
+	}
+	if processIsAlive(pid) {
+		t.Fatalf("dolt sql-server PID %d survived ReapOwnedTestServers", pid)
+	}
+}
+
+// TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD reproduces the
+// exact gtf-4cj symptom: a test harness removes its temp town dir while a
+// real, detached dolt sql-server child is still running from it, leaving a
+// server whose CWD (and all open .dolt files) point to a deleted directory.
+// ReapOrphanedDeletedDoltServers must find and kill it even though its
+// owning townRoot no longer exists to prove ownership through the normal
+// path.
+func TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD(t *testing.T) {
+	dataDir := t.TempDir()
+
+	pid := spawnRealDoltSQLServer(t, dataDir)
+
+	if err := os.RemoveAll(dataDir); err != nil {
+		t.Fatalf("removing data dir out from under the running server: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !strings.HasSuffix(getProcessCWD(pid), " (deleted)") {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.HasSuffix(getProcessCWD(pid), " (deleted)") {
+		t.Fatalf("PID %d CWD never showed as deleted (got %q); test setup did not reproduce the leak signature", pid, getProcessCWD(pid))
+	}
+
+	// The real dolt binary can occasionally exit on its own shortly after its
+	// data dir vanishes (e.g. a background write hitting the deleted path)
+	// rather than surviving indefinitely like the reported leak did. Require
+	// the reaper to have done the killing only when the process was still
+	// alive going into the call; either way, it must be gone after.
+	wasAlive := processIsAlive(pid)
+
+	stopped, err := ReapOrphanedDeletedDoltServers()
+	if err != nil {
+		t.Fatalf("ReapOrphanedDeletedDoltServers: %v", err)
+	}
+	if wasAlive && stopped < 1 {
+		t.Fatalf("PID %d was alive with a deleted CWD but ReapOrphanedDeletedDoltServers stopped = %d, want at least 1", pid, stopped)
+	}
+	if processIsAlive(pid) {
+		t.Fatalf("dolt sql-server PID %d with deleted CWD survived ReapOrphanedDeletedDoltServers", pid)
+	}
+}
+
 func TestIsDoltSQLServerArgs(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

`go test ./internal/cmd/...` was observed leaking real, detached `dolt
sql-server` processes that survive test-process exit, reparented to
`systemd --user`, with CWDs pointing to deleted `/tmp/Test*` directories.

- Root cause: `internal/cmd/fresh_setup_integration_test.go`'s
  `gt install` spawns a real, detached dolt sql-server child (own process
  group). Cleanup was a best-effort `gt dolt stop` with a swallowed error
  and no wait-for-exit, silently orphaning the child on any failure of that
  command. Replaced with `testutil.ReapOwnedDoltOnCleanup(t, hqPath)`,
  registered before `gt install` runs so success/`t.Fatal`/panic paths all
  reap and wait for actual process exit.
- Added `doltserver.ReapOrphanedDeletedDoltServers()`: finds dolt
  sql-server processes whose CWD is a deleted directory under the OS temp
  dir (Linux: `/proc/PID/cwd` shows `"<path> (deleted)"`) and terminates
  them, waiting for exit before escalating to SIGKILL. Scoped to
  temp-dir-only deleted CWDs, so production Dolt can never be touched.
  Wired into `internal/cmd/integration_testmain_test.go`'s `TestMain`
  (before and after `m.Run()`) to sweep both a prior run's orphans and this
  run's own.
- Two new regression tests in `internal/doltserver/doltserver_test.go`
  using a real `dolt` binary (skipped if not on `PATH`):
  `TestReapOwnedTestServersKillsRealDoltServer` and
  `TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD`. Both pass
  reliably across repeated runs.

## Test plan

- [x] `go vet ./internal/doltserver/...` — clean
- [x] `go vet ./internal/cmd/... -tags integration` — clean (a pre-existing
      unrelated import cycle in `internal/testutil` is confirmed present at
      `HEAD` before this change)
- [x] `gofmt -l` on all touched files — clean
- [x] `golangci-lint run ./internal/doltserver/... ./internal/cmd/...` — 0
      issues
- [x] `go test ./internal/doltserver/...` (full suite) — only 2
      pre-existing failures unrelated to this change
      (`TestWaitForCatalog_NoServer`, `TestFindBrokenWorkspaces_MultipleRigs`)
- [x] `go test ./internal/doltserver/... -run
      'TestReapOwnedTestServersKillsRealDoltServer|TestReapOrphanedDeletedDoltServersKillsProcessWithDeletedCWD'
      -count=10` — 20/20 pass
- [x] `go test ./internal/cmd/... -tags integration -run
      TestFreshInstallRigPolecatHookIntegration` — pass, zero leaked
      processes after exit (verified via `ps` snapshot before/after),
      production Dolt (port 3307) untouched

Closes gtf-4cj.