### PR TITLE
fix(doctor): isolate TestGetServerAddr_UsesConfigYAMLPort from ambient GT_DOLT_PORT

### DIFF
--- a/internal/doctor/migration_check_test.go
+++ b/internal/doctor/migration_check_test.go
@@ -188,6 +188,13 @@ func TestGetServerAddr_NoMetadata(t *testing.T) {
 }
 
 func TestGetServerAddr_UsesConfigYAMLPort(t *testing.T) {
+	// GT_DOLT_PORT is ambient in every Gas Town session (explicit operator
+	// intent, highest precedence in ResolveDoltPort) and normally matches
+	// the production authority 127.0.0.1:3307. Clear it so this test's
+	// synthetic config.yaml in an isolated townRoot is actually exercised
+	// instead of being shadowed by the caller's real session port.
+	t.Setenv("GT_DOLT_PORT", "")
+
 	check := NewDoltServerReachableCheck()
 	townRoot := t.TempDir()
 


### PR DESCRIPTION
## Summary
- `TestGetServerAddr_UsesConfigYAMLPort` wrote a synthetic `.dolt-data/config.yaml` in an isolated `t.TempDir()` and expected `getServerAddr` to fall back to its port when `metadata.json` has no port.
- `GT_DOLT_PORT` is ambient in every Gas Town session (explicit operator intent — the highest-precedence source in `ResolveDoltPort`) and normally equals the production authority `127.0.0.1:3307`. That ambient value always shadowed the fixture's config.yaml port, so the test failed deterministically whenever run inside a real Gas Town session.
- Fix is test-only: `t.Setenv("GT_DOLT_PORT", "")` isolates the test from the ambient session so it genuinely exercises the config.yaml fallback path. No change to `getServerAddr`, `ResolveDoltPort`, or production port precedence/authority (still `127.0.0.1:3307`).

## Test plan
- [x] `go test ./internal/doctor/... -run TestGetServerAddr -v` — all subtests pass
- [x] `go test ./internal/doctor/...` — full package green, no warnings
- [x] `go build ./...` — exit 0
- [x] `go vet ./internal/doctor/...` — exit 0
- [x] Verified production Dolt listener remained on `127.0.0.1:3307` throughout (`gt dolt status`)

Fixes gtf-9vf

🤖 Generated with [Claude Code](https://claude.com/claude-code)