### PR TITLE
feat: enforce bead-first runtime guard

### DIFF
--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -19,6 +19,7 @@ is violated. They're called before the tool runs, preventing the
 forbidden operation entirely.
 
 Available guards:
+  bead-first         - Require a primed, hooked Polecat for mutations
   pr-workflow        - Block PR creation and feature branches
   bd-init            - Block bd init in wrong directories
   mol-patrol         - Block mol patrol from agent contexts
@@ -64,6 +65,7 @@ Humans running outside Gas Town with a fork origin can still use PRs.`,
 func init() {
 	tapCmd.AddCommand(tapGuardCmd)
 	tapGuardCmd.AddCommand(tapGuardPRWorkflowCmd)
+	tapGuardCmd.AddCommand(tapGuardBeadFirstCmd)
 }
 
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/tap_guard_bead_first.go
+++ b/internal/cmd/tap_guard_bead_first.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/events"
+)
+
+// beadFirstExec is replaceable in tests. Keeping the policy in the runtime,
+// rather than in a site-specific shell script, makes it usable by every agent
+// provider that implements PreToolUse hooks.
+var beadFirstExec = func(dir, name string, args ...string) ([]byte, error) {
+	c := exec.Command(name, args...)
+	c.Dir = dir
+	return c.Output()
+}
+
+var tapGuardBeadFirstCmd = &cobra.Command{
+	Use:   "bead-first",
+	Short: "Require bead-first workflow for repository mutations",
+	Long: `Gate repository mutations, pull requests, and deploys.
+
+The operation is allowed only from a primed Polecat session with a currently
+hooked bead. Set GT_BEAD_FIRST_OVERRIDE to a non-empty justification for an
+audited emergency override. Read-only commands and Gas Town/Beads workflow
+commands are allowed directly. The guard reads standard PreToolUse JSON on
+stdin and exits 2 when an operation is denied.`,
+	RunE: runTapGuardBeadFirst,
+}
+
+type beadFirstHookInput struct {
+	ToolName  string `json:"tool_name"`
+	ToolInput struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+}
+
+type beadFirstIssue struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func runTapGuardBeadFirst(cmd *cobra.Command, args []string) error {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil // hook protocol errors fail open, matching the other guards
+	}
+	var hook beadFirstHookInput
+	if json.Unmarshal(input, &hook) != nil || !isBeadFirstMutation(hook.ToolName, hook.ToolInput.Command) {
+		return nil
+	}
+
+	actor := strings.TrimSpace(os.Getenv("GT_ROLE"))
+	if reason := beadFirstOverrideReason(); reason != "" {
+		_ = events.LogAudit("bead_first_override", actor, map[string]interface{}{
+			"reason": reason, "tool": hook.ToolName, "command": hook.ToolInput.Command,
+		})
+		return nil
+	}
+
+	cwd, _ := os.Getwd()
+	reason := beadFirstDenialReason(cwd, actor)
+	if reason == "" {
+		return nil
+	}
+	_ = events.LogAudit("bead_first_denied", actor, map[string]interface{}{
+		"reason": reason, "tool": hook.ToolName, "command": hook.ToolInput.Command,
+	})
+	fmt.Fprintf(os.Stderr, "BEAD-FIRST GATE: operation blocked: %s\n", reason)
+	fmt.Fprintln(os.Stderr, "Run gt prime, work from an assigned Polecat with a hooked bead, or set GT_BEAD_FIRST_OVERRIDE to an emergency justification.")
+	return NewSilentExit(2)
+}
+
+func beadFirstOverrideReason() string {
+	return strings.TrimSpace(os.Getenv("GT_BEAD_FIRST_OVERRIDE"))
+}
+
+func isBeadFirstMutation(tool, command string) bool {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "write", "edit", "multiedit", "notebookedit":
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(command))
+	if lower == "" || isBeadFirstDirectCommand(lower) {
+		return false
+	}
+	markers := []string{
+		"git commit", "git push", "git merge", "git rebase", "git tag", "git checkout -b", "git switch -c",
+		"gh pr create", "gh pr merge", "gh release create", "vercel deploy", "firebase deploy", "gcloud deploy",
+		"kubectl apply", "helm upgrade", "terraform apply", "pulumi up", "npm publish", "docker push",
+	}
+	for _, marker := range markers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// Workflow and inspection commands form the deliberately narrow direct
+// allowlist. They do not mutate source code or external deployment state.
+func isBeadFirstDirectCommand(command string) bool {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return true
+	}
+	if fields[0] == "bd" || fields[0] == "gt" {
+		return true
+	}
+	return false
+}
+
+func beadFirstDenialReason(cwd, role string) string {
+	parts := strings.Split(role, "/")
+	if len(parts) != 3 || parts[1] != "polecats" || parts[2] == "" {
+		return "mutations must be delegated to a Polecat"
+	}
+	if os.Getenv("GT_SESSION") == "" {
+		return "Polecat session identity is missing"
+	}
+	if !hasFreshPrimeMarker(cwd) {
+		return "session has not been primed"
+	}
+	out, err := beadFirstExec(cwd, "bd", "list", "--status=hooked", "--assignee="+role, "--json")
+	if err != nil {
+		return "unable to verify hooked bead"
+	}
+	var issues []beadFirstIssue
+	if json.Unmarshal(out, &issues) != nil || len(issues) == 0 {
+		return "Polecat has no currently hooked bead"
+	}
+	for _, issue := range issues {
+		if issue.ID != "" && issue.Status == "hooked" {
+			return ""
+		}
+	}
+	return "Polecat hook is stale"
+}
+
+func hasFreshPrimeMarker(cwd string) bool {
+	for dir := cwd; ; dir = filepath.Dir(dir) {
+		path := filepath.Join(dir, ".runtime", "session_id")
+		if info, err := os.Stat(path); err == nil && !info.IsDir() && time.Since(info.ModTime()) < 24*time.Hour {
+			return true
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			return false
+		}
+	}
+}

--- a/internal/cmd/tap_guard_bead_first_test.go
+++ b/internal/cmd/tap_guard_bead_first_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsBeadFirstMutation(t *testing.T) {
+	tests := []struct {
+		tool, command string
+		want          bool
+	}{
+		{"Write", "", true},
+		{"Bash", "git commit -m test", true},
+		{"Bash", "gh pr create --fill", true},
+		{"Bash", "firebase deploy", true},
+		{"Bash", "git status", false},
+		{"Bash", "bd create --title=x", false},
+		{"Bash", "gt sling gt-abc rig", false},
+	}
+	for _, tt := range tests {
+		if got := isBeadFirstMutation(tt.tool, tt.command); got != tt.want {
+			t.Errorf("isBeadFirstMutation(%q, %q)=%v, want %v", tt.tool, tt.command, got, tt.want)
+		}
+	}
+}
+
+func TestBeadFirstDenialReason(t *testing.T) {
+	original := beadFirstExec
+	t.Cleanup(func() { beadFirstExec = original })
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".runtime"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".runtime", "session_id"), []byte("session"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GT_SESSION", "gt-demo-toast")
+
+	if got := beadFirstDenialReason(dir, "demo/mayor"); got == "" {
+		t.Fatal("mayor unexpectedly allowed")
+	}
+	beadFirstExec = func(string, string, ...string) ([]byte, error) {
+		return []byte(`[{"id":"gt-abc","status":"hooked"}]`), nil
+	}
+	if got := beadFirstDenialReason(dir, "demo/polecats/toast"); got != "" {
+		t.Fatalf("valid hook denied: %s", got)
+	}
+	beadFirstExec = func(string, string, ...string) ([]byte, error) { return []byte(`[]`), nil }
+	if got := beadFirstDenialReason(dir, "demo/polecats/toast"); got == "" {
+		t.Fatal("missing hook unexpectedly allowed")
+	}
+	beadFirstExec = func(string, string, ...string) ([]byte, error) {
+		return []byte(`[{"id":"gt-abc","status":"open"}]`), nil
+	}
+	if got := beadFirstDenialReason(dir, "demo/polecats/toast"); got != "Polecat hook is stale" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBeadFirstOverrideIsExplicit(t *testing.T) {
+	t.Setenv("GT_BEAD_FIRST_OVERRIDE", "incident-42")
+	if got := beadFirstOverrideReason(); got != "incident-42" {
+		t.Fatalf("override reason = %q", got)
+	}
+	t.Setenv("GT_BEAD_FIRST_OVERRIDE", "   ")
+	if got := beadFirstOverrideReason(); got != "" {
+		t.Fatalf("blank override unexpectedly accepted: %q", got)
+	}
+}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1018,6 +1018,10 @@ func DefaultBase() *HooksConfig {
 	return &HooksConfig{
 		PreToolUse: []HookEntry{
 			{
+				Matcher: "Write|Edit|MultiEdit|NotebookEdit|Bash",
+				Hooks: []Hook{{Type: "command", Command: gtCommand("gt tap guard bead-first")}},
+			},
+			{
 				Matcher: "Bash(gh pr create*)",
 				Hooks: []Hook{{
 					Type:    "command",


### PR DESCRIPTION
## Summary
- add a generic runtime bead-first PreToolUse guard for source mutations, PRs, releases, and deploys
- require a primed Polecat session with a currently hooked bead
- provide an explicit justification-based emergency override with audit events
- install the guard in the default hook set and cover allow, deny, and stale-hook behavior

## Verification
- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test(IsBeadFirstMutation|BeadFirstDenialReason|BeadFirstOverrideIsExplicit)$' -count=1`\n- `CGO_ENABLED=0 go test ./internal/hooks -count=1`\n\nIssue: gt-2dv\n\nHost note: normal CGO compilation requires ICU headers (`unicode/regex.h`), which were unavailable locally.