### PR TITLE
fix(cmd): scope polecat done guard to top-level `gt done`

### DIFF
--- a/internal/cmd/done_worktree_guard_test.go
+++ b/internal/cmd/done_worktree_guard_test.go
@@ -298,6 +298,58 @@ func TestIsDoneCommand(t *testing.T) {
 	}
 }
 
+// Subcommands named "done" under a parent other than root are their own
+// commands, not `gt done`. Guarding them made `gt dog done` fail with
+// "gt done is for polecats only", leaving completed dog work unable to signal.
+func TestIsDoneCommandIgnoresNestedDoneSubcommands(t *testing.T) {
+	for _, parentName := range []string{"dog", "wl", "molecule"} {
+		t.Run(parentName, func(t *testing.T) {
+			root := &cobra.Command{Use: "gt"}
+			parent := &cobra.Command{Use: parentName}
+			nested := &cobra.Command{Use: "done"}
+			root.AddCommand(parent)
+			parent.AddCommand(nested)
+			if isDoneCommand(nested) {
+				t.Fatalf("gt %s done should not be treated as gt done", parentName)
+			}
+		})
+	}
+}
+
+// The guard must still cover subcommands hanging off the real `gt done`.
+func TestIsDoneCommandCoversDoneSubcommands(t *testing.T) {
+	root := &cobra.Command{Use: "gt"}
+	done := &cobra.Command{Use: "done"}
+	sub := &cobra.Command{Use: "resume"}
+	root.AddCommand(done)
+	done.AddCommand(sub)
+	if !isDoneCommand(sub) {
+		t.Fatal("subcommand of gt done should be detected")
+	}
+}
+
+// The real command tree is the thing that regressed; assert against it directly.
+func TestIsDoneCommandRealTree(t *testing.T) {
+	realDone, _, err := rootCmd.Find([]string{"done"})
+	if err != nil {
+		t.Fatalf("find gt done: %v", err)
+	}
+	if !isDoneCommand(realDone) {
+		t.Fatal("gt done should be detected in the real command tree")
+	}
+
+	dogDone, _, err := rootCmd.Find([]string{"dog", "done"})
+	if err != nil {
+		t.Fatalf("find gt dog done: %v", err)
+	}
+	if dogDone.Name() != "done" || dogDone.Parent() == nil || dogDone.Parent().Name() != "dog" {
+		t.Fatalf("resolved %q, want the dog done subcommand", dogDone.CommandPath())
+	}
+	if isDoneCommand(dogDone) {
+		t.Fatal("gt dog done should not be treated as gt done")
+	}
+}
+
 func TestPersistentPreRunDoneRejectsBeforeRegistryFallback(t *testing.T) {
 	townRoot, _ := setupDoneGuardWorktree(t, "nested", "shiny")
 	initDoneGuardGitRepo(t, townRoot)
@@ -315,7 +367,11 @@ func TestPersistentPreRunDoneRejectsBeforeRegistryFallback(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
+	// Attach to a root the way cobra dispatch does: the guard applies to the
+	// top-level `gt done`, not to any command that happens to be named "done".
+	guardRoot := &cobra.Command{Use: "gt"}
 	done := &cobra.Command{Use: "done"}
+	guardRoot.AddCommand(done)
 	err = persistentPreRun(done, nil)
 	if err == nil || !strings.Contains(err.Error(), "assigned polecat worktree") {
 		t.Fatalf("persistentPreRun error = %v, want assigned worktree rejection", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -189,11 +189,19 @@ func isRoleCommand(cmd *cobra.Command) bool {
 	return false
 }
 
+// isDoneCommand reports whether cmd is the top-level `gt done` (or one of its
+// subcommands), which is polecat-only and gets the worktree ownership guard.
+//
+// Other commands are also named "done" — `gt dog done`, `gt wl done`,
+// `gt molecule step done`. Those are not `gt done` and must not be guarded, so
+// a "done" node only counts when its parent is the root command.
 func isDoneCommand(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "done" {
-			return true
+		if c.Name() != "done" {
+			continue
 		}
+		parent := c.Parent()
+		return parent != nil && parent.Parent() == nil
 	}
 	return false
 }


### PR DESCRIPTION
## Problem

`isDoneCommand` walks the entire ancestor chain and returns true for **any** command named `done`. `persistentPreRun` uses it to apply the polecat worktree-ownership guard, so three unrelated subcommands inherit a polecat-only check:

```
$ gt dog done
Error: gt done is for polecats only (BD_ACTOR=mayor)

$ gt mol step done <step-id>
Error: gt done is for polecats only (BD_ACTOR=mayor)

$ gt wl done <wanted-id>
Error: gt done is for polecats only (BD_ACTOR=mayor)
```

None of these are polecat commands, and all three are unreachable for any non-polecat actor — which is every actor that legitimately runs them.

The dog case is the damaging one. `gt dog done` is how a dog clears its work and returns to idle, and dogs are dispatched by the Deacon, never by a polecat. A dog that finishes its assignment has no way to signal completion: work stays `working` forever, the tmux session is never reaped, and the kennel fills with dogs that look busy but aren't. We hit this with a 6/6-complete workflow that could not close out.

`gt mol step done` and `gt wl done` fail arg validation first when invoked bare, which is why this stayed hidden — pass a real argument and the guard fires.

## Fix

A `done` node only counts when its parent is the root command. That still covers `gt done` and any subcommand hanging off it, while leaving `dog`/`mol step`/`wl` siblings alone.

## Tests

`TestPersistentPreRunDoneRejectsBeforeRegistryFallback` built a parentless `&cobra.Command{Use: "done"}`. A command with no parent isn't something cobra dispatch produces, and the fixture is the only reason the old behavior looked correct — it's attached to a root now.

Added:
- `TestIsDoneCommandIgnoresNestedDoneSubcommands` — dog/wl/molecule siblings
- `TestIsDoneCommandCoversDoneSubcommands` — guard still reaches `gt done` subcommands
- `TestIsDoneCommandRealTree` — asserts against the actual `rootCmd` tree, since that's what regressed

Verified against a built binary:

```
# before
$ gt dog done
Error: gt done is for polecats only (BD_ACTOR=mayor)

# after
$ gt dog done
Dog alpha is already idle with no work

# gt done still guarded
$ gt done
Error: gt done is for polecats only (BD_ACTOR=mayor)
```

`go test ./internal/cmd/ -run 'Done|Dog'` passes except `TestRunDoneWithRoutedIssueIgnoresCurrentRigMirror`, which fails identically on unmodified `main` at 649b832 and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)