### PR TITLE
docs: document the ICU cgo dependency that blocks every build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@ This file exists for compatibility with tools that look for AGENTS.md.
 
 Full context is injected by `gt prime` at session start.
 
+> **Before your first build:** if `go build` fails with
+> `'unicode/regex.h' file not found`, this is a missing ICU system dependency
+> pulled in through Dolt, not a broken checkout — no package in the repo builds
+> until cgo can find it. See the troubleshooting note under **Getting Started**
+> in CONTRIBUTING.md for the `CGO_CPPFLAGS` / `CGO_LDFLAGS` settings, and note
+> that the prefix must match your Go toolchain's `GOARCH`, not your CPU.
+
 <!-- beads-agent-instructions-v2 -->
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,33 @@ Thanks for your interest in contributing! Gas Town is experimental software, and
 3. Install prerequisites (see README.md)
 4. Build and test: `go build -o gt ./cmd/gt && go test ./...`
 
+### If the build fails with `'unicode/regex.h' file not found`
+
+Gas Town depends on Dolt, which pulls in `go-icu-regex`, a cgo package that
+needs the ICU headers and libraries. Nothing in this repo builds until cgo can
+find them, so this failure looks like a broken checkout rather than a missing
+system dependency:
+
+```
+# github.com/dolthub/go-icu-regex/internal/icu
+file.cpp:3:10: fatal error: 'unicode/regex.h' file not found
+```
+
+Install ICU (`brew install icu4c` on macOS), then point cgo at it. **Match the
+prefix to your Go toolchain's architecture, not to your CPU** — a `GOARCH=amd64`
+toolchain on Apple Silicon needs the x86_64 build under `/usr/local`, and
+pointing it at the arm64 build under `/opt/homebrew` gets you past the header
+error only to fail at link time with `symbol(s) not found for architecture`.
+
+```bash
+go env GOARCH                       # amd64 -> /usr/local, arm64 -> /opt/homebrew
+export CGO_CPPFLAGS="-I/usr/local/opt/icu4c/include"
+export CGO_LDFLAGS="-L/usr/local/opt/icu4c/lib"
+```
+
+Use `CGO_CPPFLAGS`, not `CGO_CFLAGS`: the package compiles both C and C++, and
+only `CGO_CPPFLAGS` reaches both.
+
 ## Setting up a rig to contribute to Gas Town
 
 If you run a Gas Town rig against this repo, you don't own the canonical


### PR DESCRIPTION
Documents the ICU cgo dependency that currently blocks every build on a clean
checkout, per the mayor's request to put this where polecats find it before
their first build rather than only in a bead.

## The failure

```
# github.com/dolthub/go-icu-regex/internal/icu
file.cpp:3:10: fatal error: 'unicode/regex.h' file not found
```

Dolt pulls in `go-icu-regex`, which is cgo. Until cgo can find the ICU headers,
**no package in the repo builds** — not just the ones that touch Dolt. That
breadth is what makes it read as a broken checkout instead of a missing system
dependency, and it has already cost more than one agent a build cycle tonight.

## The two non-obvious parts

Both verified firsthand on an `amd64` toolchain while working gt-cw1:

1. **The prefix must match the Go toolchain's `GOARCH`, not the CPU.** A
   `GOARCH=amd64` toolchain on Apple Silicon needs the x86_64 ICU under
   `/usr/local`. Pointing it at the arm64 build under `/opt/homebrew` clears the
   header error and then fails at *link* time with `symbol(s) not found for
   architecture x86_64`, which looks like an entirely different problem.
2. **The include path belongs in `CGO_CPPFLAGS`, not `CGO_CFLAGS`.** The package
   compiles both C and C++; only `CGO_CPPFLAGS` reaches both. Setting
   `CGO_CFLAGS` alone changes nothing and makes the fix look wrong.

## Where it is documented

- `CONTRIBUTING.md` — a troubleshooting subsection directly under the existing
  "Build and test" step in Getting Started, so it is next to the command that
  fails.
- `AGENTS.md` — a short "before your first build" pointer, since agents read
  this file and not CONTRIBUTING.md.

Docs only. No code changes.
