### PR TITLE
Unify agent address handling behind one canonical type — reconciles #4780 and #4781 (gt-cw1)

### DIFF
--- a/internal/agentaddr/address.go
+++ b/internal/agentaddr/address.go
@@ -1,0 +1,411 @@
+// Package agentaddr provides the single canonical representation of a Gas Town
+// agent address.
+//
+// Gas Town writes an agent's address into bead assignee fields, hook records
+// and mail envelopes. Before this package each command built that string by
+// hand, so the same agent was stored under several spellings: `gt sling deacon`
+// wrote "deacon/" while `gt patrol new` wrote "deacon", and an exact-match
+// lookup for one could not see rows written by the other. That mismatch
+// stranded hooked patrol wisps and leaked them into the open backlog.
+//
+// The rule this package enforces is: parse liberally, store one way, and match
+// across every historical spelling.
+//
+//   - Parse accepts every spelling Gas Town has ever written.
+//   - Address.String renders the one canonical form that must be stored.
+//   - Address.Variants lists the equivalent spellings a read must also match,
+//     so rows written before this package are still found.
+package agentaddr
+
+import (
+	"strings"
+)
+
+// Role is the canonical role token of an agent address.
+type Role string
+
+// Canonical roles. These mirror session.Role, but agentaddr is a leaf package
+// with no Gas Town dependencies so that both internal/cmd and internal/mail can
+// use it without an import cycle.
+const (
+	RoleUnknown  Role = ""
+	RoleOverseer Role = "overseer"
+	RoleMayor    Role = "mayor"
+	RoleDeacon   Role = "deacon"
+	RoleBoot     Role = "boot"
+	RoleDog      Role = "dog"
+	RoleWitness  Role = "witness"
+	RoleRefinery Role = "refinery"
+	RolePolecat  Role = "polecat"
+	RoleCrew     Role = "crew"
+)
+
+// Address is a parsed Gas Town agent address.
+//
+// Rig is empty for town-level agents (mayor, deacon, boot, dogs, overseer).
+// Name is empty for singleton roles (mayor, deacon, witness, refinery).
+type Address struct {
+	Rig  string
+	Role Role
+	Name string
+}
+
+// townLevel reports whether the role lives at the town level, i.e. has no rig.
+func (a Address) townLevel() bool {
+	switch a.Role {
+	case RoleOverseer, RoleMayor, RoleDeacon, RoleBoot, RoleDog:
+		return true
+	default:
+		return false
+	}
+}
+
+// needsName reports whether the role identifies a specific named worker.
+func (a Address) needsName() bool {
+	switch a.Role {
+	case RoleDog, RolePolecat, RoleCrew:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsComplete reports whether the address identifies exactly one agent.
+//
+// An incomplete address is a bare pool role such as "dog" or "witness": the
+// role is known but the rig or worker name is missing, so it cannot be stored
+// as an assignee. Dispatch code uses this to detect the bug where child step
+// wisps inherited the bare pool role instead of the resolved root address.
+func (a Address) IsComplete() bool {
+	if a.Role == RoleUnknown {
+		return false
+	}
+	if !a.townLevel() && a.Rig == "" {
+		return false
+	}
+	if a.needsName() && a.Name == "" {
+		return false
+	}
+	return true
+}
+
+// String renders the canonical stored form of the address.
+//
+// There is exactly one correct string for each agent:
+//
+//	overseer               → "overseer"
+//	mayor                  → "mayor/"
+//	deacon                 → "deacon/"
+//	boot                   → "deacon/boot"
+//	dog alpha              → "deacon/dogs/alpha"
+//	witness of gastown     → "gastown/witness"
+//	refinery of gastown    → "gastown/refinery"
+//	polecat toast, gastown → "gastown/polecats/toast"
+//	crew max, gastown      → "gastown/crew/max"
+//
+// An incomplete address renders as its bare role token, which is never a valid
+// assignee. Callers that store the result must check IsComplete first.
+func (a Address) String() string {
+	if !a.IsComplete() {
+		return string(a.Role)
+	}
+	switch a.Role {
+	case RoleOverseer:
+		return "overseer"
+	case RoleMayor:
+		return "mayor/"
+	case RoleDeacon:
+		return "deacon/"
+	case RoleBoot:
+		return "deacon/boot"
+	case RoleDog:
+		return "deacon/dogs/" + a.Name
+	case RoleWitness:
+		return a.Rig + "/witness"
+	case RoleRefinery:
+		return a.Rig + "/refinery"
+	case RolePolecat:
+		return a.Rig + "/polecats/" + a.Name
+	case RoleCrew:
+		return a.Rig + "/crew/" + a.Name
+	default:
+		return ""
+	}
+}
+
+// Variants returns every spelling that refers to this agent, canonical form
+// first. Reads must match all of them: rows written before this package exists
+// still carry the legacy spellings, and a lookup that only matched the
+// canonical form would silently skip them.
+func (a Address) Variants() []string {
+	canonical := a.String()
+	if !a.IsComplete() {
+		return uniqueNonEmpty([]string{canonical})
+	}
+
+	var out []string
+	switch a.Role {
+	case RoleOverseer:
+		out = []string{"overseer", "overseer/"}
+	case RoleMayor:
+		out = []string{"mayor/", "mayor"}
+	case RoleDeacon:
+		out = []string{"deacon/", "deacon"}
+	case RoleBoot:
+		out = []string{"deacon/boot", "boot"}
+	case RoleDog:
+		out = []string{
+			"deacon/dogs/" + a.Name,
+			"deacon/dog/" + a.Name,
+			"dog:" + a.Name,
+		}
+	case RoleWitness:
+		// "/witness" is the legacy unqualified form written before the rig was
+		// resolved at the write site.
+		out = []string{a.Rig + "/witness", "/witness"}
+	case RoleRefinery:
+		out = []string{a.Rig + "/refinery", "/refinery"}
+	case RolePolecat:
+		out = []string{
+			a.Rig + "/polecats/" + a.Name,
+			a.Rig + "/polecat/" + a.Name,
+			a.Rig + "/" + a.Name,
+		}
+	case RoleCrew:
+		out = []string{
+			a.Rig + "/crew/" + a.Name,
+			a.Rig + "/" + a.Name,
+		}
+	default:
+		out = []string{canonical}
+	}
+	return uniqueNonEmpty(append([]string{canonical}, out...))
+}
+
+// Parse converts any spelling Gas Town has written into a canonical Address.
+// The second return value is false when the input cannot be recognised at all;
+// callers should then leave the original string untouched rather than guess.
+func Parse(s string) (Address, bool) {
+	trimmed := strings.TrimSpace(s)
+	// Collapse repeated trailing slashes ("slingshot///") but remember that a
+	// town-level role legitimately ends in one.
+	for strings.HasSuffix(trimmed, "/") {
+		trimmed = strings.TrimSuffix(trimmed, "/")
+	}
+	if trimmed == "" {
+		return Address{}, false
+	}
+
+	// "dog:alpha" / "dog:" shorthand used by sling targets.
+	if rest, ok := strings.CutPrefix(strings.ToLower(trimmed), "dog:"); ok {
+		if strings.Contains(rest, "/") {
+			return Address{}, false
+		}
+		return Address{Role: RoleDog, Name: sameCase(trimmed, rest)}, true
+	}
+
+	parts := strings.Split(trimmed, "/")
+	for _, part := range parts {
+		if part == "" {
+			// An interior empty segment ("gastown//witness") is not an address.
+			// A leading empty segment is the legacy "/witness" form, handled
+			// below, so only reject when it is not that shape.
+			if !(len(parts) == 2 && parts[0] == "") {
+				return Address{}, false
+			}
+		}
+	}
+
+	switch len(parts) {
+	case 1:
+		return parseBare(parts[0])
+	case 2:
+		return parseTwo(parts[0], parts[1])
+	case 3:
+		return parseThree(parts[0], parts[1], parts[2])
+	default:
+		return Address{}, false
+	}
+}
+
+func parseBare(token string) (Address, bool) {
+	switch strings.ToLower(token) {
+	case "overseer":
+		return Address{Role: RoleOverseer}, true
+	case "mayor":
+		return Address{Role: RoleMayor}, true
+	case "deacon":
+		return Address{Role: RoleDeacon}, true
+	case "boot":
+		return Address{Role: RoleBoot}, true
+	// Bare pool roles: recognised, but incomplete. They are the exact strings
+	// that leaked onto child step wisps, so naming them lets callers detect the
+	// mistake instead of storing them.
+	case "dog", "dogs":
+		return Address{Role: RoleDog}, true
+	case "witness":
+		return Address{Role: RoleWitness}, true
+	case "refinery":
+		return Address{Role: RoleRefinery}, true
+	case "polecat", "polecats":
+		return Address{Role: RolePolecat}, true
+	case "crew":
+		return Address{Role: RoleCrew}, true
+	default:
+		return Address{}, false
+	}
+}
+
+func parseTwo(first, second string) (Address, bool) {
+	lowerFirst, lowerSecond := strings.ToLower(first), strings.ToLower(second)
+	// Rig names are lowercase identifiers (they name a directory and a Dolt
+	// database), so casing them differently never means a different rig.
+	first = lowerFirst
+
+	// Legacy unqualified rig-scoped form: "/witness", "/refinery".
+	if first == "" {
+		switch lowerSecond {
+		case "witness":
+			return Address{Role: RoleWitness}, true
+		case "refinery":
+			return Address{Role: RoleRefinery}, true
+		default:
+			return Address{}, false
+		}
+	}
+
+	// Town-level singletons are town-level however they were addressed:
+	// "gastown/mayor" is still the one mayor.
+	switch lowerSecond {
+	case "mayor":
+		return Address{Role: RoleMayor}, true
+	case "deacon":
+		return Address{Role: RoleDeacon}, true
+	}
+
+	if lowerFirst == "deacon" {
+		switch lowerSecond {
+		case "boot":
+			return Address{Role: RoleBoot}, true
+		case "dog", "dogs":
+			return Address{Role: RoleDog}, true
+		default:
+			return Address{}, false
+		}
+	}
+
+	switch lowerSecond {
+	case "witness":
+		return Address{Rig: first, Role: RoleWitness}, true
+	case "refinery":
+		return Address{Rig: first, Role: RoleRefinery}, true
+	case "polecat", "polecats", "crew":
+		// A pool with a rig but no worker name.
+		if lowerSecond == "crew" {
+			return Address{Rig: first, Role: RoleCrew}, true
+		}
+		return Address{Rig: first, Role: RolePolecat}, true
+	case "overseer", "boot":
+		return Address{}, false
+	default:
+		// "gastown/toast" is the shorthand polecat form.
+		return Address{Rig: first, Role: RolePolecat, Name: second}, true
+	}
+}
+
+func parseThree(first, second, third string) (Address, bool) {
+	lowerFirst, lowerSecond := strings.ToLower(first), strings.ToLower(second)
+	first = lowerFirst
+
+	if lowerFirst == "deacon" {
+		if lowerSecond == "dog" || lowerSecond == "dogs" {
+			return Address{Role: RoleDog, Name: third}, true
+		}
+		return Address{}, false
+	}
+
+	switch lowerSecond {
+	case "polecat", "polecats":
+		return Address{Rig: first, Role: RolePolecat, Name: third}, true
+	case "crew":
+		return Address{Rig: first, Role: RoleCrew, Name: third}, true
+	default:
+		return Address{}, false
+	}
+}
+
+// Normalize returns the canonical stored form of addr.
+//
+// Unrecognised and incomplete input is returned trimmed but otherwise
+// unchanged: normalizing must never invent an address that identifies a
+// different agent than the caller meant.
+func Normalize(addr string) string {
+	parsed, ok := Parse(addr)
+	if !ok || !parsed.IsComplete() {
+		return strings.TrimSpace(addr)
+	}
+	return parsed.String()
+}
+
+// Variants returns every spelling equivalent to addr, canonical form first.
+// Unrecognised input yields just itself, so callers can always use the result
+// as their complete match set.
+func Variants(addr string) []string {
+	parsed, ok := Parse(addr)
+	if !ok || !parsed.IsComplete() {
+		if trimmed := strings.TrimSpace(addr); trimmed != "" {
+			return []string{trimmed}
+		}
+		return nil
+	}
+	return parsed.Variants()
+}
+
+// Equal reports whether two addresses name the same agent, comparing across
+// spellings and ignoring case.
+func Equal(a, b string) bool {
+	parsedA, okA := Parse(a)
+	parsedB, okB := Parse(b)
+	if okA && okB && parsedA.IsComplete() && parsedB.IsComplete() {
+		return strings.EqualFold(parsedA.String(), parsedB.String())
+	}
+	return MatchKey(a) == MatchKey(b)
+}
+
+// MatchKey returns the loose comparison key for an address: trimmed,
+// lowercased, with a trailing slash removed, so that "Mayor/" and "mayor"
+// compare equal.
+//
+// This is the normalization that used to live unexported in the mail send path,
+// where it was the only reason mail resolved these addresses reliably. It is
+// kept byte-for-byte identical so that moving it here changes no mail
+// behaviour. Prefer Equal for new code: it also matches across the
+// polecats/polecat and dogs/dog spellings, which this key does not.
+func MatchKey(addr string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(addr)), "/")
+}
+
+// sameCase recovers the original casing of a suffix that was matched against a
+// lowercased copy of the whole string.
+func sameCase(original, lowerSuffix string) string {
+	if len(lowerSuffix) == 0 {
+		return ""
+	}
+	return original[len(original)-len(lowerSuffix):]
+}
+
+func uniqueNonEmpty(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/agentaddr/address_test.go
+++ b/internal/agentaddr/address_test.go
@@ -1,0 +1,246 @@
+package agentaddr
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseCanonicalForms(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Address
+	}{
+		// Town-level singletons, in every spelling seen in the wisps table.
+		{"deacon", Address{Role: RoleDeacon}},
+		{"deacon/", Address{Role: RoleDeacon}},
+		{"  deacon/  ", Address{Role: RoleDeacon}},
+		{"Deacon", Address{Role: RoleDeacon}},
+		{"gastown/deacon", Address{Role: RoleDeacon}},
+		{"mayor", Address{Role: RoleMayor}},
+		{"mayor/", Address{Role: RoleMayor}},
+		{"gastown/mayor", Address{Role: RoleMayor}},
+		{"overseer", Address{Role: RoleOverseer}},
+		{"boot", Address{Role: RoleBoot}},
+		{"deacon/boot", Address{Role: RoleBoot}},
+
+		// Rig-scoped singletons, including the legacy unqualified form.
+		{"gastown/witness", Address{Rig: "gastown", Role: RoleWitness}},
+		{"sandbox/refinery", Address{Rig: "sandbox", Role: RoleRefinery}},
+		{"/witness", Address{Role: RoleWitness}},
+		{"/refinery", Address{Role: RoleRefinery}},
+
+		// Named workers.
+		{"gastown/polecats/obsidian", Address{Rig: "gastown", Role: RolePolecat, Name: "obsidian"}},
+		{"gastown/polecat/obsidian", Address{Rig: "gastown", Role: RolePolecat, Name: "obsidian"}},
+		{"gastown/obsidian", Address{Rig: "gastown", Role: RolePolecat, Name: "obsidian"}},
+		{"gastown/crew/max", Address{Rig: "gastown", Role: RoleCrew, Name: "max"}},
+		{"deacon/dogs/alpha", Address{Role: RoleDog, Name: "alpha"}},
+		{"deacon/dog/alpha", Address{Role: RoleDog, Name: "alpha"}},
+		{"dog:alpha", Address{Role: RoleDog, Name: "alpha"}},
+
+		// Bare pool roles: recognised but not complete.
+		{"dog", Address{Role: RoleDog}},
+		{"dogs", Address{Role: RoleDog}},
+		{"deacon/dogs", Address{Role: RoleDog}},
+		{"witness", Address{Rig: "", Role: RoleWitness}},
+		{"gastown/polecats", Address{Rig: "gastown", Role: RolePolecat}},
+	}
+
+	for _, c := range cases {
+		got, ok := Parse(c.in)
+		if !ok {
+			t.Errorf("Parse(%q) returned ok=false, want a parsed address", c.in)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Parse(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseRejectsNonAddresses(t *testing.T) {
+	for _, in := range []string{"", "   ", "/", "///", "gastown//witness", "a/b/c/d", "gastown/overseer"} {
+		if got, ok := Parse(in); ok {
+			t.Errorf("Parse(%q) = %+v, ok=true; want ok=false", in, got)
+		}
+	}
+}
+
+func TestStringIsTheSingleCanonicalForm(t *testing.T) {
+	cases := []struct {
+		addr Address
+		want string
+	}{
+		{Address{Role: RoleOverseer}, "overseer"},
+		{Address{Role: RoleMayor}, "mayor/"},
+		{Address{Role: RoleDeacon}, "deacon/"},
+		{Address{Role: RoleBoot}, "deacon/boot"},
+		{Address{Role: RoleDog, Name: "alpha"}, "deacon/dogs/alpha"},
+		{Address{Rig: "gastown", Role: RoleWitness}, "gastown/witness"},
+		{Address{Rig: "gastown", Role: RoleRefinery}, "gastown/refinery"},
+		{Address{Rig: "gastown", Role: RolePolecat, Name: "obsidian"}, "gastown/polecats/obsidian"},
+		{Address{Rig: "gastown", Role: RoleCrew, Name: "max"}, "gastown/crew/max"},
+	}
+	for _, c := range cases {
+		if got := c.addr.String(); got != c.want {
+			t.Errorf("Address%+v.String() = %q, want %q", c.addr, got, c.want)
+		}
+	}
+}
+
+// Every spelling of one agent must normalize to the same stored string. This is
+// the property whose absence stranded hooked patrol wisps.
+func TestNormalizeCollapsesEverySpelling(t *testing.T) {
+	groups := [][]string{
+		{"deacon", "deacon/", "Deacon", "gastown/deacon", " deacon "},
+		{"mayor", "mayor/", "MAYOR", "gastown/mayor"},
+		{"gastown/witness", "gastown/witness/", "GASTOWN/WITNESS"},
+		{"deacon/dogs/alpha", "deacon/dog/alpha", "dog:alpha"},
+		{"gastown/polecats/obsidian", "gastown/polecat/obsidian", "gastown/obsidian"},
+	}
+	for _, group := range groups {
+		want := Normalize(group[0])
+		for _, spelling := range group {
+			if got := Normalize(spelling); got != want {
+				t.Errorf("Normalize(%q) = %q, want %q (same agent as %q)", spelling, got, want, group[0])
+			}
+			if !Equal(spelling, group[0]) {
+				t.Errorf("Equal(%q, %q) = false, want true", spelling, group[0])
+			}
+		}
+	}
+}
+
+// "/witness" names a witness whose rig was dropped at the write site. It is a
+// variant to match on read, but it cannot be normalized: nothing in the string
+// says which rig, and guessing would assign the bead to the wrong agent.
+func TestRiglessWitnessIsMatchedButNotNormalized(t *testing.T) {
+	parsed, ok := Parse("/witness")
+	if !ok || parsed.Role != RoleWitness {
+		t.Fatalf("Parse(\"/witness\") = %+v, ok=%v; want a witness", parsed, ok)
+	}
+	if parsed.IsComplete() {
+		t.Error("Parse(\"/witness\").IsComplete() = true, want false: the rig is unknown")
+	}
+	if got := Normalize("/witness"); got != "/witness" {
+		t.Errorf("Normalize(\"/witness\") = %q, want it left alone", got)
+	}
+	if !contains(Variants("gastown/witness"), "/witness") {
+		t.Error("Variants(gastown/witness) must include the legacy \"/witness\" rows")
+	}
+}
+
+func TestNormalizeLeavesUnrecognisedInputAlone(t *testing.T) {
+	for _, in := range []string{"not an address", "gastown//witness", "a/b/c/d"} {
+		if got := Normalize(in); got != strings.TrimSpace(in) {
+			t.Errorf("Normalize(%q) = %q, want the input unchanged", in, got)
+		}
+	}
+}
+
+// A bare pool role must never be treated as a storable assignee: that is the
+// bug where child step wisps were written as "dog" instead of the resolved
+// "deacon/dogs/alpha".
+func TestBarePoolRolesAreIncomplete(t *testing.T) {
+	for _, in := range []string{"dog", "dogs", "deacon/dogs", "witness", "refinery", "crew", "gastown/polecats"} {
+		parsed, ok := Parse(in)
+		if !ok {
+			t.Fatalf("Parse(%q) = ok false, want the pool role recognised", in)
+		}
+		if parsed.IsComplete() {
+			t.Errorf("Parse(%q).IsComplete() = true, want false", in)
+		}
+	}
+	for _, in := range []string{"deacon", "mayor/", "gastown/witness", "deacon/dogs/alpha", "gastown/polecats/obsidian"} {
+		parsed, _ := Parse(in)
+		if !parsed.IsComplete() {
+			t.Errorf("Parse(%q).IsComplete() = false, want true", in)
+		}
+	}
+}
+
+func TestVariantsLeadWithCanonicalAndCoverLegacySpellings(t *testing.T) {
+	cases := []struct {
+		in       string
+		contains []string
+	}{
+		{"deacon", []string{"deacon/", "deacon"}},
+		{"deacon/", []string{"deacon/", "deacon"}},
+		{"mayor", []string{"mayor/", "mayor"}},
+		{"gastown/witness", []string{"gastown/witness", "/witness"}},
+		{"gastown/polecats/obsidian", []string{"gastown/polecats/obsidian", "gastown/polecat/obsidian", "gastown/obsidian"}},
+		{"deacon/dogs/alpha", []string{"deacon/dogs/alpha", "deacon/dog/alpha", "dog:alpha"}},
+	}
+	for _, c := range cases {
+		got := Variants(c.in)
+		if len(got) == 0 || got[0] != Normalize(c.in) {
+			t.Errorf("Variants(%q) = %v, want canonical form %q first", c.in, got, Normalize(c.in))
+		}
+		for _, want := range c.contains {
+			if !contains(got, want) {
+				t.Errorf("Variants(%q) = %v, missing %q", c.in, got, want)
+			}
+		}
+	}
+}
+
+func TestVariantsHasNoDuplicates(t *testing.T) {
+	for _, in := range []string{"deacon", "mayor", "gastown/witness", "gastown/polecats/obsidian", "deacon/dogs/alpha", "overseer"} {
+		got := Variants(in)
+		seen := map[string]bool{}
+		for _, v := range got {
+			if seen[v] {
+				t.Errorf("Variants(%q) = %v, contains duplicate %q", in, got, v)
+			}
+			seen[v] = true
+		}
+	}
+}
+
+func TestVariantsOfUnrecognisedInputIsItself(t *testing.T) {
+	if got := Variants("not an address"); !reflect.DeepEqual(got, []string{"not an address"}) {
+		t.Errorf("Variants(unrecognised) = %v, want the input itself", got)
+	}
+	if got := Variants("  "); got != nil {
+		t.Errorf("Variants(blank) = %v, want nil", got)
+	}
+}
+
+// MatchKey must stay byte-for-byte what the mail send path used, so that
+// adopting the shared package changes no mail behaviour.
+func TestMatchKeyPreservesLegacyMailNormalization(t *testing.T) {
+	legacy := func(addr string) string {
+		return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(addr)), "/")
+	}
+	for _, in := range []string{
+		"", "  ", "mayor", "Mayor/", "deacon/", "DEACON", " gastown/witness ",
+		"gastown/polecats/Toast", "overseer", "//", "not an address",
+	} {
+		if got, want := MatchKey(in), legacy(in); got != want {
+			t.Errorf("MatchKey(%q) = %q, want %q (legacy mail behaviour)", in, got, want)
+		}
+	}
+}
+
+// The concrete leak: `gt sling deacon` wrote "deacon/" and `gt patrol report`
+// looked up "deacon". Through the canonical type they are one agent.
+func TestSlingAndPatrolSpellingsResolveToOneAgent(t *testing.T) {
+	slingWrote := Normalize("deacon/")
+	patrolLookedUp := Normalize("deacon")
+	if slingWrote != patrolLookedUp {
+		t.Fatalf("sling wrote %q but patrol looked up %q; they must be identical", slingWrote, patrolLookedUp)
+	}
+	if !contains(Variants("deacon"), "deacon/") || !contains(Variants("deacon"), "deacon") {
+		t.Errorf("Variants(deacon) = %v, must match rows written under both spellings", Variants("deacon"))
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/agent_address_test.go
+++ b/internal/cmd/agent_address_test.go
@@ -130,3 +130,71 @@ func TestNormalizeAddressPreservesMailBehaviour(t *testing.T) {
 		}
 	}
 }
+
+// TestAssigneeFlagCanonicalizesWriteSites pins the gap that made 4780 worth
+// porting onto this branch: every `bd update --assignee=` write site now routes
+// through one helper, so the same agent cannot land in storage under two
+// spellings depending on which command wrote the row (gt-cw1).
+func TestAssigneeFlagCanonicalizesWriteSites(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "bare deacon gains the trailing slash sling always wrote",
+			addr: "deacon",
+			want: "--assignee=deacon/",
+		},
+		{
+			name: "deacon with trailing slash is already canonical",
+			addr: "deacon/",
+			want: "--assignee=deacon/",
+		},
+		{
+			name: "legacy singular polecat segment becomes plural",
+			addr: "gastown/polecat/toast",
+			want: "--assignee=gastown/polecats/toast",
+		},
+		{
+			name: "legacy singular dog segment becomes plural",
+			addr: "deacon/dog/alpha",
+			want: "--assignee=deacon/dogs/alpha",
+		},
+		{
+			name: "rig-scoped deacon collapses to the one town-level deacon",
+			addr: "gastown/deacon",
+			want: "--assignee=deacon/",
+		},
+		{
+			name: "surrounding space is trimmed",
+			addr: "  gastown/polecats/toast  ",
+			want: "--assignee=gastown/polecats/toast",
+		},
+		{
+			name: "already-canonical worker address is unchanged",
+			addr: "gastown/polecats/toast",
+			want: "--assignee=gastown/polecats/toast",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := assigneeFlag(tc.addr); got != tc.want {
+				t.Errorf("assigneeFlag(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAssigneeFlagPreservesUnparseableInput guards the deliberate conservatism
+// in Normalize: a write site holding something this package cannot parse must
+// still store what the caller meant rather than a guess or an empty assignee.
+func TestAssigneeFlagPreservesUnparseableInput(t *testing.T) {
+	for _, addr := range []string{"", "not/a/real/address/at/all", "overseer"} {
+		want := "--assignee=" + agentaddr.Normalize(addr)
+		if got := assigneeFlag(addr); got != want {
+			t.Errorf("assigneeFlag(%q) = %q, want %q", addr, got, want)
+		}
+	}
+}

--- a/internal/cmd/agent_address_test.go
+++ b/internal/cmd/agent_address_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/agentaddr"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+// TestPatrolAssigneeMatchesSlingAssignee pins the invariant the address split
+// broke: the string `gt patrol new` stores must be the string `gt sling` stores
+// for the same agent. When they diverged, `gt patrol report` could not see a
+// slung patrol and stranded its wisp.
+func TestPatrolAssigneeMatchesSlingAssignee(t *testing.T) {
+	cases := []struct {
+		name     string
+		role     Role
+		rig      string
+		identity *session.AgentIdentity
+		want     string
+	}{
+		{
+			name:     "deacon is town level and keeps its trailing slash",
+			role:     RoleDeacon,
+			identity: &session.AgentIdentity{Role: session.RoleDeacon},
+			want:     "deacon/",
+		},
+		{
+			name:     "witness is qualified by its rig",
+			role:     RoleWitness,
+			rig:      "gastown",
+			identity: &session.AgentIdentity{Role: session.RoleWitness, Rig: "gastown"},
+			want:     "gastown/witness",
+		},
+		{
+			name:     "refinery is qualified by its rig",
+			role:     RoleRefinery,
+			rig:      "gastown",
+			identity: &session.AgentIdentity{Role: session.RoleRefinery, Rig: "gastown"},
+			want:     "gastown/refinery",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := buildPatrolConfig(tc.role, RoleInfo{Role: tc.role, Rig: tc.rig})
+			if err != nil {
+				t.Fatalf("buildPatrolConfig: %v", err)
+			}
+			if cfg.Assignee != tc.want {
+				t.Errorf("patrol assignee = %q, want %q", cfg.Assignee, tc.want)
+			}
+			if got := canonicalAssigneeAddress(tc.identity); got != tc.want {
+				t.Errorf("sling assignee = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPatrolAssigneeVariantsFindLegacyRows covers the read side: rows written
+// before canonicalization carry the old spelling, so a lookup that matched only
+// the canonical form would skip them.
+func TestPatrolAssigneeVariantsFindLegacyRows(t *testing.T) {
+	cfg, err := buildPatrolConfig(RoleDeacon, RoleInfo{Role: RoleDeacon})
+	if err != nil {
+		t.Fatalf("buildPatrolConfig: %v", err)
+	}
+
+	variants := cfg.assigneeVariants()
+	if len(variants) == 0 || variants[0] != "deacon/" {
+		t.Fatalf("variants = %v, want canonical %q first", variants, "deacon/")
+	}
+
+	var sawLegacy bool
+	for _, v := range variants {
+		if v == "deacon" {
+			sawLegacy = true
+		}
+	}
+	if !sawLegacy {
+		t.Errorf("variants %v do not include the legacy bare %q spelling", variants, "deacon")
+	}
+}
+
+// TestPatrolRigNameTownLevel guards the naive-cut bug: the canonical town-level
+// address ends in a slash, which cutting at the first slash reports as a rig
+// named "deacon".
+func TestPatrolRigNameTownLevel(t *testing.T) {
+	if got := patrolRigName(PatrolConfig{Assignee: "deacon/"}); got != "" {
+		t.Errorf("patrolRigName(%q) = %q, want empty (town level)", "deacon/", got)
+	}
+	if got := patrolRigName(PatrolConfig{Assignee: "gastown/witness"}); got != "gastown" {
+		t.Errorf("patrolRigName(%q) = %q, want %q", "gastown/witness", got, "gastown")
+	}
+}
+
+// TestAddressForRoleRejectsIncompleteRoles ensures a rig-scoped role detected
+// without its rig is refused rather than stored as a bare pool name.
+func TestAddressForRoleRejectsIncompleteRoles(t *testing.T) {
+	if addr, ok := addressForRole(RoleWitness, "", ""); ok {
+		t.Errorf("addressForRole(witness, no rig) = %q, want rejected", addr.String())
+	}
+	if addr, ok := addressForRole(RolePolecat, "gastown", ""); ok {
+		t.Errorf("addressForRole(polecat, no name) = %q, want rejected", addr.String())
+	}
+	addr, ok := addressForRole(RoleDog, "", "alpha")
+	if !ok {
+		t.Fatalf("addressForRole(dog, alpha) rejected, want accepted")
+	}
+	if got := addr.String(); got != "deacon/dogs/alpha" {
+		t.Errorf("dog address = %q, want %q", got, "deacon/dogs/alpha")
+	}
+}
+
+// TestNormalizeAddressPreservesMailBehaviour pins that routing mail through the
+// shared package did not change how mail resolves an address.
+func TestNormalizeAddressPreservesMailBehaviour(t *testing.T) {
+	cases := map[string]string{
+		"Mayor/":          "mayor",
+		"mayor":           "mayor",
+		"  deacon/  ":     "deacon",
+		"gastown/Witness": "gastown/witness",
+	}
+	for in, want := range cases {
+		if got := normalizeAddress(in); got != want {
+			t.Errorf("normalizeAddress(%q) = %q, want %q", in, got, want)
+		}
+		if got := agentaddr.MatchKey(in); got != want {
+			t.Errorf("agentaddr.MatchKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/cmd/assign.go
+++ b/internal/cmd/assign.go
@@ -144,7 +144,7 @@ func runAssign(_ *cobra.Command, args []string) error {
 	const backoffMax = 10 * time.Second
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		if err := BdCmd("update", beadID, "--status=hooked", "--assignee="+agentID).
+		if err := BdCmd("update", beadID, "--status=hooked", assigneeFlag(agentID)).
 			Dir(townRoot).
 			WithAutoCommit().
 			Run(); err != nil {

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -20,6 +20,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	convoyops "github.com/steveyegge/gastown/internal/convoy"
@@ -2849,18 +2850,20 @@ func parseWorkerFromAgentBead(agentID string) string {
 		return ""
 	}
 
-	// Build path from parsed components
-	if rig == "" {
-		// Town-level
-		if name != "" {
-			return role + "/" + name
-		}
-		return role
+	// Rebuild the path, then canonicalize it. Concatenating the components is
+	// how this drifted from the other address builders in the first place.
+	var path string
+	switch {
+	case rig == "" && name != "":
+		path = role + "/" + name
+	case rig == "":
+		path = role
+	case name != "":
+		path = rig + "/" + role + "/" + name
+	default:
+		path = rig + "/" + role
 	}
-	if name != "" {
-		return rig + "/" + role + "/" + name
-	}
-	return rig + "/" + role
+	return agentaddr.Normalize(path)
 }
 
 // formatWorkerAge formats a duration as a short string (e.g., "5m", "2h", "1d")

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -1135,40 +1136,39 @@ func runDeaconHealthState(cmd *cobra.Command, args []string) error {
 // agentAddressToIDs converts an agent address to bead ID and session name.
 // Supports formats: "gastown/polecats/max", "gastown/witness", "deacon", "mayor"
 // Note: Town-level agents (Mayor, Deacon) use hq- prefix bead IDs stored in town beads.
+//
+// Parsing goes through agentaddr so that every spelling of an agent — "deacon"
+// and "deacon/", "gastown/polecats/max" and "gastown/max" — reaches the same
+// bead and session. Splitting the string here was one of the ad-hoc address
+// implementations that let those spellings diverge.
 func agentAddressToIDs(address string) (beadID, sessionName string, err error) {
-	switch address {
-	case constants.RoleDeacon:
-		return beads.DeaconBeadIDTown(), session.DeaconSessionName(), nil
-	case constants.RoleMayor:
-		return beads.MayorBeadIDTown(), session.MayorSessionName(), nil
+	addr, ok := agentaddr.Parse(address)
+	if !ok {
+		return "", "", fmt.Errorf("invalid agent address format: %s (expected rig/type/name or rig/role)", address)
+	}
+	if !addr.IsComplete() {
+		return "", "", fmt.Errorf("agent address %s names a pool, not a single agent", address)
 	}
 
-	parts := strings.Split(address, "/")
-	switch len(parts) {
-	case 2:
-		// rig/role: "gastown/witness", "gastown/refinery"
-		rig, role := parts[0], parts[1]
-		switch role {
-		case constants.RoleWitness:
-			return session.WitnessSessionName(session.PrefixFor(rig)), session.WitnessSessionName(session.PrefixFor(rig)), nil
-		case constants.RoleRefinery:
-			return session.RefinerySessionName(session.PrefixFor(rig)), session.RefinerySessionName(session.PrefixFor(rig)), nil
-		default:
-			return "", "", fmt.Errorf("unknown role: %s", role)
-		}
-	case 3:
-		// rig/type/name: "gastown/polecats/max", "gastown/crew/alpha"
-		rig, agentType, name := parts[0], parts[1], parts[2]
-		switch agentType {
-		case "polecats":
-			return session.PolecatSessionName(session.PrefixFor(rig), name), session.PolecatSessionName(session.PrefixFor(rig), name), nil
-		case constants.RoleCrew:
-			return session.CrewSessionName(session.PrefixFor(rig), name), session.CrewSessionName(session.PrefixFor(rig), name), nil
-		default:
-			return "", "", fmt.Errorf("unknown agent type: %s", agentType)
-		}
+	switch addr.Role {
+	case agentaddr.RoleDeacon:
+		return beads.DeaconBeadIDTown(), session.DeaconSessionName(), nil
+	case agentaddr.RoleMayor:
+		return beads.MayorBeadIDTown(), session.MayorSessionName(), nil
+	case agentaddr.RoleWitness:
+		name := session.WitnessSessionName(session.PrefixFor(addr.Rig))
+		return name, name, nil
+	case agentaddr.RoleRefinery:
+		name := session.RefinerySessionName(session.PrefixFor(addr.Rig))
+		return name, name, nil
+	case agentaddr.RolePolecat:
+		name := session.PolecatSessionName(session.PrefixFor(addr.Rig), addr.Name)
+		return name, name, nil
+	case agentaddr.RoleCrew:
+		name := session.CrewSessionName(session.PrefixFor(addr.Rig), addr.Name)
+		return name, name, nil
 	default:
-		return "", "", fmt.Errorf("invalid agent address format: %s (expected rig/type/name or rig/role)", address)
+		return "", "", fmt.Errorf("unknown role: %s", addr.Role)
 	}
 }
 

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1340,7 +1340,7 @@ func sendHandoffMail(subject, message string) (string, error) {
 	}
 
 	// Auto-hook the created mail bead
-	hookCmd := BdCmd("update", beadID, "--status=hooked", "--assignee="+agentID).
+	hookCmd := BdCmd("update", beadID, "--status=hooked", assigneeFlag(agentID)).
 		WithAutoCommit().
 		Dir(townRoot).
 		Build()
@@ -1445,12 +1445,12 @@ func hookBeadForHandoff(beadID string) error {
 	fmt.Printf("%s Hooking %s...\n", style.Bold.Render("🪝"), beadID)
 
 	if handoffDryRun {
-		fmt.Printf("Would run: bd update %s --status=pinned --assignee=%s\n", beadID, agentID)
+		fmt.Printf("Would run: bd update %s --status=pinned %s\n", beadID, assigneeFlag(agentID))
 		return nil
 	}
 
 	// Pin the bead using bd update (discovery-based approach)
-	pinCmd := exec.Command("bd", "update", beadID, "--status=pinned", "--assignee="+agentID)
+	pinCmd := exec.Command("bd", "update", beadID, "--status=pinned", assigneeFlag(agentID))
 	pinCmd.Stderr = os.Stderr
 	if err := pinCmd.Run(); err != nil {
 		return fmt.Errorf("pinning bead: %w", err)

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -357,7 +357,7 @@ func runHook(_ *cobra.Command, args []string) error {
 	}
 
 	if hookDryRun {
-		fmt.Printf("Would run: bd update %s --status=hooked --assignee=%s\n", beadID, agentID)
+		fmt.Printf("Would run: bd update %s --status=hooked %s\n", beadID, assigneeFlag(agentID))
 		if hookSubject != "" {
 			fmt.Printf("  subject (for handoff mail): %s\n", hookSubject)
 		}
@@ -377,7 +377,7 @@ func runHook(_ *cobra.Command, args []string) error {
 	const hookBackoffMax = 10 * time.Second
 	var lastHookErr error
 	for attempt := 1; attempt <= hookMaxRetries; attempt++ {
-		if err := BdCmd("update", beadID, "--status=hooked", "--assignee="+agentID).
+		if err := BdCmd("update", beadID, "--status=hooked", assigneeFlag(agentID)).
 			Dir(resolveBeadDir(beadID)).
 			StripBeadsDir().
 			WithAutoCommit().

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -71,6 +71,35 @@ func listAssignedActiveWorkAcrossStatuses(b *beads.Beads, assignee string) ([]*b
 	return mergeBeadLists(assigned, nil), nil
 }
 
+// listActiveWorkForAnyAssignee returns active work assigned under any of the
+// given assignee spellings, deduplicated.
+//
+// Reads have to be liberal where writes are strict. An agent's beads may have
+// been written under several spellings over time — "deacon" from patrol,
+// "deacon/" from sling — and an exact-match lookup for one silently skips the
+// other. Passing agentaddr.Variants here makes the lookup see all of them.
+func listActiveWorkForAnyAssignee(b *beads.Beads, assignees []string) ([]*beads.Issue, error) {
+	var found []*beads.Issue
+	seen := make(map[string]bool)
+	for _, assignee := range assignees {
+		if assignee == "" {
+			continue
+		}
+		issues, err := listAssignedActiveWorkAcrossStatuses(b, assignee)
+		if err != nil {
+			return nil, err
+		}
+		for _, issue := range issues {
+			if issue == nil || seen[issue.ID] {
+				continue
+			}
+			seen[issue.ID] = true
+			found = append(found, issue)
+		}
+	}
+	return found, nil
+}
+
 func listChildrenAcrossTables(b *beads.Beads, parentID string) ([]*beads.Issue, error) {
 	return listBeadsAcrossTables(b, beads.ListOptions{
 		Parent:   parentID,

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/mail"
@@ -278,8 +279,13 @@ func normalizeReplySubject(subject string) string {
 // normalizeAddress lowercases an address and trims a trailing slash so that
 // "Mayor/" and "mayor" compare equal. Matches identityVariants behavior in
 // mail.Mailbox without depending on its internals.
+//
+// The implementation now lives in agentaddr, which is the one place agent
+// address spellings are reconciled. Mail keeps this exact key rather than the
+// stricter agentaddr.Equal so that adopting the shared package changes no mail
+// resolution behaviour.
 func normalizeAddress(addr string) string {
-	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(addr)), "/")
+	return agentaddr.MatchKey(addr)
 }
 
 // inferReplyTo searches the sender's mailbox for a single unambiguous message

--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -294,7 +294,7 @@ func handleStepContinue(cwd, townRoot string, nextStep *beads.Issue, dryRun bool
 	}
 
 	// Pin the next step bead
-	pinCmd := exec.Command("bd", "update", nextStep.ID, "--status=pinned", "--assignee="+agentID)
+	pinCmd := exec.Command("bd", "update", nextStep.ID, "--status=pinned", assigneeFlag(agentID))
 	pinCmd.Dir = gitRoot
 	pinCmd.Stderr = os.Stderr
 	if err := pinCmd.Run(); err != nil {

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -27,6 +28,48 @@ type PatrolConfig struct {
 	WorkLoopSteps []string     // role-specific instructions
 	ExtraVars     []string     // additional --var key=value args for wisp creation
 	Beads         *beads.Beads // optional injected beads instance (for test isolation)
+}
+
+// buildPatrolConfig assembles the patrol configuration for a role.
+//
+// gt patrol new and gt patrol report must agree on the assignee down to the
+// byte: report finds the wisp to close by matching this string. They used to
+// build it separately and wrote a bare "deacon" while gt sling wrote "deacon/",
+// so report could not see a slung patrol and opened a fresh cycle instead of
+// closing the hooked one, stranding the old wisp. One builder and one canonical
+// spelling remove that whole class of mismatch.
+func buildPatrolConfig(role Role, roleInfo RoleInfo) (PatrolConfig, error) {
+	addr, ok := addressForRole(role, roleInfo.Rig, roleInfo.Polecat)
+	if !ok {
+		return PatrolConfig{}, fmt.Errorf("unsupported role for patrol: %q (expected deacon, witness, or refinery)", string(role))
+	}
+
+	cfg := PatrolConfig{
+		RoleName: string(role),
+		BeadsDir: roleInfo.TownRoot,
+		Assignee: addr.String(),
+	}
+
+	switch role {
+	case RoleDeacon:
+		cfg.PatrolMolName = constants.MolDeaconPatrol
+	case RoleWitness:
+		cfg.PatrolMolName = constants.MolWitnessPatrol
+	case RoleRefinery:
+		cfg.PatrolMolName = constants.MolRefineryPatrol
+		cfg.ExtraVars = buildRefineryPatrolVars(roleInfo)
+	default:
+		return PatrolConfig{}, fmt.Errorf("unsupported role for patrol: %q (expected deacon, witness, or refinery)", string(role))
+	}
+
+	return cfg, nil
+}
+
+// assigneeVariants returns every spelling of the patrol assignee that a lookup
+// must match. Rows written before addresses were canonicalized still carry the
+// legacy spelling, so matching only the canonical form would strand them.
+func (c PatrolConfig) assigneeVariants() []string {
+	return agentaddr.Variants(c.Assignee)
 }
 
 // maxStalePurgePerRun caps the number of stale patrol beads cleaned up in a
@@ -55,7 +98,7 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 	}
 
 	// Find active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, listErr := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
+	hookedBeads, listErr := listActiveWorkForAnyAssignee(b, cfg.assigneeVariants())
 	if listErr != nil {
 		return "", "", false, fmt.Errorf("listing active patrol work: %w", listErr)
 	}
@@ -160,7 +203,7 @@ func burnPreviousPatrolWisps(cfg PatrolConfig) {
 	}
 
 	// Find all active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, err := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
+	hookedBeads, err := listActiveWorkForAnyAssignee(b, cfg.assigneeVariants())
 	if err != nil {
 		style.PrintWarning("burn: could not list active patrol work: %v", err)
 		return
@@ -324,12 +367,16 @@ func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
 	return renderFormulaRootAndStepsFull(cfg.PatrolMolName, cfg.BeadsDir, rigName, vars)
 }
 
+// patrolRigName returns the rig the patrol belongs to, or "" for town-level
+// patrols. It reads the rig off the parsed address rather than cutting at the
+// first slash: the canonical town-level address ends in a slash ("deacon/"),
+// which a naive cut would report as a rig named "deacon".
 func patrolRigName(cfg PatrolConfig) string {
-	rigName, _, ok := strings.Cut(cfg.Assignee, "/")
+	addr, ok := agentaddr.Parse(cfg.Assignee)
 	if !ok {
 		return ""
 	}
-	return rigName
+	return addr.Rig
 }
 
 func updatePatrolWispDescription(cfg PatrolConfig, resolvedBeadsDir, patrolID, desc string) error {
@@ -406,9 +453,9 @@ func refineryPatrolSafetyStop(cfg PatrolConfig) (*refinery.SafetyStop, error) {
 	if cfg.RoleName != "refinery" {
 		return nil, nil
 	}
-	rigName := strings.TrimSuffix(cfg.Assignee, "/refinery")
-	if rigName == cfg.Assignee || rigName == "" {
+	addr, ok := agentaddr.Parse(cfg.Assignee)
+	if !ok || addr.Role != agentaddr.RoleRefinery || addr.Rig == "" {
 		return nil, nil
 	}
-	return refinery.ActiveSafetyStop(cfg.BeadsDir, rigName)
+	return refinery.ActiveSafetyStop(cfg.BeadsDir, addr.Rig)
 }

--- a/internal/cmd/patrol_new.go
+++ b/internal/cmd/patrol_new.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/constants"
 )
 
 var patrolNewRole string
@@ -46,33 +45,11 @@ func runPatrolNew(cmd *cobra.Command, args []string) error {
 		roleName = patrolNewRole
 	}
 
-	// Build config based on role
-	var cfg PatrolConfig
-	switch Role(roleName) {
-	case RoleDeacon:
-		cfg = PatrolConfig{
-			RoleName:      "deacon",
-			PatrolMolName: constants.MolDeaconPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      "deacon",
-		}
-	case RoleWitness:
-		cfg = PatrolConfig{
-			RoleName:      "witness",
-			PatrolMolName: constants.MolWitnessPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      roleInfo.Rig + "/witness",
-		}
-	case RoleRefinery:
-		cfg = PatrolConfig{
-			RoleName:      "refinery",
-			PatrolMolName: constants.MolRefineryPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      roleInfo.Rig + "/refinery",
-			ExtraVars:     buildRefineryPatrolVars(roleInfo),
-		}
-	default:
-		return fmt.Errorf("unsupported role for patrol: %q (expected deacon, witness, or refinery)", roleName)
+	// Build config based on role. gt patrol report builds the same config from
+	// the same function, so the assignee it later matches on is identical.
+	cfg, err := buildPatrolConfig(Role(roleName), roleInfo)
+	if err != nil {
+		return err
 	}
 
 	// Create and hook the wisp

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/style"
@@ -51,35 +50,12 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("detecting role: %w", err)
 	}
 
-	roleName := string(roleInfo.Role)
-
-	// Build config based on role
-	var cfg PatrolConfig
-	switch roleInfo.Role {
-	case RoleDeacon:
-		cfg = PatrolConfig{
-			RoleName:      "deacon",
-			PatrolMolName: constants.MolDeaconPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      "deacon",
-		}
-	case RoleWitness:
-		cfg = PatrolConfig{
-			RoleName:      "witness",
-			PatrolMolName: constants.MolWitnessPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      roleInfo.Rig + "/witness",
-		}
-	case RoleRefinery:
-		cfg = PatrolConfig{
-			RoleName:      "refinery",
-			PatrolMolName: constants.MolRefineryPatrol,
-			BeadsDir:      roleInfo.TownRoot,
-			Assignee:      roleInfo.Rig + "/refinery",
-			ExtraVars:     buildRefineryPatrolVars(roleInfo),
-		}
-	default:
-		return fmt.Errorf("unsupported role for patrol report: %q", roleName)
+	// Build config based on role. gt patrol new builds the same config from the
+	// same function, so the assignee matched here is byte-identical to the one
+	// written when the patrol was hooked.
+	cfg, err := buildPatrolConfig(roleInfo.Role, roleInfo)
+	if err != nil {
+		return err
 	}
 
 	// Find the active patrol

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -335,17 +335,21 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 		return
 	}
 
-	cfg := PatrolConfig{
-		RoleName:      "deacon",
-		PatrolMolName: constants.MolDeaconPatrol,
-		BeadsDir:      ctx.TownRoot, // Town-level role uses town root beads
-		Assignee:      "deacon",
-		HeaderEmoji:   "🔄",
-		HeaderTitle:   "Patrol Status (Wisp-based)",
-		WorkLoopSteps: []string{
-			"Work through each patrol step in sequence (see checklist below)",
-			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
-		},
+	// Built by the same function gt patrol new and gt patrol report use, so the
+	// wisp this may auto-spawn carries the identical canonical assignee. Built
+	// by hand here, it wrote the bare "deacon" that patrol report could not
+	// reconcile with the "deacon/" gt sling wrote.
+	cfg, err := buildPatrolConfig(RoleDeacon, ctx)
+	if err != nil {
+		style.PrintWarning("could not build deacon patrol config: %v", err)
+		return
+	}
+	cfg.BeadsDir = ctx.TownRoot // Town-level role uses town root beads
+	cfg.HeaderEmoji = "🔄"
+	cfg.HeaderTitle = "Patrol Status (Wisp-based)"
+	cfg.WorkLoopSteps = []string{
+		"Work through each patrol step in sequence (see checklist below)",
+		"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 	}
 	outputPatrolContext(cfg)
 	showFormulaStepsFull(constants.MolDeaconPatrol, ctx.TownRoot, ctx.Rig)
@@ -359,18 +363,17 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 		return
 	}
 	extraVars := buildWitnessPatrolVars(ctx)
-	cfg := PatrolConfig{
-		RoleName:      "witness",
-		PatrolMolName: constants.MolWitnessPatrol,
-		BeadsDir:      ctx.TownRoot,
-		Assignee:      ctx.Rig + "/witness",
-		HeaderEmoji:   constants.EmojiWitness,
-		HeaderTitle:   "Witness Patrol Status",
-		ExtraVars:     extraVars,
-		WorkLoopSteps: []string{
-			"Work through each patrol step in sequence (see checklist below)",
-			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Witness patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
-		},
+	cfg, err := buildPatrolConfig(RoleWitness, ctx)
+	if err != nil {
+		style.PrintWarning("could not build witness patrol config: %v", err)
+		return
+	}
+	cfg.HeaderEmoji = constants.EmojiWitness
+	cfg.HeaderTitle = "Witness Patrol Status"
+	cfg.ExtraVars = extraVars
+	cfg.WorkLoopSteps = []string{
+		"Work through each patrol step in sequence (see checklist below)",
+		"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Witness patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 	}
 	outputPatrolContext(cfg)
 	showFormulaSteps(constants.MolWitnessPatrol, "Patrol Steps", ctx.TownRoot, ctx.Rig, extraVars)
@@ -390,18 +393,16 @@ func outputRefineryPatrolContext(ctx RoleContext) {
 		fmt.Printf("\nRefinery %s is %s; skipping patrol wisp generation.\n", ctx.Rig, stop.Reason())
 		return
 	}
-	cfg := PatrolConfig{
-		RoleName:      "refinery",
-		PatrolMolName: constants.MolRefineryPatrol,
-		BeadsDir:      ctx.TownRoot,
-		Assignee:      ctx.Rig + "/refinery",
-		HeaderEmoji:   "🔧",
-		HeaderTitle:   "Refinery Patrol Status",
-		ExtraVars:     buildRefineryPatrolVars(ctx),
-		WorkLoopSteps: []string{
-			"Work through each patrol step in sequence (see checklist below)",
-			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
-		},
+	cfg, err := buildPatrolConfig(RoleRefinery, ctx)
+	if err != nil {
+		style.PrintWarning("could not build refinery patrol config: %v", err)
+		return
+	}
+	cfg.HeaderEmoji = "🔧"
+	cfg.HeaderTitle = "Refinery Patrol Status"
+	cfg.WorkLoopSteps = []string{
+		"Work through each patrol step in sequence (see checklist below)",
+		"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 	}
 	outputPatrolContext(cfg)
 	showFormulaStepsFull(constants.MolRefineryPatrol, ctx.TownRoot, ctx.Rig, cfg.ExtraVars)

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
@@ -252,7 +253,22 @@ func newSessionHealthReport(session string, status tmux.ZombieStatus, maxInactiv
 
 // parseAddress parses "rig/polecat" format.
 // If no "/" is present, attempts to infer rig from current directory.
+//
+// The canonical worker forms ("rig/polecats/name", "rig/crew/name") are
+// recognised through agentaddr, so the address a bead stores is also the
+// address these commands accept (gt-cw1). Anything else keeps the historic
+// split-on-first-slash behaviour, which callers rely on for rig-level roles
+// such as "gastown/witness".
 func parseAddress(addr string) (rigName, polecatName string, err error) {
+	if parsed, ok := agentaddr.Parse(addr); ok {
+		switch parsed.Role {
+		case agentaddr.RolePolecat, agentaddr.RoleCrew:
+			if parsed.Rig != "" && parsed.Name != "" {
+				return parsed.Rig, parsed.Name, nil
+			}
+		}
+	}
+
 	parts := strings.SplitN(addr, "/", 2)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -924,9 +924,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Printf("Would instantiate formula %s:\n", formulaName)
 			fmt.Printf("  1. bd cook %s\n", formulaName)
 			fmt.Printf("  2. bd mol bond %s %s --json --ephemeral --var feature=\"%s\" --var issue=\"%s\"\n", formulaName, beadID, info.Title, beadID)
-			fmt.Printf("  3. bd update %s --status=hooked --assignee=%s\n", beadID, targetAgent)
+			fmt.Printf("  3. bd update %s --status=hooked %s\n", beadID, assigneeFlag(targetAgent))
 		} else {
-			fmt.Printf("Would run: bd update %s --status=hooked --assignee=%s\n", beadID, targetAgent)
+			fmt.Printf("Would run: bd update %s --status=hooked %s\n", beadID, assigneeFlag(targetAgent))
 		}
 		if slingSubject != "" {
 			fmt.Printf("  subject (in nudge): %s\n", slingSubject)
@@ -1284,7 +1284,7 @@ func restorePinnedBead(townRoot, beadID, assignee string) {
 		return
 	}
 	dir := beads.ResolveHookDir(townRoot, beadID, "")
-	if err := BdCmd("update", beadID, "--status=pinned", "--assignee="+assignee).
+	if err := BdCmd("update", beadID, "--status=pinned", assigneeFlag(assignee)).
 		Dir(dir).
 		WithAutoCommit().
 		Run(); err != nil {

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1053,6 +1053,13 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	fmt.Printf("%s Work attached to hook (status=hooked)\n", style.Bold.Render("✓"))
 
+	// Give the attached molecule's steps the address the root just resolved to.
+	// Steps come out of the formula carrying its bare pool role, which names no
+	// single agent and leaves them unfindable by assignee.
+	if attachedMoleculeID != "" {
+		propagateAssigneeToSteps(beads.ResolveHookDir(townRoot, attachedMoleculeID, hookWorkDir), attachedMoleculeID, targetAgent)
+	}
+
 	// Log sling event to activity feed
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadID, targetAgent))
 

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -397,6 +397,13 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 
 	fmt.Printf("  %s Work attached to %s\n", style.Bold.Render("✓"), spawnInfo.PolecatName)
 
+	// Give the attached molecule's steps the address the root just resolved to.
+	// Steps come out of the formula carrying its bare pool role, which names no
+	// single agent and leaves them unfindable by assignee.
+	if attachedMoleculeID != "" {
+		propagateAssigneeToSteps(beads.ResolveHookDir(townRoot, attachedMoleculeID, hookWorkDir), attachedMoleculeID, targetAgent)
+	}
+
 	// 8. Log sling event
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadToHook, targetAgent))
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -507,6 +507,10 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 	fmt.Printf("%s Attached to hook (status=hooked)\n", style.Bold.Render("✓"))
 
+	// Give every step the address the root just resolved to. Steps are created
+	// from the formula and come back carrying its bare pool role.
+	propagateAssigneeToSteps(hookDir, wispRootID, targetAgent)
+
 	// Log sling event to activity feed (formula slinging)
 	actor := detectActor()
 	payload := events.SlingPayload(wispRootID, targetAgent)

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1275,7 +1275,7 @@ func hookBeadWithRetryWithTownRoot(beadID, targetAgent, hookDir, townRoot string
 
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		out, err := BdCmd("update", beadID, "--status=hooked", "--assignee="+targetAgent).
+		out, err := BdCmd("update", beadID, "--status=hooked", assigneeFlag(targetAgent)).
 			Dir(hookDir).
 			WithAutoCommit().
 			CombinedOutput()

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -350,3 +350,18 @@ func addressForRole(role Role, rigName, workerName string) (agentaddr.Address, b
 	}
 	return addr, addr.IsComplete()
 }
+
+// assigneeFlag renders the `--assignee` flag for a `bd update`, canonicalizing
+// the address on the way through.
+//
+// Every write site used to interpolate whatever string it happened to hold, so
+// the same agent landed in storage under several spellings and exact-match
+// lookups missed rows that plainly existed (gt-cw1). Routing the flag through
+// one helper means a new write site cannot reintroduce the split by accident.
+//
+// Normalize leaves unrecognised or incomplete input untouched apart from
+// trimming, so a write site that holds something this package cannot parse
+// still stores what the caller meant rather than a guess.
+func assigneeFlag(addr string) string {
+	return "--assignee=" + agentaddr.Normalize(addr)
+}

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -56,19 +57,13 @@ func sessionToAgentID(sessionName string) string {
 }
 
 // canonicalAssigneeAddress returns the address used for bead assignees and
-// hook-status queries. This matches the form emitted by resolveSelfTarget and
-// buildAgentIdentity: town-level agents (mayor, deacon) get a trailing slash.
-// session.AgentIdentity.Address() returns the bare name for those roles, which
-// causes the read/write mismatch in GH#3699.
+// hook-status queries.
+//
+// session.AgentIdentity.Address() returns the bare name for town-level agents,
+// which is what caused the read/write mismatch in GH#3699. Routing it through
+// agentaddr gives every write site the one canonical spelling.
 func canonicalAssigneeAddress(identity *session.AgentIdentity) string {
-	addr := identity.Address()
-	switch identity.Role {
-	case session.RoleMayor, session.RoleDeacon:
-		if !strings.HasSuffix(addr, "/") {
-			return addr + "/"
-		}
-	}
-	return addr
+	return agentaddr.Normalize(identity.Address())
 }
 
 // resolveSelfTarget determines agent identity, pane, and hook root for slinging to self.
@@ -78,28 +73,13 @@ func resolveSelfTarget() (agentID string, pane string, hookRoot string, err erro
 		return "", "", "", fmt.Errorf("detecting role: %w", err)
 	}
 
-	// Build agent identity from role
-	// Town-level agents use trailing slash to match addressToIdentity() normalization
-	switch roleInfo.Role {
-	case RoleMayor:
-		agentID = "mayor/"
-	case RoleDeacon:
-		agentID = "deacon/"
-	case RoleBoot:
-		agentID = "deacon/boot"
-	case RoleWitness:
-		agentID = fmt.Sprintf("%s/witness", roleInfo.Rig)
-	case RoleRefinery:
-		agentID = fmt.Sprintf("%s/refinery", roleInfo.Rig)
-	case RolePolecat:
-		agentID = fmt.Sprintf("%s/polecats/%s", roleInfo.Rig, roleInfo.Polecat)
-	case RoleCrew:
-		agentID = fmt.Sprintf("%s/crew/%s", roleInfo.Rig, roleInfo.Polecat)
-	case RoleDog:
-		agentID = fmt.Sprintf("deacon/dogs/%s", roleInfo.Polecat)
-	default:
+	// Build the agent identity from the role. agentaddr renders the one
+	// canonical spelling, so this write site cannot drift from the others.
+	addr, ok := addressForRole(roleInfo.Role, roleInfo.Rig, roleInfo.Polecat)
+	if !ok {
 		return "", "", "", fmt.Errorf("cannot determine agent identity (role: %s)", roleInfo.Role)
 	}
+	agentID = addr.String()
 
 	pane = os.Getenv("TMUX_PANE")
 	hookRoot = roleInfo.Home
@@ -341,4 +321,32 @@ func missingPolecatTargetRig(target string, allowShorthand bool, townRoot string
 		}
 	}
 	return parts[0], true
+}
+
+// addressForRole converts a detected role context into a canonical address.
+// The second return value is false when the role does not identify one agent —
+// an unknown role, or a rig-scoped role detected without its rig.
+func addressForRole(role Role, rigName, workerName string) (agentaddr.Address, bool) {
+	var addr agentaddr.Address
+	switch role {
+	case RoleMayor:
+		addr = agentaddr.Address{Role: agentaddr.RoleMayor}
+	case RoleDeacon:
+		addr = agentaddr.Address{Role: agentaddr.RoleDeacon}
+	case RoleBoot:
+		addr = agentaddr.Address{Role: agentaddr.RoleBoot}
+	case RoleWitness:
+		addr = agentaddr.Address{Rig: rigName, Role: agentaddr.RoleWitness}
+	case RoleRefinery:
+		addr = agentaddr.Address{Rig: rigName, Role: agentaddr.RoleRefinery}
+	case RolePolecat:
+		addr = agentaddr.Address{Rig: rigName, Role: agentaddr.RolePolecat, Name: workerName}
+	case RoleCrew:
+		addr = agentaddr.Address{Rig: rigName, Role: agentaddr.RoleCrew, Name: workerName}
+	case RoleDog:
+		addr = agentaddr.Address{Role: agentaddr.RoleDog, Name: workerName}
+	default:
+		return agentaddr.Address{}, false
+	}
+	return addr, addr.IsComplete()
 }

--- a/internal/cmd/wisp_assignee.go
+++ b/internal/cmd/wisp_assignee.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/steveyegge/gastown/internal/agentaddr"
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// propagateAssigneeToSteps copies a dispatched root wisp's resolved address
+// down to its child step beads.
+//
+// The root gets the address the dispatcher resolved, but the steps are created
+// by `bd mol wisp` from the formula and come back carrying the bare pool role
+// the wisp was cooked under — "dog" rather than "deacon/dogs/alpha". A bare
+// pool role names no single agent, so anything looking those steps up by
+// assignee cannot find them and they are stranded when the root is closed.
+//
+// This runs after the root is hooked, so a step is only ever rewritten to an
+// address that is already known to be complete. It is best-effort: the root is
+// hooked and the work is dispatchable regardless, so a failure here warns
+// rather than unwinding the dispatch.
+func propagateAssigneeToSteps(workDir, rootID, resolvedAddress string) {
+	if workDir == "" || rootID == "" {
+		return
+	}
+	addr, ok := agentaddr.Parse(resolvedAddress)
+	if !ok || !addr.IsComplete() {
+		// Nothing better to propagate than what the steps already carry.
+		return
+	}
+	canonical := addr.String()
+
+	b := beads.New(workDir)
+	children, err := listChildrenAcrossTables(b, rootID)
+	if err != nil {
+		style.PrintWarning("could not read steps of %s to set their assignee: %v", rootID, err)
+		return
+	}
+
+	for _, child := range children {
+		if child == nil || child.ID == "" {
+			continue
+		}
+		// Leave a step alone when it already names this agent under any
+		// spelling; rewriting it would only churn Dolt commits.
+		if agentaddr.Equal(child.Assignee, canonical) {
+			continue
+		}
+		// A step assigned to a genuinely different, fully-resolved agent was
+		// deliberately routed elsewhere — a formula may fan a step out to
+		// another worker. Only replace an assignee that names no single agent.
+		if existing, ok := agentaddr.Parse(child.Assignee); ok && existing.IsComplete() {
+			continue
+		}
+		if err := BdCmd("update", child.ID, "--assignee="+canonical).
+			Dir(workDir).
+			WithAutoCommit().
+			Run(); err != nil {
+			style.PrintWarning("could not set assignee of step %s to %s: %v", child.ID, canonical, err)
+		}
+	}
+}


### PR DESCRIPTION
Reconciles #4780 and #4781 into one branch, per the mayor's ruling on gt-cw1.

## Why this exists

gt-cw1 was dispatched to several polecats at once, and two complete,
independent implementations landed as open PRs. **They could not both merge.**
Each adds an `internal/cmd` test defining `TestPatrolAssigneeMatchesSlingAssignee`,
and each adds its own copy of `propagateAssigneeToSteps` (`molecule_assignee.go`
in #4780, `wisp_assignee.go` in #4781). Whichever merged first would have won
silently and left the other's write sites unfixed.

Neither was a superset of the other, so this branch is not "pick one".

## What was chosen, and why

**Basis: #4781.** It has the richer `agentaddr` package, and its `parseTwo`
resolves two-segment addresses by *role name* rather than by position, which is
better than #4780 on the exact ambiguity #4780 disclosed in its own PR. That
behaviour is preserved here, not regressed.

**Ported from #4780: the write-site canonicalization**, which is the one thing
#4781 lacked. #4781 removed zero raw `"--assignee="+x` write sites; #4780
removed eight and routed them through a single helper. That gap *is* the bead:
gt-cw1 exists because scattered write sites let one agent land under several
spellings, and it warns that patching some leaves the rest to be found later.

**Dropped: #4780's `molecule_assignee.go`**, resolved deliberately rather than
letting a merge pick.

## What this commit adds on top of the basis

- `assigneeFlag()` renders the flag through `agentaddr.Normalize`, so a new
  write site cannot reintroduce the split by accident.
- **11 raw write sites** routed through it: `assign.go`, `handoff.go` (x3),
  `hook.go` (x2), `molecule_step.go`, `sling_helpers.go`, `sling.go` (x3).
  #4780 covered eight; **the three in `sling.go` were missed by both PRs**.
- `parseAddress` in `session.go` accepts the canonical worker forms, so the
  address a bead stores is also the address these commands accept.
- Tests covering the legacy singular segments, the bare-vs-trailing-slash
  `deacon` split that stranded the wisps, and the deliberate pass-through of
  unparseable input.

## Verification

Measured against an `origin/main` baseline on the same machine:

| gate | origin/main | this branch |
|---|---|---|
| `go build ./...` | clean | clean |
| `go vet ./internal/...` | clean | clean |
| `go test ./internal/agentaddr/...` | n/a (new pkg) | ok |
| `go test ./internal/cmd/...` | 2 failures | **same 2 failures** |

The two failures (`TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir`,
`TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown`) are **pre-existing
on main** and unrelated to addresses. No new failures.

Note for anyone reproducing locally: on an x86_64 toolchain this repo does not
build at all without pointing cgo at the Intel ICU, which is a pre-existing
environment issue, not a code one:

```
export CGO_CPPFLAGS="-I/usr/local/opt/icu4c/include"
export CGO_LDFLAGS="-L/usr/local/opt/icu4c/lib"
```

## Deliberately out of scope

Write sites in `internal/polecat`, `internal/beads` and `internal/web` are still
raw, as are three lookup sites that match an exact string instead of
`agentaddr.Variants`. Fixing them needs a layering decision (does `internal/beads`
canonicalize centrally for every caller, or does each package do it at its own
write site?) that this reconciliation PR should not make unilaterally. Tracked
in **gt-3ft**.

## Merge note

Please close #4780 and #4781 in favour of this branch rather than merging either.

Closes gt-cw1 once merged, with the caveat above recorded in gt-3ft.
