### PR TITLE
fix(tmux): select the affirmative option in the workspace trust dialog

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2014,7 +2014,15 @@ func (t *Tmux) AcceptWorkspaceTrustDialog(session string) error {
 		// Codex trust screens include a leading ">" banner line, so prompt
 		// detection alone would exit too early.
 		if containsWorkspaceTrustDialog(content) {
-			// Dialog found — accept it (option 1 is pre-selected, just press Enter)
+			// Move the selection onto the affirmative option before confirming.
+			// Do NOT assume the first option is affirmative: Claude Code's trust
+			// dialog pre-selects "No, exit", so a bare Enter tells the agent to
+			// quit and the session dies seconds after it was created.
+			for i := 0; i < trustDialogDownPresses(content); i++ {
+				if _, err := t.run("send-keys", "-t", session, "Down"); err != nil {
+					return err
+				}
+			}
 			if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
 				return err
 			}
@@ -2035,6 +2043,84 @@ func (t *Tmux) AcceptWorkspaceTrustDialog(session string) error {
 
 	// Timeout — no dialog detected, safe to proceed
 	return nil
+}
+
+// trustDialogSelectionMarkers are the glyphs a TUI uses to mark the currently
+// highlighted option.
+var trustDialogSelectionMarkers = []string{"\u276f", "\u25b6", "\u2192", "*", ">"}
+
+// trustDialogAffirmativeHints identify the option that grants trust. Matching on
+// text rather than ordinal position keeps this correct if the agent reorders its
+// options, which is exactly the assumption that broke before.
+var trustDialogAffirmativeHints = []string{
+	"yes, i trust",
+	"yes, proceed",
+	"trust this folder",
+	"trust the files",
+	"yes, trust",
+}
+
+// trustDialogOptionLines returns the option lines of a trust dialog in display
+// order, along with the index of the currently selected one (-1 if unknown).
+func trustDialogOptionLines(content string) ([]string, int) {
+	var options []string
+	selected := -1
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		marked := false
+		for _, marker := range trustDialogSelectionMarkers {
+			if strings.HasPrefix(line, marker) {
+				line = strings.TrimSpace(strings.TrimPrefix(line, marker))
+				marked = true
+				break
+			}
+		}
+		lower := strings.ToLower(line)
+		// An option line either grants trust or declines it.
+		isOption := false
+		for _, hint := range trustDialogAffirmativeHints {
+			if strings.Contains(lower, hint) {
+				isOption = true
+				break
+			}
+		}
+		if !isOption && (strings.HasPrefix(lower, "no,") || strings.HasPrefix(lower, "no ") || lower == "no") {
+			isOption = true
+		}
+		if !isOption {
+			continue
+		}
+		if marked {
+			selected = len(options)
+		}
+		options = append(options, lower)
+	}
+	return options, selected
+}
+
+// trustDialogDownPresses reports how many Down keypresses move the selection
+// from its current position onto the affirmative option. It returns 0 when the
+// affirmative option is already selected, or when the dialog cannot be parsed —
+// in which case the caller falls back to confirming whatever is selected.
+func trustDialogDownPresses(content string) int {
+	options, selected := trustDialogOptionLines(content)
+	if len(options) == 0 || selected < 0 {
+		return 0
+	}
+	for i, opt := range options {
+		for _, hint := range trustDialogAffirmativeHints {
+			if strings.Contains(opt, hint) {
+				if i <= selected {
+					return 0
+				}
+				return i - selected
+			}
+		}
+	}
+	return 0
 }
 
 func containsWorkspaceTrustDialog(content string) bool {

--- a/internal/tmux/trust_dialog_test.go
+++ b/internal/tmux/trust_dialog_test.go
@@ -1,0 +1,77 @@
+package tmux
+
+import "testing"
+
+// claudeTrustDialog is captured verbatim from a live polecat session that died
+// during startup. Claude Code pre-selects "No, exit", so confirming the
+// pre-selected option quits the agent.
+const claudeTrustDialog = `────────────────────────────────────────────────────
+ Accessing workspace:
+
+ /Users/x/gt/gastown/polecats/obsidian/gastown
+
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ No, exit
+   Yes, I trust this folder
+
+ Enter to confirm · Esc to cancel
+`
+
+// affirmativeFirst covers an agent that lists the trusting option first.
+const affirmativeFirst = `Do you trust the contents of this directory?
+
+ ❯ Yes, I trust this folder
+   No, exit
+`
+
+func TestTrustDialogDownPresses(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"claude puts No first, must move down one", claudeTrustDialog, 1},
+		{"affirmative already selected, do not move", affirmativeFirst, 0},
+		{"unparseable content falls back to confirming", "some unrelated output", 0},
+		{"no selection marker falls back to confirming", "No, exit\nYes, I trust this folder\n", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trustDialogDownPresses(tc.content); got != tc.want {
+				t.Fatalf("trustDialogDownPresses() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The regression this guards: the old code pressed Enter unconditionally, which
+// selected "No, exit" and killed every polecat in a freshly forked rig.
+func TestClaudeTrustDialogDoesNotConfirmDecline(t *testing.T) {
+	options, selected := trustDialogOptionLines(claudeTrustDialog)
+	if selected < 0 {
+		t.Fatal("selection marker not detected in captured Claude dialog")
+	}
+	if got := options[selected]; got != "no, exit" {
+		t.Fatalf("expected the decline option to start selected, got %q", got)
+	}
+	moved := selected + trustDialogDownPresses(claudeTrustDialog)
+	if moved >= len(options) {
+		t.Fatalf("moved selection out of range: %d of %d", moved, len(options))
+	}
+	if got := options[moved]; got != "yes, i trust this folder" {
+		t.Fatalf("selection landed on %q, want the affirmative option", got)
+	}
+}
+
+func TestWorkspaceTrustDialogStillDetected(t *testing.T) {
+	if !containsWorkspaceTrustDialog(claudeTrustDialog) {
+		t.Fatal("captured Claude trust dialog no longer detected")
+	}
+}


### PR DESCRIPTION
## The bug

`AcceptWorkspaceTrustDialog` detects the workspace trust prompt correctly, then confirms whatever option happens to be selected, on the assumption that the first one grants trust:

```go
if containsWorkspaceTrustDialog(content) {
    // Dialog found — accept it (option 1 is pre-selected, just press Enter)
    if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
```

Claude Code pre-selects the **negative** option:

```
 Quick safety check: Is this a project you created or one you trust?

 ❯ No, exit
   Yes, I trust this folder

 Enter to confirm · Esc to cancel
```

So gt answers its own trust prompt with "No, exit" and instructs the agent to quit. gt is not failing to handle the dialog — it is actively answering it wrong.

## Impact

Every polecat in a newly created rig dies on spawn. Any workspace path the agent has not seen before shows this dialog, so this reproduces on every fresh rig. Existing rigs are unaffected only because their paths already carry `hasTrustDialogAccepted` in `~/.claude.json`, which is why the defect looks rig-specific and is not.

The failure path then marks the polecat `idle-recovery-needed`, after which it cannot be started *or* cleaned, so each attempt strands another polecat.

## Why it was hard to diagnose

`CheckStartupBlocked` runs after the session has already died and calls `CapturePane` on it, producing:

```
startup blocked: tmux capture-pane: can't find pane: gt-<name>
```

That reads like a session that was never created, and it sent two of us toward a "probe before create" ordering bug. Polling tmux once a second across a start attempt shows session count going `0,1,1,0,0,0` — created, then dead ~2-3s later. Capturing the pane at t+2s yields the dialog above.

I have left that misleading error as a separate concern rather than widening this PR, but it is worth distinguishing "pane missing because the session died" from "dialog still visible".

## The fix

Locate the affirmative option by its text and move the selection onto it before confirming.

Matching on text rather than ordinal position is deliberate: assuming position is exactly what failed here, and the ordering belongs to the agent, not to us. When the dialog cannot be parsed, behaviour is unchanged, so this cannot regress a dialog shape that is not recognised.

## Tests

Four cases in `internal/tmux/trust_dialog_test.go`, including the verbatim captured dialog from a session that died this way:

- Claude's ordering (decline first) moves the selection down one
- affirmative-first ordering does not move
- unparseable content falls back to confirming
- absent selection marker falls back to confirming

Plus an assertion that existing trust-dialog detection still matches.

## Verification

I diffed the failing tests in `./internal/tmux/` before and after the change. Ten pre-existing environment-dependent failures appear in both (tmux key-binding and nudge tests). **Zero new failures.** Three nudge tests are flaky and happened to pass on the run with my change.
