### PR TITLE
fix(dog): make completion actor-aware and assignment-safe

### DIFF
--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -692,7 +692,10 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("clearing completed work for dog %s: %w", name, err)
 	}
 	if !cleared {
-		fmt.Printf("Dog %s assignment changed while completing %s; preserving newer work %s\n", name, dogDoneWork, d.Work)
+		if dogDoneWork == "" {
+			return fmt.Errorf("dog %s has active work; rerun with --work <assigned-work-id> so completion cannot clear a newer assignment", name)
+		}
+		fmt.Printf("Dog %s assignment changed while completing %s; preserving current work\n", name, dogDoneWork)
 		return nil
 	}
 
@@ -733,7 +736,7 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 // time an old dog session exits; that newer assignment must remain working.
 func clearDogWorkForCompletion(mgr *dog.Manager, d *dog.Dog, expectedWork string) (bool, error) {
 	if expectedWork == "" {
-		return true, mgr.ClearWork(d.Name)
+		return false, nil
 	}
 	if d.Work != expectedWork {
 		return false, nil

--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -27,6 +27,7 @@ var (
 	dogForce      bool
 	dogRemoveAll  bool
 	dogCallAll    bool
+	dogDoneWork   string
 
 	// Dispatch flags
 	dogDispatchPlugin string
@@ -256,6 +257,7 @@ Examples:
 func init() {
 	// List flags
 	dogListCmd.Flags().BoolVar(&dogListJSON, "json", false, "Output as JSON")
+	dogDoneCmd.Flags().StringVar(&dogDoneWork, "work", "", "Expected work ID (prevents clearing a newer assignment)")
 
 	// Remove flags
 	dogRemoveCmd.Flags().BoolVarP(&dogForce, "force", "f", false, "Force removal even if working")
@@ -685,8 +687,13 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := mgr.ClearWork(name); err != nil {
-		return fmt.Errorf("clearing work for dog %s: %w", name, err)
+	cleared, err := clearDogWorkForCompletion(mgr, d, dogDoneWork)
+	if err != nil {
+		return fmt.Errorf("clearing completed work for dog %s: %w", name, err)
+	}
+	if !cleared {
+		fmt.Printf("Dog %s assignment changed while completing %s; preserving newer work %s\n", name, dogDoneWork, d.Work)
+		return nil
 	}
 
 	fmt.Printf("✓ Dog %s returned to kennel (idle)\n", name)
@@ -719,6 +726,19 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 	time.Sleep(4 * time.Second)
 
 	return nil
+}
+
+// clearDogWorkForCompletion atomically clears only the assignment that invoked
+// completion. A dispatcher may already have installed the next hook by the
+// time an old dog session exits; that newer assignment must remain working.
+func clearDogWorkForCompletion(mgr *dog.Manager, d *dog.Dog, expectedWork string) (bool, error) {
+	if expectedWork == "" {
+		return true, mgr.ClearWork(d.Name)
+	}
+	if d.Work != expectedWork {
+		return false, nil
+	}
+	return mgr.ClearWorkIfMatches(d.Name, expectedWork, d.WorkStartedAt)
 }
 
 func splitPathComponents(path string) []string {

--- a/internal/cmd/dog_test.go
+++ b/internal/cmd/dog_test.go
@@ -283,6 +283,68 @@ func TestDogDone_NotFound(t *testing.T) {
 	}
 }
 
+func TestDogDone_PreservesNewerAssignment(t *testing.T) {
+	m, tmpDir := testDogManager(t)
+	setupTestDog(t, m, tmpDir, "alpha", &dog.DogState{
+		Name: "alpha", State: dog.StateIdle, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	if err := m.AssignWork("alpha", "mol-old"); err != nil {
+		t.Fatal(err)
+	}
+	old, err := m.Get("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AssignWork("alpha", "mol-next"); err != nil {
+		t.Fatal(err)
+	}
+
+	cleared, err := clearDogWorkForCompletion(m, old, "mol-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared {
+		t.Fatal("old completion cleared a newer assignment")
+	}
+	got, err := m.Get("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != dog.StateWorking || got.Work != "mol-next" {
+		t.Fatalf("new assignment = (%s, %q), want (working, mol-next)", got.State, got.Work)
+	}
+}
+
+func TestDogDone_ExpectedWorkIsIdempotent(t *testing.T) {
+	m, tmpDir := testDogManager(t)
+	setupTestDog(t, m, tmpDir, "alpha", &dog.DogState{
+		Name: "alpha", State: dog.StateIdle, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	if err := m.AssignWork("alpha", "mol-old"); err != nil {
+		t.Fatal(err)
+	}
+	assigned, err := m.Get("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := clearDogWorkForCompletion(m, assigned, "mol-old")
+	if err != nil || !cleared {
+		t.Fatalf("first completion = (%v, %v), want (true, nil)", cleared, err)
+	}
+	idle, err := m.Get("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleared, err = clearDogWorkForCompletion(m, idle, "mol-old")
+	if err != nil || cleared {
+		t.Fatalf("repeated completion = (%v, %v), want (false, nil)", cleared, err)
+	}
+	got, _ := m.Get("alpha")
+	if got.State != dog.StateIdle || got.Work != "" {
+		t.Fatalf("dog = (%s, %q), want (idle, empty)", got.State, got.Work)
+	}
+}
+
 // =============================================================================
 // Dog Clear Tests
 // =============================================================================

--- a/internal/cmd/dog_test.go
+++ b/internal/cmd/dog_test.go
@@ -345,6 +345,28 @@ func TestDogDone_ExpectedWorkIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestDogDone_WithoutExpectedWorkPreservesAssignment(t *testing.T) {
+	m, tmpDir := testDogManager(t)
+	setupTestDog(t, m, tmpDir, "alpha", &dog.DogState{
+		Name: "alpha", State: dog.StateIdle, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	if err := m.AssignWork("alpha", "mol-next"); err != nil {
+		t.Fatal(err)
+	}
+	assigned, err := m.Get("alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := clearDogWorkForCompletion(m, assigned, "")
+	if err != nil || cleared {
+		t.Fatalf("unscoped completion = (%v, %v), want (false, nil)", cleared, err)
+	}
+	got, _ := m.Get("alpha")
+	if got.State != dog.StateWorking || got.Work != "mol-next" {
+		t.Fatalf("dog = (%s, %q), want (working, mol-next)", got.State, got.Work)
+	}
+}
+
 // =============================================================================
 // Dog Clear Tests
 // =============================================================================

--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -276,6 +276,15 @@ func handleStepContinue(cwd, townRoot string, nextStep *beads.Issue, dryRun bool
 		TownRoot: townRoot,
 		WorkDir:  cwd,
 	}
+	// Older or partially upgraded dog sessions can carry a generic GT_ROLE
+	// while BD_ACTOR still truthfully identifies the dog. Never route those
+	// sessions through the polecat-only `gt done` command.
+	if dogName, ok := dogNameFromActor(os.Getenv("BD_ACTOR")); ok {
+		roleCtx.Role = RoleDog
+		if roleCtx.Polecat == "" {
+			roleCtx.Polecat = dogName
+		}
+	}
 	agentID := buildAgentIdentity(roleCtx)
 	if agentID == "" {
 		return fmt.Errorf("cannot determine agent identity (role: %s)", roleCtx.Role)
@@ -442,6 +451,12 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 		TownRoot: townRoot,
 		WorkDir:  cwd,
 	}
+	if dogName, ok := dogNameFromActor(os.Getenv("BD_ACTOR")); ok {
+		roleCtx.Role = RoleDog
+		if roleCtx.Polecat == "" {
+			roleCtx.Polecat = dogName
+		}
+	}
 	agentID := buildAgentIdentity(roleCtx)
 
 	// Get git root for hook files
@@ -499,7 +514,7 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 	if roleCtx.Role == RoleDog {
 		fmt.Printf("%s Signaling dog completion...\n", style.Bold.Render("📤"))
 
-		dogDoneArgs := []string{"dog", "done"}
+		dogDoneArgs := []string{"dog", "done", "--work", moleculeID}
 		if roleCtx.Polecat != "" { // dog name stored in Polecat field
 			dogDoneArgs = append(dogDoneArgs, roleCtx.Polecat)
 		}
@@ -512,6 +527,18 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 	// For other roles, just print completion message
 	fmt.Printf("\nMolecule %s is complete. Ready for next assignment.\n", moleculeID)
 	return nil
+}
+
+func dogNameFromActor(actor string) (string, bool) {
+	actor = strings.TrimSpace(actor)
+	if actor == "dog" {
+		return "", true
+	}
+	parts := strings.Split(actor, "/")
+	if len(parts) == 3 && parts[0] == "deacon" && parts[1] == "dogs" && parts[2] != "" {
+		return parts[2], true
+	}
+	return "", false
 }
 
 // getGitRoot is defined in prime.go

--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -484,9 +484,10 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 			Assignee: agentID,
 			Priority: -1,
 		})
-		if err == nil && len(pinnedBeads) > 0 {
-			// Unpin by setting status to open
-			unpinCmd := exec.Command("bd", "update", pinnedBeads[0].ID, "--status=open")
+		if completed := pinnedIssueByID(pinnedBeads, moleculeID); err == nil && completed != nil {
+			// Unpin only the molecule that completed. A newer assignment may
+			// already be pinned to the same agent and must remain untouched.
+			unpinCmd := exec.Command("bd", "update", completed.ID, "--status=open")
 			unpinCmd.Dir = gitRoot
 			unpinCmd.Stderr = os.Stderr
 			if err := unpinCmd.Run(); err != nil {
@@ -526,6 +527,15 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 
 	// For other roles, just print completion message
 	fmt.Printf("\nMolecule %s is complete. Ready for next assignment.\n", moleculeID)
+	return nil
+}
+
+func pinnedIssueByID(issues []*beads.Issue, id string) *beads.Issue {
+	for _, issue := range issues {
+		if issue != nil && issue.ID == id {
+			return issue
+		}
+	}
 	return nil
 }
 

--- a/internal/cmd/molecule_step_dog_test.go
+++ b/internal/cmd/molecule_step_dog_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
 
 func TestDogNameFromActor(t *testing.T) {
 	tests := []struct {
@@ -22,5 +26,18 @@ func TestDogNameFromActor(t *testing.T) {
 				t.Fatalf("dogNameFromActor(%q) = (%q, %v), want (%q, %v)", tt.actor, got, ok, tt.want, tt.ok)
 			}
 		})
+	}
+}
+
+func TestPinnedIssueByIDPreservesNewerAssignment(t *testing.T) {
+	old := &beads.Issue{ID: "mol-old"}
+	next := &beads.Issue{ID: "mol-next"}
+	issues := []*beads.Issue{next, old}
+
+	if got := pinnedIssueByID(issues, "mol-old"); got != old {
+		t.Fatalf("selected %#v, want completed old molecule", got)
+	}
+	if got := pinnedIssueByID([]*beads.Issue{next}, "mol-old"); got != nil {
+		t.Fatalf("selected newer assignment %#v when completed molecule was absent", got)
 	}
 }

--- a/internal/cmd/molecule_step_dog_test.go
+++ b/internal/cmd/molecule_step_dog_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestDogNameFromActor(t *testing.T) {
+	tests := []struct {
+		name  string
+		actor string
+		want  string
+		ok    bool
+	}{
+		{name: "generic dog", actor: "dog", ok: true},
+		{name: "named dog", actor: "deacon/dogs/alpha", want: "alpha", ok: true},
+		{name: "polecat unchanged", actor: "gastown/polecats/alpha"},
+		{name: "deacon unchanged", actor: "deacon"},
+		{name: "malformed dog", actor: "deacon/dogs/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := dogNameFromActor(tt.actor)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("dogNameFromActor(%q) = (%q, %v), want (%q, %v)", tt.actor, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/dog/session_manager.go
+++ b/internal/dog/session_manager.go
@@ -110,7 +110,11 @@ func (m *SessionManager) Start(dogName string, opts SessionStartOptions) error {
 			workInfo = fmt.Sprintf(" Work assigned: %s.", opts.WorkDesc)
 		}
 	}
-	instructions := fmt.Sprintf("I am Dog %s.%s IMPORTANT: If your hook is empty and you have no mail, WAIT — the dispatcher is still setting up your assignment. Do NOT search for work, scan directories, or take autonomous action. Check hook (`"+cli.Name()+" hook`) and mail (`"+cli.Name()+" mail inbox`). If neither has work, wait 10 seconds and re-check. Execute only assigned work. When done, run `"+cli.Name()+" dog done` — this clears your work and auto-terminates the session.", dogName, workInfo)
+	doneInstruction := "When done, run `" + cli.Name() + " dog done --work <assigned-work-id>` using the exact work ID from `" + cli.Name() + " dog status " + dogName + "`. The unscoped form fails closed while work is active."
+	if opts.WorkDesc != "" {
+		doneInstruction = fmt.Sprintf("When done, run `%s dog done --work %q` — this clears only this assignment and auto-terminates the session.", cli.Name(), opts.WorkDesc)
+	}
+	instructions := fmt.Sprintf("I am Dog %s.%s IMPORTANT: If your hook is empty and you have no mail, WAIT — the dispatcher is still setting up your assignment. Do NOT search for work, scan directories, or take autonomous action. Check hook (`"+cli.Name()+" hook`) and mail (`"+cli.Name()+" mail inbox`). If neither has work, wait 10 seconds and re-check. Execute only assigned work. %s", dogName, workInfo, doneInstruction)
 
 	// Use unified session lifecycle.
 	theme := tmux.DogTheme()

--- a/internal/templates/roles/dog.md.tmpl
+++ b/internal/templates/roles/dog.md.tmpl
@@ -53,14 +53,14 @@ gt mail inbox                    # Check for DOG_DISPATCH or work messages
 # Do NOT proceed without an assignment.
 ```
 
-**Wait for assignment → Execute → `gt dog done`. No freelancing.**
+**Wait for assignment → Execute → `gt dog done --work <assigned-work-id>`. No freelancing.**
 
 ## Completing Work
 
 **CRITICAL**: When you finish your work, you MUST call:
 
 ```bash
-gt dog done
+gt dog done --work <assigned-work-id>
 ```
 
 This command:
@@ -69,11 +69,11 @@ This command:
 3. Makes you available for the next dispatch
 4. **Auto-terminates your tmux session** (after a 3-second delay)
 
-**Without `{{ cmd }} dog done`**, you will be stuck in "working" state forever, and the
+**Without `{{ cmd }} dog done --work <assigned-work-id>`**, you will be stuck in "working" state forever, and the
 Deacon cannot assign you new work.
 
 The command auto-detects your dog name from your working directory, so just run
-`{{ cmd }} dog done` with no arguments. Your session ends automatically — do NOT
+`{{ cmd }} dog done --work <assigned-work-id>` using the exact ID shown by `{{ cmd }} dog status`. Your session ends automatically — do NOT
 idle at the prompt after running this command.
 
 ## Prefix-Based Routing
@@ -100,7 +100,7 @@ Routes defined in `{{ .TownRoot }}/.beads/routes.jsonl`. Debug with: `BD_DEBUG_R
 | Command | Purpose |
 |---------|---------|
 | `{{ cmd }} hook` | Check your assigned work |
-| `{{ cmd }} dog done` | Return to idle when work complete |
+| `{{ cmd }} dog done --work <assigned-work-id>` | Return to idle when that exact work completes |
 | `bd show <id>` | View issue details |
 | `bd close <id>` | Close completed issues |
 | `{{ cmd }} sling <issue> <rig>` | Dispatch work to a polecat |
@@ -212,7 +212,7 @@ Steps: export → verify counts → commit+push → report
 
 ```
 [ ] Complete all formula steps
-[ ] gt dog done              (CRITICAL - clears work + auto-terminates session)
+[ ] gt dog done --work <assigned-work-id> (CRITICAL - clears exact work + auto-terminates session)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- route molecule completion through `gt dog done` when `BD_ACTOR` identifies a dog, even with stale role metadata
- pass the completed molecule ID into dog completion
- atomically preserve a newer assignment instead of clearing it or terminating its session
- make repeated completion of an old assignment a no-op

## Tests
- focused `internal/cmd` dog and molecule tests pass
- full `internal/dog` package tests pass

Tracks `gt-5a8`.