### PR TITLE
fix: use 'gt dog done' in RoleDog no-hook startup protocol

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -611,7 +611,7 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("2. If mail has work → execute it")
 		fmt.Println("3. If no mail → check ready queue: `bd ready`")
 		fmt.Println("4. If ready queue has work → claim top bead: `bd update <id> --claim`")
-		fmt.Println("5. If nothing available → run `" + cli.Name() + " done` and exit")
+		fmt.Println("5. If nothing available → run `" + cli.Name() + " dog done` and exit")
 		fmt.Println()
 		fmt.Println("DO NOT sit idle waiting. Recover or terminate. (GH#2748)")
 	case RoleBoot:


### PR DESCRIPTION
## Summary

In `prime_output.go`, the `RoleDog` case of the no-hook startup protocol (line 614) told idle dogs to run `gt done`. But `gt done` is for polecats only — dogs must use `gt dog done`.

This caused a confusing error for dogs with empty hooks:
```
gt done is for polecats only (you are deacon/dogs/alpha)
```

## Change

Single line fix in `internal/cmd/prime_output.go`:

```diff
-fmt.Println("5. If nothing available → run `" + cli.Name() + " done` and exit")
+fmt.Println("5. If nothing available → run `" + cli.Name() + " dog done` and exit")
```

## Scope check

All other `done` references in `prime_output.go` are correctly scoped:
- Line 289: `outputPolecatContext` — correct
- Lines 533, 537: `RolePolecat` case — correct
- Line 614: `RoleDog` case — **this fix**

Closes gt-frs