### PR TITLE
docs: correct rig directory layout

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -162,7 +162,6 @@ gt install ~/gt --shell --git
 #   ~/gt/
 #   ├── CLAUDE.md          # Identity anchor (run gt prime)
 #   ├── mayor/             # Mayor config and state
-#   ├── rigs/              # Project containers (initially empty)
 #   └── .beads/            # Town-level issue tracking
 ```
 


### PR DESCRIPTION
## Summary
Remove the stale `rigs/` directory from the `gt install` workspace layout.

## Related Issue
Fixes #4529

## Changes
- Align the Step 2 layout with the direct `townRoot/<name>` rig placement shown in Step 3.

## Testing
- [ ] Unit tests pass (`go test ./...`) — not run; documentation-only change
- [x] Manual testing performed
  - `git diff --check`
  - Verified Markdown fences are balanced and the `~/gt/myproject/` example remains intact

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)