### PR TITLE
fix(doctor): detect and safely internalize stale bare-repo alternates

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -76,6 +76,7 @@ Rig checks (with --rig flag):
   - rig-is-git-repo          Verify rig is a valid git repository
   - git-exclude-configured   Check .git/info/exclude has Gas Town dirs (fixable)
   - bare-repo-exists         Verify .repo.git exists when worktrees depend on it (fixable)
+  - bare-repo-alternates     Verify .repo.git objects don't depend on a removed external alternates path (fixable)
   - witness-exists           Verify witness/ structure exists (fixable)
   - refinery-exists          Verify refinery/ structure exists (fixable)
   - mayor-clone-exists       Verify mayor/rig/ clone exists (fixable)

--- a/internal/doctor/bare_repo_alternates_check.go
+++ b/internal/doctor/bare_repo_alternates_check.go
@@ -1,0 +1,260 @@
+package doctor
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// BareRepoAlternatesCheck detects a shared bare repo whose objects/info/alternates
+// file references an external checkout that no longer exists. Gas Town clones
+// sometimes borrow objects from another local repo via `git clone --reference-if-able`
+// to save disk; if that external repo is later deleted (a sibling rig removed, an
+// unrelated local checkout cleaned up), the bare repo silently loses access to every
+// object it never copied for itself. The break stays invisible until a `git log`,
+// `git fetch`, or worktree checkout needs one of those objects — this check catches
+// it during `gt doctor` instead.
+type BareRepoAlternatesCheck struct {
+	FixableCheck
+	stalePaths []string // alternates entries whose target directory is gone
+}
+
+// NewBareRepoAlternatesCheck creates a new stale-alternates check.
+func NewBareRepoAlternatesCheck() *BareRepoAlternatesCheck {
+	return &BareRepoAlternatesCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "bare-repo-alternates",
+				CheckDescription: "Verify shared bare repo does not depend on a removed external alternates path",
+				CheckCategory:    CategoryRig,
+			},
+		},
+	}
+}
+
+// alternatesFilePath returns the path to a bare repo's alternates file.
+func alternatesFilePath(bareRepoPath string) string {
+	return filepath.Join(bareRepoPath, "objects", "info", "alternates")
+}
+
+// resolveAlternateTarget resolves an alternates file entry to an absolute path.
+// Per gitrepository-layout(5), relative entries are relative to $GIT_DIR/objects.
+func resolveAlternateTarget(bareRepoPath, line string) string {
+	if filepath.IsAbs(line) {
+		return line
+	}
+	return filepath.Join(bareRepoPath, "objects", line)
+}
+
+// readAlternates returns the non-empty, non-comment lines of a bare repo's
+// alternates file. A missing file is not an error — it means nothing is configured.
+func readAlternates(bareRepoPath string) ([]string, error) {
+	data, err := os.ReadFile(alternatesFilePath(bareRepoPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var lines []string
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines, scanner.Err()
+}
+
+// splitLiveDead partitions alternates entries into ones whose target directory
+// still exists and ones whose target directory is gone.
+func splitLiveDead(bareRepoPath string, lines []string) (live, dead []string) {
+	for _, line := range lines {
+		if _, err := os.Stat(resolveAlternateTarget(bareRepoPath, line)); os.IsNotExist(err) {
+			dead = append(dead, line)
+		} else {
+			live = append(live, line)
+		}
+	}
+	return live, dead
+}
+
+// unreachableOIDs lists objects that registered refs (branches and tags) need
+// but cannot find in the bare repo's current object store (local + alternates).
+// Uses `rev-list --missing=print` so a broken chain is reported, not fatal.
+func unreachableOIDs(bareRepoPath string) ([]string, error) {
+	cmd := exec.Command("git", "-C", bareRepoPath, "rev-list", "--objects",
+		"--branches", "--tags", "--missing=print")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("git rev-list failed: %s", msg)
+	}
+	var missing []string
+	scanner := bufio.NewScanner(bytes.NewReader(stdout.Bytes()))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "?") {
+			missing = append(missing, strings.Fields(strings.TrimPrefix(line, "?"))[0])
+		}
+	}
+	return missing, scanner.Err()
+}
+
+// Run checks whether the rig's bare repo has an alternates entry pointing at a
+// directory that no longer exists.
+func (c *BareRepoAlternatesCheck) Run(ctx *CheckContext) *CheckResult {
+	if ctx.RigName == "" {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No rig specified (skipping alternates check)",
+			Category: c.Category(),
+		}
+	}
+
+	bareRepoPath := filepath.Join(ctx.RigPath(), ".repo.git")
+	if _, err := os.Stat(bareRepoPath); err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No shared bare repo found",
+			Category: c.Category(),
+		}
+	}
+
+	c.stalePaths = nil
+	lines, err := readAlternates(bareRepoPath)
+	if err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusWarning,
+			Message:  "Cannot read objects/info/alternates",
+			Details:  []string{err.Error()},
+			Category: c.Category(),
+		}
+	}
+	if len(lines) == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No external alternates configured",
+			Category: c.Category(),
+		}
+	}
+
+	_, dead := splitLiveDead(bareRepoPath, lines)
+	c.stalePaths = dead
+	if len(dead) == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  fmt.Sprintf("%d external alternate(s) configured and reachable", len(lines)),
+			Category: c.Category(),
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d stale external alternate(s) — objects may become unreadable", len(dead)),
+		Details: append([]string{
+			"Removed external checkout(s) still referenced by objects/info/alternates:",
+		}, dead...),
+		FixHint:  "Run 'gt doctor --fix --rig " + ctx.RigName + "' to internalize reachable objects and drop the stale alternate(s)",
+		Category: c.Category(),
+	}
+}
+
+// Fix internalizes every object that registered refs (branches, tags) can still
+// reach, then drops alternates entries whose target is gone. It never trades
+// data for a clean report: if any object required by a ref cannot be proven
+// present afterward (locally, or by refetching from the configured remote), the
+// alternates file is restored exactly as found and Fix returns an error listing
+// the unreachable objects.
+func (c *BareRepoAlternatesCheck) Fix(ctx *CheckContext) error {
+	if ctx.RigName == "" {
+		return nil
+	}
+
+	bareRepoPath := filepath.Join(ctx.RigPath(), ".repo.git")
+	altPath := alternatesFilePath(bareRepoPath)
+
+	// Re-read and re-verify before mutating — Run may have flagged this minutes
+	// ago and the state could have changed since (TOCTOU guard).
+	origContent, err := os.ReadFile(altPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to fix
+		}
+		return fmt.Errorf("read alternates: %w", err)
+	}
+	lines, err := readAlternates(bareRepoPath)
+	if err != nil {
+		return fmt.Errorf("read alternates: %w", err)
+	}
+	live, dead := splitLiveDead(bareRepoPath, lines)
+	if len(dead) == 0 {
+		return nil // nothing stale to fix
+	}
+
+	// Stage the pruned alternates (dead entries removed, live entries kept) so
+	// we can prove ref reachability using only what would remain after the fix.
+	newContent := ""
+	if len(live) > 0 {
+		newContent = strings.Join(live, "\n") + "\n"
+	}
+	restore := func() error { return os.WriteFile(altPath, origContent, 0644) }
+
+	if len(live) == 0 {
+		if err := os.Remove(altPath); err != nil {
+			return fmt.Errorf("stage alternates for verification: %w", err)
+		}
+	} else if err := os.WriteFile(altPath, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("stage alternates for verification: %w", err)
+	}
+
+	missing, proofErr := unreachableOIDs(bareRepoPath)
+	if proofErr != nil {
+		_ = restore()
+		return fmt.Errorf("prove ref reachability: %w", proofErr)
+	}
+
+	if len(missing) > 0 {
+		// Best-effort recovery: the objects are gone from the dead alternate,
+		// but a ref that mirrors something on the remote can often be repaired
+		// by refetching it. Refs with no upstream (typical worker branches)
+		// won't be helped by this — that's expected and handled below.
+		refetchErr := exec.Command("git", "-C", bareRepoPath, "fetch", "origin",
+			"+refs/heads/*:refs/remotes/origin/*", "--prune").Run()
+		if refetchErr == nil {
+			missing, proofErr = unreachableOIDs(bareRepoPath)
+			if proofErr != nil {
+				_ = restore()
+				return fmt.Errorf("prove ref reachability after refetch: %w", proofErr)
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		// Fail closed: restoring the dead pointer doesn't recover anything
+		// either (the target is gone), but silently declaring the repo
+		// self-contained while refs still need it would hide real data loss.
+		_ = restore()
+		return fmt.Errorf("refusing to drop stale alternate(s) %v: %d object(s) still unreachable from registered refs: %s",
+			dead, len(missing), strings.Join(missing, ", "))
+	}
+
+	return nil
+}

--- a/internal/doctor/bare_repo_alternates_check_test.go
+++ b/internal/doctor/bare_repo_alternates_check_test.go
@@ -1,0 +1,200 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestBareRepoAlternatesCheck_Name(t *testing.T) {
+	check := NewBareRepoAlternatesCheck()
+	if check.Name() != "bare-repo-alternates" {
+		t.Errorf("expected name 'bare-repo-alternates', got %q", check.Name())
+	}
+	if !check.CanFix() {
+		t.Error("expected CanFix to return true")
+	}
+}
+
+func TestBareRepoAlternatesCheck_NoRig(t *testing.T) {
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir(), RigName: ""}
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no rig specified, got %v", result.Status)
+	}
+}
+
+func TestBareRepoAlternatesCheck_NoBareRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "testrig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when .repo.git is missing, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestBareRepoAlternatesCheck_NoAlternatesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigDir := filepath.Join(tmpDir, "testrig")
+	bareRepo := filepath.Join(rigDir, ".repo.git")
+	runGit(t, "", "init", "--bare", bareRepo)
+
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK with no alternates configured, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestBareRepoAlternatesCheck_LiveAlternateOK(t *testing.T) {
+	tmpDir := t.TempDir()
+	externalRepo := seedRepo(t, tmpDir, "external.git", "hello")
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	bareRepo := filepath.Join(rigDir, ".repo.git")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, externalRepo, bareRepo)
+	assertHasAlternates(t, bareRepo)
+
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when the alternate target still exists, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// TestBareRepoAlternatesCheck_ReachableAfterRefetch is the "safely internalize"
+// fixture: the bare repo was cloned with --reference-if-able against an external
+// checkout (so it never copied the objects for itself), the external checkout is
+// then deleted, and origin still has everything — so Fix must refetch the missing
+// objects, prove every registered ref reachable, and drop the stale alternate.
+func TestBareRepoAlternatesCheck_ReachableAfterRefetch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originRepo := seedRepo(t, tmpDir, "origin.git", "hello")
+	externalRepo := filepath.Join(tmpDir, "external.git")
+	runGit(t, "", "clone", "--bare", originRepo, externalRepo)
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	bareRepo := filepath.Join(rigDir, ".repo.git")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, originRepo, bareRepo)
+	runGit(t, bareRepo, "remote", "set-url", "origin", originRepo)
+	assertHasAlternates(t, bareRepo)
+
+	// Simulate the external checkout being deleted from under the rig.
+	if err := os.RemoveAll(externalRepo); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError for a stale alternate, got %v: %s", result.Status, result.Message)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix should recover objects still present on origin: %v", err)
+	}
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+	if _, err := os.Stat(alternatesFilePath(bareRepo)); !os.IsNotExist(err) {
+		t.Errorf("expected alternates file removed after successful internalization, stat err=%v", err)
+	}
+	out, err := exec.Command("git", "-C", bareRepo, "log", "--oneline", "main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("branch unreadable after fix: %v\n%s", err, out)
+	}
+}
+
+// TestBareRepoAlternatesCheck_UnreachableRefusesFix is the fail-closed fixture:
+// the external checkout is deleted and origin cannot supply the missing objects
+// either (matching a purely local, never-pushed branch). Fix must refuse and
+// leave the alternates file byte-identical.
+func TestBareRepoAlternatesCheck_UnreachableRefusesFix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	externalRepo := seedRepo(t, tmpDir, "external.git", "only-in-external")
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	bareRepo := filepath.Join(rigDir, ".repo.git")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, externalRepo, bareRepo)
+	// No reachable origin — nothing to refetch from.
+	runGit(t, bareRepo, "remote", "set-url", "origin", filepath.Join(tmpDir, "does-not-exist.git"))
+	assertHasAlternates(t, bareRepo)
+
+	origAlternates, err := os.ReadFile(alternatesFilePath(bareRepo))
+	if err != nil {
+		t.Fatalf("expected alternates file before repair: %v", err)
+	}
+
+	if err := os.RemoveAll(externalRepo); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewBareRepoAlternatesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError for a stale alternate, got %v: %s", result.Status, result.Message)
+	}
+
+	if err := check.Fix(ctx); err == nil {
+		t.Fatal("expected Fix to refuse when required objects are unreachable")
+	}
+
+	after, err := os.ReadFile(alternatesFilePath(bareRepo))
+	if err != nil {
+		t.Fatalf("alternates file missing after refused fix: %v", err)
+	}
+	if string(after) != string(origAlternates) {
+		t.Errorf("alternates file mutated despite refused fix:\nbefore: %q\nafter:  %q", origAlternates, after)
+	}
+}
+
+// seedRepo creates a bare repo at tmpDir/name containing one commit on "main"
+// with the given file content, returning the bare repo's path.
+func seedRepo(t *testing.T, tmpDir, name, content string) string {
+	t.Helper()
+	bareRepo := filepath.Join(tmpDir, name)
+	runGit(t, "", "init", "--bare", "-b", "main", bareRepo)
+
+	seed := filepath.Join(tmpDir, name+".seed")
+	runGit(t, "", "clone", bareRepo, seed)
+	if err := os.WriteFile(filepath.Join(seed, "file.txt"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, seed, "add", "file.txt")
+	runGit(t, seed, "commit", "-m", "seed commit")
+	runGit(t, seed, "push", "origin", "HEAD:refs/heads/main")
+	return bareRepo
+}
+
+// assertHasAlternates fails the test if bareRepo has no objects/info/alternates file.
+func assertHasAlternates(t *testing.T, bareRepo string) {
+	t.Helper()
+	if _, err := os.Stat(alternatesFilePath(bareRepo)); err != nil {
+		t.Fatalf("expected alternates file to exist: %v", err)
+	}
+}

--- a/internal/doctor/bare_repo_alternates_check_test.go
+++ b/internal/doctor/bare_repo_alternates_check_test.go
@@ -62,7 +62,7 @@ func TestBareRepoAlternatesCheck_LiveAlternateOK(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, externalRepo, bareRepo)
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, fileURL(externalRepo), bareRepo)
 	assertHasAlternates(t, bareRepo)
 
 	check := NewBareRepoAlternatesCheck()
@@ -90,8 +90,8 @@ func TestBareRepoAlternatesCheck_ReachableAfterRefetch(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, originRepo, bareRepo)
-	runGit(t, bareRepo, "remote", "set-url", "origin", originRepo)
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, fileURL(originRepo), bareRepo)
+	runGit(t, bareRepo, "remote", "set-url", "origin", fileURL(originRepo))
 	assertHasAlternates(t, bareRepo)
 
 	// Simulate the external checkout being deleted from under the rig.
@@ -138,9 +138,9 @@ func TestBareRepoAlternatesCheck_UnreachableRefusesFix(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, externalRepo, bareRepo)
+	runGit(t, "", "clone", "--bare", "--reference-if-able", externalRepo, fileURL(externalRepo), bareRepo)
 	// No reachable origin — nothing to refetch from.
-	runGit(t, bareRepo, "remote", "set-url", "origin", filepath.Join(tmpDir, "does-not-exist.git"))
+	runGit(t, bareRepo, "remote", "set-url", "origin", fileURL(filepath.Join(tmpDir, "does-not-exist.git")))
 	assertHasAlternates(t, bareRepo)
 
 	origAlternates, err := os.ReadFile(alternatesFilePath(bareRepo))
@@ -189,6 +189,13 @@ func seedRepo(t *testing.T, tmpDir, name, content string) string {
 	runGit(t, seed, "commit", "-m", "seed commit")
 	runGit(t, seed, "push", "origin", "HEAD:refs/heads/main")
 	return bareRepo
+}
+
+// fileURL forces git to treat a local path as a remote (disabling the
+// same-filesystem hardlink optimization) so a clone's --reference-if-able
+// dedup is actually exercised, matching how a real GitHub-hosted clone behaves.
+func fileURL(path string) string {
+	return "file://" + path
 }
 
 // assertHasAlternates fails the test if bareRepo has no objects/info/alternates file.

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -2055,6 +2055,7 @@ func RigChecks() []Check {
 		NewHooksPathConfiguredCheck(),
 		NewBareRepoExistsCheck(),
 		NewBareRepoRefspecCheck(),
+		NewBareRepoAlternatesCheck(),
 		NewDefaultBranchExistsCheck(),
 		NewWitnessExistsCheck(),
 		NewRefineryExistsCheck(),


### PR DESCRIPTION
## Summary

- Adds a `bare-repo-alternates` doctor check that detects a rig's shared `.repo.git` bare repo depending on a removed external checkout via `objects/info/alternates` (created by `git clone --reference-if-able` — see `internal/git/git.go`'s `cloneInternal`).
- `Fix()` proves every registered ref's objects are reachable via `git rev-list --objects --branches --tags --missing=print` before touching anything, retries once via `git fetch origin +refs/heads/*:refs/remotes/origin/*` for objects still recoverable from the remote, re-proves, and only then drops the stale alternate entry. If objects remain unreachable it fails closed: restores the alternates file byte-for-byte and returns an error listing the unreachable OIDs — it never silently trades data for a clean report.
- Registered in `RigChecks()` and the `gt doctor` CLI help listing.

Root cause addressed: gtf-spr — a rig's `.repo.git` can silently lose access to objects it never copied locally once the external checkout it was cloned `--reference-if-able` against is deleted; `gt doctor` previously detected nothing and had no repair path.

## Test plan

- [x] `internal/doctor/bare_repo_alternates_check_test.go`: 7 tests — name/CanFix, no-rig, no-bare-repo, no-alternates-file, live-alternate-still-present (OK), reachable-after-refetch (Fix succeeds, alternates file removed, branch stays readable), unreachable (Fix refuses, alternates file byte-identical to before).
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/doctor/...` green (one pre-existing, unrelated failure: `TestGetServerAddr_UsesConfigYAMLPort`, dolt port resolution, untouched by this change).
- [x] `make build` produces a working `gt` binary with the check linked in; `./gt doctor --rig flext --verbose` confirms the check runs correctly against a real rig (currently reports OK — flext's alternates file was already removed, unsafely, before this work started; zero live refs are affected, confirmed via `rev-list --missing=print`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)