### PR TITLE
fix(cmd): route handoff-bead lookups through ForAgentBead

### DIFF
--- a/internal/cmd/molecule_attach.go
+++ b/internal/cmd/molecule_attach.go
@@ -19,7 +19,12 @@ func runMoleculeAttach(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
-	b := beads.New(workDir)
+	// Pinned beads — handoff beads and agent beads alike — live in the town
+	// database, but they carry rig prefixes, so prefix routing sends every
+	// lookup to the rig database where they do not exist. ForAgentBead re-roots
+	// at the town beads dir and disables routing; without it, attach fails with
+	// "fetching pinned bead: issue not found" from any rig context.
+	b := beads.New(workDir).ForAgentBead()
 
 	if len(args) == 2 {
 		// Explicit: gt mol attach <pinned-bead-id> <molecule-id>
@@ -61,12 +66,13 @@ func runMoleculeAttach(cmd *cobra.Command, args []string) error {
 
 		role := extractRoleFromIdentity(target)
 
-		handoff, err := b.FindHandoffBead(role)
+		// Create the handoff bead if this role doesn't have one yet. Attaching is
+		// the point at which a role first needs its pin, and nothing else in the
+		// codebase creates it — requiring it to pre-exist meant attach could never
+		// succeed for a role that had not somehow acquired one already.
+		handoff, err := b.GetOrCreateHandoffBead(role)
 		if err != nil {
 			return fmt.Errorf("finding handoff bead: %w", err)
-		}
-		if handoff == nil {
-			return fmt.Errorf("no handoff bead found for %s (looked for %q with pinned status)", target, beads.HandoffBeadTitle(role))
 		}
 		pinnedBeadID = handoff.ID
 	}

--- a/internal/cmd/molecule_lifecycle.go
+++ b/internal/cmd/molecule_lifecycle.go
@@ -61,7 +61,10 @@ func runMoleculeBurn(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
-	b := beads.New(workDir)
+	// Handoff beads live in the town database but carry rig prefixes, so prefix
+	// routing sends lookups to the rig database where they do not exist.
+	// ForAgentBead re-roots at the town beads dir and disables routing.
+	b := beads.New(workDir).ForAgentBead()
 
 	// Find agent's pinned bead (handoff bead)
 	role := extractRoleFromIdentity(target)
@@ -70,8 +73,13 @@ func runMoleculeBurn(cmd *cobra.Command, args []string) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("finding handoff bead: %w", err)
 	}
+
+	// A role with no handoff bead has nothing attached — the same outcome as an
+	// unattached pin. Burning is a no-op either way, so don't fail the caller.
 	if handoff == nil {
-		return fmt.Errorf("no handoff bead found for %s (looked for %q with pinned status)", target, beads.HandoffBeadTitle(role))
+		fmt.Printf("%s No molecule attached to %s - nothing to burn\n",
+			style.Dim.Render("ℹ"), target)
+		return nil
 	}
 
 	// Check for attached molecule
@@ -195,7 +203,10 @@ func runMoleculeSquash(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
-	b := beads.New(workDir)
+	// Handoff beads live in the town database but carry rig prefixes, so prefix
+	// routing sends lookups to the rig database where they do not exist.
+	// ForAgentBead re-roots at the town beads dir and disables routing.
+	b := beads.New(workDir).ForAgentBead()
 
 	// Find agent's pinned bead (handoff bead)
 	role := extractRoleFromIdentity(target)
@@ -204,8 +215,13 @@ func runMoleculeSquash(cmd *cobra.Command, args []string) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("finding handoff bead: %w", err)
 	}
+
+	// A role with no handoff bead has nothing attached — the same outcome as an
+	// unattached pin. Squashing is a no-op either way, so don't fail the caller.
 	if handoff == nil {
-		return fmt.Errorf("no handoff bead found for %s (looked for %q with pinned status)", target, beads.HandoffBeadTitle(role))
+		fmt.Printf("%s No molecule attached to %s - nothing to squash\n",
+			style.Dim.Render("ℹ"), target)
+		return nil
 	}
 
 	// Check for attached molecule

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -1058,3 +1058,73 @@ exit /b 0
 			"Beads closed: %v", closeLines)
 	}
 }
+
+// A role with no pinned handoff bead has nothing attached, so burn and squash
+// are no-ops. They used to return "no handoff bead found for %s", which meant a
+// patrol agent could not close its cycle: burn failed, squash failed, and the
+// error looked like a broken workspace rather than an empty one.
+func TestBurnAndSquashNoOpWithoutHandoffBead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(*cobra.Command, []string) error
+	}{
+		{"burn", runMoleculeBurn},
+		{"squash", runMoleculeSquash},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+				t.Fatalf("mkdir mayor: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Join(townRoot, ".beads", "locks"), 0755); err != nil {
+				t.Fatalf("mkdir .beads/locks: %v", err)
+			}
+
+			binDir := filepath.Join(townRoot, "bin")
+			if err := os.MkdirAll(binDir, 0755); err != nil {
+				t.Fatalf("mkdir bin: %v", err)
+			}
+
+			// No pinned beads exist — FindHandoffBead returns nil, not an error.
+			bdScript := `#!/bin/sh
+while [ "$1" = "--allow-stale" ]; do shift; done
+echo '[]'
+exit 0
+`
+			if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+				t.Fatalf("write bd stub: %v", err)
+			}
+
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv(EnvGTRole, "witness")
+			t.Setenv("GT_POLECAT", "")
+			t.Setenv("GT_CREW", "")
+			t.Setenv("GT_RIG", "")
+			t.Setenv("TMUX_PANE", "")
+			t.Setenv("BEADS_DIR", "")
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(cwd) })
+			if err := os.Chdir(townRoot); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
+
+			prevJSON := moleculeJSON
+			t.Cleanup(func() { moleculeJSON = prevJSON })
+			moleculeJSON = false
+
+			cmd := &cobra.Command{Use: tc.name}
+			cmd.SetContext(context.Background())
+			if err := tc.run(cmd, []string{"witness"}); err != nil {
+				t.Fatalf("%s with no handoff bead returned error, want no-op: %v", tc.name, err)
+			}
+		})
+	}
+}

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -959,7 +959,10 @@ func runMoleculeCurrent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
-	b := beads.New(workDir)
+	// Handoff beads live in the town database but carry rig prefixes, so prefix
+	// routing sends lookups to the rig database where they do not exist.
+	// ForAgentBead re-roots at the town beads dir and disables routing.
+	b := beads.New(workDir).ForAgentBead()
 
 	// Extract role from target for handoff bead lookup
 	role := extractRoleFromIdentity(target)

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1544,8 +1544,10 @@ func capitalizeFirst(s string) string {
 func discoverRigHooks(r *rig.Rig, crews []string) []AgentHookInfo {
 	var hooks []AgentHookInfo
 
-	// Create beads instance for the rig
-	b := beads.New(r.Path)
+	// Handoff beads live in the town database but carry rig prefixes, so prefix
+	// routing sends lookups to the rig database where they do not exist, and
+	// every agent read as unhooked. ForAgentBead re-roots and disables routing.
+	b := beads.New(r.Path).ForAgentBead()
 
 	// Batch-fetch all handoff beads in one bd call
 	allHandoffs, err := b.FindAllHandoffBeads()


### PR DESCRIPTION
## Problem

Pinned handoff beads live in the **town** database but carry **rig** prefixes, so prefix routing sends every lookup to the rig database, where they do not exist.

`ForAgentBead` already exists for exactly this hazard — its doc comment describes it precisely ("any agent-bead operation issued from a rig context ... gets sent to the wrong DB and fails with 'issue not found'") — but the molecule commands built their handle with a bare `beads.New(findLocalBeadsDir())`.

Run from inside a rig, that database has no handoff bead for any role:

| Command | Before |
|---|---|
| `gt mol attach <mol>` | `no handoff bead found for <rig>/witness` |
| `gt mol attach <id> <mol>` | `attaching molecule: fetching pinned bead: issue not found` |
| `gt mol burn` | `no handoff bead found for <rig>/refinery` |
| `gt mol squash` | `no handoff bead found for <rig>/refinery` |
| `gt mol current` | `naked - awaiting work assignment` (with a pin present) |
| `gt status` | every agent reads as unhooked |

Witness and refinery patrols could not attach a molecule, could not burn or squash one, and so could not close a cycle. Agents reported it as *"no pinned handoff bead exists for any role, town-wide"* — accurate from where they were standing, since the town database was never the one being read.

## Two further gaps

Routing alone doesn't fix attach.

**Nothing created the pin.** `GetOrCreateHandoffBead` is fully implemented, tested, and had **no production caller**. All seven read sites use `FindHandoffBead`, which returns nil when absent. Attach now creates on demand — it's the point at which a role first needs its pin, and creation is idempotent.

**Burn and squash treated a missing pin as an error.** A role with no handoff bead has nothing attached, which is the same outcome as an unattached pin — both already have a "nothing to burn/squash" branch. They now take it instead of failing a patrol that had nothing to do.

## Verification

Against a live town:

```
# gt mol attach, auto-detect, as a witness
before:  Error: no handoff bead found for trustsig_frontend/witness
after:   ✓ Attached mol-witness-patrol to hq-g2r

# gt mol current — same database state, both binaries
before:  Handoff: (none)      Status: naked - awaiting work assignment
after:   Handoff: hq-g2r (witness Handoff)   Molecule: mol-witness-patrol

# gt mol burn, role with no pin
before:  Error: no handoff bead found for trustsig_frontend/refinery
after:   ℹ No molecule attached to trustsig_frontend/refinery - nothing to burn
```

Explicit `gt mol attach <agent-bead-id>` now resolves the bead and correctly rejects it with `issue ... is not pinned (status: open)` rather than `issue not found` — agent beads were never a valid attach target, but the routing bug masked that with a misleading error.

## Tests

`TestBurnAndSquashNoOpWithoutHandoffBead` covers the no-op semantics for both commands, using the existing shell-stub `bd` pattern. Confirmed it fails without the fix:

```
burn with no handoff bead returned error, want no-op:
  no handoff bead found for witness (looked for "witness Handoff" with pinned status)
```

`go build ./...` and `go vet ./internal/cmd/` are clean. Two tests fail in `./internal/cmd/` — `TestRunDoneWithRoutedIssueIgnoresCurrentRigMirror` and `TestRunMoleculeAwaitSignalAgentBeadUsesCwdRigBeadsDirWhenBeadsDirPointsTown` — both reproduce identically on unmodified `main` at 649b832 and are untouched here.

The routing change itself is covered only by the live verification above; I did not find a cheap way to assert database selection without a full town fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)