### PR TITLE
fix: route agent lifecycle state through town db

### DIFF
--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -646,3 +646,102 @@ esac
 		t.Fatalf("CreateOrReopenAgentBead did not use town BEADS_DIR for existing bead path; log:\n%s", logOutput)
 	}
 }
+
+func TestAgentLifecycleWritesUseTownAndWorkIssueStaysRigScoped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{{Prefix: "hq-", Path: "."}, {Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'beads_dir=%%s args=%%s\n' "${BEADS_DIR:-<unset>}" "$*" >> %q
+cmd=""
+for arg in "$@"; do
+  case "$arg" in --*) ;; *) cmd="$arg"; break ;; esac
+done
+case "$cmd" in
+  version)
+    printf 'bd version 1.2.2\n'
+    ;;
+  show)
+    case "$*" in
+      *gt-gastown-polecat-rust*)
+        [ "${BEADS_DIR:-}" = %q ] || exit 9
+        printf '%%s\n' '[{"id":"gt-gastown-polecat-rust","title":"rust","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: working\nhook_bead: gt-work-1"}]'
+        ;;
+      *gt-work-1*)
+        [ "${BEADS_DIR:-}" = %q ] || exit 8
+        printf '%%s\n' '[{"id":"gt-work-1","title":"work","issue_type":"task","status":"hooked"}]'
+        ;;
+    esac
+    ;;
+  update)
+    case "$*" in
+      *gt-gastown-polecat-rust*) [ "${BEADS_DIR:-}" = %q ] || exit 9 ;;
+      *) exit 7 ;;
+    esac
+    ;;
+esac
+`, logPath, townBeadsDir, rigBeadsDir, townBeadsDir)
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	agentID := "gt-gastown-polecat-rust"
+	workID := "gt-work-1"
+	clients := []*Beads{
+		NewWithBeadsDir(townRoot, townBeadsDir),
+		NewWithBeadsDir(rigDir, rigBeadsDir),
+	}
+	for _, client := range clients {
+		agentBD := client.ForAgentBead()
+		if err := agentBD.UpdateAgentCompletion(agentID, &CompletionMetadata{ExitType: "COMPLETED", HookBead: workID}); err != nil {
+			t.Fatalf("completion write from %s: %v", client.workDir, err)
+		}
+		if err := agentBD.Update(agentID, UpdateOptions{AddLabels: []string{"done-cp:pushed:branch:1"}}); err != nil {
+			t.Fatalf("checkpoint write from %s: %v", client.workDir, err)
+		}
+		empty := ""
+		if err := agentBD.UpdateAgentDescriptionFields(agentID, AgentFieldUpdates{HookBead: &empty}); err != nil {
+			t.Fatalf("hook-clear write from %s: %v", client.workDir, err)
+		}
+		if _, err := client.Show(workID); err != nil {
+			t.Fatalf("rig work lookup from %s: %v", client.workDir, err)
+		}
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		switch {
+		case strings.Contains(line, agentID):
+			if !strings.Contains(line, "beads_dir="+townBeadsDir) || strings.Contains(line, "beads_dir="+rigBeadsDir) {
+				t.Fatalf("agent lifecycle call was not town-scoped: %s", line)
+			}
+		case strings.Contains(line, workID):
+			if !strings.Contains(line, "beads_dir="+rigBeadsDir) {
+				t.Fatalf("work issue call was not rig-scoped: %s", line)
+			}
+		}
+	}
+}

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -275,7 +275,8 @@ func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 
 	if err := cmd.Run(); err != nil {
 		errMsg := strings.TrimSpace(stderr.String())
-		if strings.Contains(errMsg, "not found") {
+		lowerErr := strings.ToLower(errMsg)
+		if strings.Contains(lowerErr, "not found") || strings.Contains(lowerErr, "no issue found") || strings.Contains(lowerErr, "no issues found") {
 			return nil, fmt.Errorf("agent bead not found: %s", agentBead)
 		}
 		if errMsg != "" {

--- a/internal/cmd/agent_tracking_beads.go
+++ b/internal/cmd/agent_tracking_beads.go
@@ -33,17 +33,33 @@ func findCwdBeadsWorkDir() (string, error) {
 	return "", fmt.Errorf("no .beads directory found")
 }
 
-// resolveAgentTrackingBeadsDir resolves the bead database used for agent state.
-// Agent tracking follows the agent's current rig, so cwd-local redirects must
-// win over an inherited town-level BEADS_DIR. The env-first resolver remains a
-// fallback for contexts that do not have a cwd-local .beads directory.
+// resolveAgentTrackingBeadsDir resolves the database used for agent identity
+// state. Agent beads are town-owned even though their IDs use the owning rig's
+// prefix, so allowing normal prefix routing (or pinning the cwd-local rig DB)
+// sends a rig agent lookup to the work-issue database and returns not found.
+//
+// Prefer the town database discovered from CWD. The local/env resolver remains
+// a fallback for standalone or partially initialized workspaces where no town
+// marker is available yet.
 func resolveAgentTrackingBeadsDir() (string, error) {
-	workDir, err := findCwdBeadsWorkDir()
-	if err != nil {
-		workDir, err = findLocalBeadsDir()
+	cwd, err := os.Getwd()
+	if err == nil {
+		if townRoot := beads.FindTownRoot(cwd); townRoot != "" {
+			if beadsDir := beads.ResolveBeadsDir(beads.GetTownBeadsPath(townRoot)); beadsDir != "" {
+				return beadsDir, nil
+			}
+		}
 	}
-	if err != nil {
-		return "", err
+
+	workDir, localErr := findCwdBeadsWorkDir()
+	if localErr != nil {
+		workDir, localErr = findLocalBeadsDir()
+	}
+	if localErr != nil {
+		if err != nil {
+			return "", err
+		}
+		return "", localErr
 	}
 
 	beadsDir := beads.ResolveBeadsDir(workDir)

--- a/internal/cmd/agent_tracking_beads_test.go
+++ b/internal/cmd/agent_tracking_beads_test.go
@@ -8,21 +8,24 @@ import (
 	"testing"
 )
 
-func TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir(t *testing.T) {
-	tmp := t.TempDir()
+func TestResolveAgentTrackingBeadsDirUsesTownFromTownAndRigCwd(t *testing.T) {
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
 	townRoot := filepath.Join(tmp, "gt")
 	townBeads := filepath.Join(townRoot, ".beads")
 	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
 	rigRedirect := filepath.Join(rigWorkDir, ".beads")
 	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
 
-	for _, dir := range []string{townBeads, rigRedirect, rigBeads} {
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), townBeads, rigRedirect, rigBeads} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
 	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
 		t.Fatalf("write rig redirect: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
 	}
 	t.Setenv("BEADS_DIR", townBeads)
 
@@ -43,12 +46,17 @@ func TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir(t *testin
 		t.Fatalf("findCwdBeadsWorkDir() = %q, want %q", gotWorkDir, rigWorkDir)
 	}
 
-	gotBeadsDir, err := resolveAgentTrackingBeadsDir()
-	if err != nil {
-		t.Fatalf("resolveAgentTrackingBeadsDir() error = %v", err)
-	}
-	if gotBeadsDir != rigBeads {
-		t.Fatalf("resolveAgentTrackingBeadsDir() = %q, want %q", gotBeadsDir, rigBeads)
+	for _, cwd := range []string{rigWorkDir, townRoot} {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("chdir %s: %v", cwd, err)
+		}
+		gotBeadsDir, err := resolveAgentTrackingBeadsDir()
+		if err != nil {
+			t.Fatalf("resolveAgentTrackingBeadsDir() from %s error = %v", cwd, err)
+		}
+		if gotBeadsDir != townBeads {
+			t.Fatalf("resolveAgentTrackingBeadsDir() from %s = %q, want town %q", cwd, gotBeadsDir, townBeads)
+		}
 	}
 
 	gotLocalWorkDir, err := findLocalBeadsDir()
@@ -60,19 +68,19 @@ func TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir(t *testin
 	}
 }
 
-func TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
+func TestRunAgentStateUsesTownBeadsDirFromTownAndRigCwd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses a POSIX shell fake bd")
 	}
 
-	tmp := t.TempDir()
+	tmp, _ := filepath.EvalSymlinks(t.TempDir())
 	townRoot := filepath.Join(tmp, "gt")
 	townBeads := filepath.Join(townRoot, ".beads")
 	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
 	rigRedirect := filepath.Join(rigWorkDir, ".beads")
 	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
 
-	for _, dir := range []string{townBeads, rigRedirect, rigBeads} {
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), townBeads, rigRedirect, rigBeads} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
@@ -80,9 +88,14 @@ func TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
 		t.Fatalf("write rig redirect: %v", err)
 	}
-	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
-	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), metadata, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`), 0o644); err != nil {
 		t.Fatalf("write rig metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townBeads, "metadata.json"), []byte(`{"dolt_database":"town","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`), 0o644); err != nil {
+		t.Fatalf("write town metadata: %v", err)
 	}
 
 	binDir := filepath.Join(tmp, "bin")
@@ -120,10 +133,6 @@ esac
 		t.Fatalf("getwd: %v", err)
 	}
 	defer func() { _ = os.Chdir(oldWd) }()
-	if err := os.Chdir(rigWorkDir); err != nil {
-		t.Fatalf("chdir rig work dir: %v", err)
-	}
-
 	oldSet := agentStateSet
 	oldIncr := agentStateIncr
 	oldDel := agentStateDel
@@ -139,8 +148,13 @@ esac
 	agentStateDel = nil
 	agentStateJSON = false
 
-	if err := runAgentState(nil, []string{"gt-gastown-refinery"}); err != nil {
-		t.Fatalf("runAgentState() error = %v", err)
+	for _, cwd := range []string{rigWorkDir, townRoot} {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("chdir %s: %v", cwd, err)
+		}
+		if err := runAgentState(nil, []string{"gt-gastown-refinery"}); err != nil {
+			t.Fatalf("runAgentState() from %s error = %v", cwd, err)
+		}
 	}
 
 	data, err := os.ReadFile(logPath)
@@ -153,14 +167,14 @@ esac
 	}
 
 	for _, line := range strings.Split(log, "\n") {
-		if !strings.Contains(line, "BEADS_DIR="+rigBeads) {
-			t.Fatalf("bd call was not pinned to rig beads %q: %s\nfull log:\n%s", rigBeads, line, log)
+		if !strings.Contains(line, "BEADS_DIR="+townBeads) {
+			t.Fatalf("bd call was not pinned to town beads %q: %s\nfull log:\n%s", townBeads, line, log)
 		}
-		if strings.Contains(line, "BEADS_DIR="+townBeads) {
-			t.Fatalf("bd call used inherited town BEADS_DIR %q: %s\nfull log:\n%s", townBeads, line, log)
+		if strings.Contains(line, "BEADS_DIR="+rigBeads) {
+			t.Fatalf("bd call used rig BEADS_DIR %q: %s\nfull log:\n%s", rigBeads, line, log)
 		}
-		if !strings.Contains(line, "DB=rigdb") || strings.Contains(line, "DB=town") {
-			t.Fatalf("bd call was not pinned to rig database: %s\nfull log:\n%s", line, log)
+		if !strings.Contains(line, "DB=town") || strings.Contains(line, "DB=rigdb") {
+			t.Fatalf("bd call was not pinned to town database: %s\nfull log:\n%s", line, log)
 		}
 		if strings.Contains(line, "cmd=show") {
 			if !strings.Contains(line, "READONLY=true") || !strings.Contains(line, "AUTO=off") {
@@ -172,5 +186,30 @@ esac
 				t.Fatalf("bd mutation was not mutation pinned: %s\nfull log:\n%s", line, log)
 			}
 		}
+	}
+}
+
+func TestGetAllAgentLabelsRejectsNonzeroJSONError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+printf '%s\n' '{"error":"no issues found matching the provided IDs","schema_version":1}'
+printf '%s\n' 'Error fetching gt-missing: no issue found matching "gt-missing"' >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	labels, err := getAllAgentLabels("gt-missing", t.TempDir())
+	if err == nil {
+		t.Fatalf("getAllAgentLabels() = %v, nil; want nonzero bd exit to fail", labels)
+	}
+	if !strings.Contains(err.Error(), "agent bead not found") {
+		t.Fatalf("getAllAgentLabels() error = %q, want not-found diagnostic", err)
 	}
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -24,9 +24,10 @@ var agentsResolveCmd = &cobra.Command{
 	Short: "Resolve the active agent bead for a role",
 	Long: `Resolve the active agent bead for a role.
 
-The resolver searches the current rig database and the town database across
-both durable issues and ephemeral wisps. It prefers the current rig's wisp
-record, then rig issue, town wisp, and town issue. Closed beads are ignored.`,
+Agent identity beads are town-owned even when their IDs carry a rig prefix.
+The resolver searches the town database across durable issues and ephemeral
+wisps, falling back to a local database only outside a Gas Town workspace.
+Closed beads are ignored.`,
 	RunE: runAgentsResolve,
 }
 
@@ -108,10 +109,6 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 		}
 		return fmt.Errorf("%s", message)
 	}
-	if rig != "" && agentBeadSourceIsTown(match.Source) && !agentsResolveJSON {
-		return fmt.Errorf("agent bead %s was found only in %s; patrol await/state commands require a rig-local agent bead", match.ID, match.Source)
-	}
-
 	if agentsResolveJSON {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(agentsResolveResult{
 			ID:       match.ID,
@@ -126,29 +123,11 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 }
 
 func findAgentBeadCandidates(cwd, currentBeadsDir string) ([]agentBeadCandidate, error) {
-	var candidates []agentBeadCandidate
-
-	rigCandidates, err := loadAgentBeadsFromDir(currentBeadsDir, agentSourceRigIssues, agentSourceRigWisps)
-	if err != nil {
-		return nil, err
+	issueSource, wispSource := agentSourceTownIssues, agentSourceTownWisps
+	if beads.FindTownRoot(cwd) == "" {
+		issueSource, wispSource = agentSourceRigIssues, agentSourceRigWisps
 	}
-	candidates = append(candidates, rigCandidates...)
-
-	townRoot := beads.FindTownRoot(cwd)
-	if townRoot == "" {
-		return candidates, nil
-	}
-	townBeadsDir := beads.ResolveBeadsDir(beads.GetTownBeadsPath(townRoot))
-	if townBeadsDir == "" || filepath.Clean(townBeadsDir) == filepath.Clean(currentBeadsDir) {
-		return candidates, nil
-	}
-
-	townCandidates, err := loadAgentBeadsFromDir(townBeadsDir, agentSourceTownIssues, agentSourceTownWisps)
-	if err != nil {
-		return nil, err
-	}
-	candidates = append(candidates, townCandidates...)
-	return candidates, nil
+	return loadAgentBeadsFromDir(currentBeadsDir, issueSource, wispSource)
 }
 
 func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSource) ([]agentBeadCandidate, error) {
@@ -260,19 +239,15 @@ func pickBestAgentBead(candidates []agentBeadCandidate) (*agentBeadCandidate, er
 
 func agentBeadSourceRank(source agentBeadSource) int {
 	switch source {
-	case agentSourceRigWisps:
-		return 0
-	case agentSourceRigIssues:
-		return 1
 	case agentSourceTownWisps:
-		return 2
+		return 0
 	case agentSourceTownIssues:
+		return 1
+	case agentSourceRigWisps:
+		return 2
+	case agentSourceRigIssues:
 		return 3
 	default:
 		return 99
 	}
-}
-
-func agentBeadSourceIsTown(source agentBeadSource) bool {
-	return source == agentSourceTownWisps || source == agentSourceTownIssues
 }

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -1,11 +1,68 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
 )
+
+func TestFindAgentBeadCandidatesResolvesSameTownIdentityFromTownAndRigCwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), townBeadsDir, rigDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do case "$arg" in --*) ;; *) cmd="$arg"; break ;; esac; done
+case "$cmd" in
+  version) printf 'bd version 1.2.2\n' ;;
+  list) printf '%s\n' '[{"id":"gt-gastown-refinery","status":"open","labels":["gt:agent"],"description":"role_type: refinery\nrig: gastown"}]' ;;
+  query) printf '%s\n' '[]' ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	for _, cwd := range []string{townRoot, rigDir} {
+		candidates, err := findAgentBeadCandidates(cwd, townBeadsDir)
+		if err != nil {
+			t.Fatalf("find candidates from %s: %v", cwd, err)
+		}
+		var matches []agentBeadCandidate
+		for _, candidate := range candidates {
+			if agentBeadMatches(candidate.Issue, "refinery", "gastown") {
+				matches = append(matches, candidate)
+			}
+		}
+		got, err := pickBestAgentBead(matches)
+		if err != nil {
+			t.Fatalf("pick candidate from %s: %v", cwd, err)
+		}
+		if got == nil || got.ID != "gt-gastown-refinery" || got.Source != agentSourceTownIssues {
+			t.Fatalf("candidate from %s = %#v, want canonical town identity", cwd, got)
+		}
+	}
+}
 
 func TestAgentBeadMatchesDescriptionAndIDFallback(t *testing.T) {
 	tests := []struct {
@@ -87,8 +144,8 @@ func TestPickBestAgentBead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pickBestAgentBead returned error: %v", err)
 	}
-	if got == nil || got.ID != "rig-wisp" {
-		t.Fatalf("pickBestAgentBead picked %v, want rig-wisp", got)
+	if got == nil || got.ID != "town-wisp" {
+		t.Fatalf("pickBestAgentBead picked %v, want town-wisp", got)
 	}
 }
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2117,6 +2117,7 @@ func setDoneIntentLabel(bd *beads.Beads, agentBeadID, exitType string) {
 	if agentBeadID == "" {
 		return
 	}
+	bd = bd.ForAgentBead()
 	label := fmt.Sprintf("done-intent:%s:%d", exitType, time.Now().Unix())
 	if err := bd.Update(agentBeadID, beads.UpdateOptions{
 		AddLabels: []string{label},
@@ -2133,6 +2134,7 @@ func clearDoneIntentLabel(bd *beads.Beads, agentBeadID string) {
 	if agentBeadID == "" {
 		return
 	}
+	bd = bd.ForAgentBead()
 	issue, err := bd.Show(agentBeadID)
 	if err != nil {
 		return // Agent bead gone, nothing to clear
@@ -2173,6 +2175,7 @@ func writeDoneCheckpoint(bd *beads.Beads, agentBeadID string, cp DoneCheckpoint,
 	if agentBeadID == "" {
 		return
 	}
+	bd = bd.ForAgentBead()
 	label := fmt.Sprintf("done-cp:%s:%s:%d", cp, value, time.Now().Unix())
 	if err := bd.Update(agentBeadID, beads.UpdateOptions{
 		AddLabels: []string{label},
@@ -2188,6 +2191,7 @@ func readDoneCheckpoints(bd *beads.Beads, agentBeadID string) map[DoneCheckpoint
 	if agentBeadID == "" {
 		return checkpoints
 	}
+	bd = bd.ForAgentBead()
 	issue, err := bd.Show(agentBeadID)
 	if err != nil {
 		return checkpoints
@@ -2212,6 +2216,7 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 	if agentBeadID == "" {
 		return
 	}
+	bd = bd.ForAgentBead()
 	issue, err := bd.Show(agentBeadID)
 	if err != nil {
 		return

--- a/internal/cmd/done_agent_routing_test.go
+++ b/internal/cmd/done_agent_routing_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestDoneAgentLifecycleWritesUseTownFromTownAndRigContexts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{{Prefix: "hq-", Path: "."}, {Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'beads_dir=%%s args=%%s\n' "${BEADS_DIR:-<unset>}" "$*" >> %q
+cmd=""
+for arg in "$@"; do case "$arg" in --*) ;; *) cmd="$arg"; break ;; esac; done
+case "$cmd" in
+  version) printf 'bd version 1.2.2\n' ;;
+  show)
+    case "$*" in
+      *gt-gastown-polecat-rust*)
+        [ "${BEADS_DIR:-}" = %q ] || exit 9
+        printf '%%s\n' '[{"id":"gt-gastown-polecat-rust","title":"rust","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: working\nhook_bead: gt-work-1"}]'
+        ;;
+      *gt-work-1*)
+        [ "${BEADS_DIR:-}" = %q ] || exit 8
+        printf '%%s\n' '[{"id":"gt-work-1","title":"work","issue_type":"task","status":"hooked"}]'
+        ;;
+    esac
+    ;;
+  update)
+    case "$*" in *gt-gastown-polecat-rust*) [ "${BEADS_DIR:-}" = %q ] || exit 9 ;; *) exit 7 ;; esac
+    ;;
+esac
+`, logPath, townBeadsDir, rigBeadsDir, townBeadsDir)
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	agentID := "gt-gastown-polecat-rust"
+	workID := "gt-work-1"
+	clients := []*beads.Beads{
+		beads.NewWithBeadsDir(townRoot, townBeadsDir),
+		beads.NewWithBeadsDir(rigDir, rigBeadsDir),
+	}
+	for _, client := range clients {
+		if err := client.UpdateAgentCompletion(agentID, &beads.CompletionMetadata{ExitType: ExitCompleted, HookBead: workID}); err != nil {
+			t.Fatalf("completion write: %v", err)
+		}
+		writeDoneCheckpoint(client, agentID, CheckpointPushed, "branch")
+		empty := ""
+		if err := client.UpdateAgentDescriptionFields(agentID, beads.AgentFieldUpdates{HookBead: &empty}); err != nil {
+			t.Fatalf("hook-clear write: %v", err)
+		}
+		if _, err := client.Show(workID); err != nil {
+			t.Fatalf("rig work lookup: %v", err)
+		}
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		switch {
+		case strings.Contains(line, agentID):
+			if !strings.Contains(line, "beads_dir="+townBeadsDir) || strings.Contains(line, "beads_dir="+rigBeadsDir) {
+				t.Fatalf("agent lifecycle call was not town-scoped: %s", line)
+			}
+		case strings.Contains(line, workID):
+			if !strings.Contains(line, "beads_dir="+rigBeadsDir) {
+				t.Fatalf("work issue call was not rig-scoped: %s", line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- resolve Gas Town agent identity beads against the town database from both town and rig working directories
- keep ordinary work-bead operations rig-scoped
- pin completion, checkpoint, and hook-clear helpers to town agent state
- reject nonzero bd JSON error envelopes before parsing

## Validation

- go test ./...
- go vet ./...
- make build
- focused internal/cmd and internal/beads regression tests
- built CLI reproduction from town and rig working directories

The optional broader make test wrapper also exposed an unrelated pre-existing exit-code bug in plugins/stuck-agent-dog/run_test.sh; that follow-up is tracked separately as Gas Town bead gt-0z6.