### PR TITLE
fix(tmux): select the trust dialog's affirmative option by text, not position

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1993,6 +1993,59 @@ func (t *Tmux) CheckStartupBlocked(session string) error {
 	}
 }
 
+// --- workspace trust dialog option selection -------------------------------
+//
+// The affirmative option is NOT reliably pre-selected. Claude Code v2.1.252
+// renders the trust dialog with "No, exit" FIRST and selected, so a bare Enter
+// DECLINES trust — the session then refuses to start and the caller rolls back
+// (gt-ma1 / gt-jnr). Position is not a contract another tool owes us, so select
+// by option TEXT and navigate to it.
+var (
+	trustAffirmativeRe = regexp.MustCompile(`(?i)^\s*[>\x{276f}\x{203a}*]?\s*(?:\d[.)]\s*)?(?:yes\b|proceed\b|trust\b|allow\b)`)
+	trustDeclineRe     = regexp.MustCompile(`(?i)^\s*[>\x{276f}\x{203a}*]?\s*(?:\d[.)]\s*)?(?:no\b|cancel\b|exit\b|don'?t\b)`)
+	trustCursorRe      = regexp.MustCompile(`^\s*[>\x{276f}\x{203a}]\s+\S`)
+)
+
+// trustDialogNavigation reports how to reach the affirmative option.
+// upFirst is a count of Up presses used to normalise to the first option when
+// the cursor is not visible; steps is the number of Down presses from there
+// (or, when the cursor IS visible, the signed offset from it — negative means
+// Up). ok is false only when no affirmative option is in view at all, in which
+// case the caller keeps the legacy behaviour rather than erroring.
+func trustDialogNavigation(content string) (upFirst int, steps int, ok bool) {
+	selected, affirmative, idx := -1, -1, 0
+	for _, line := range strings.Split(content, "\n") {
+		// A line ending in "?" is the dialog's question, not one of its options.
+		if strings.HasSuffix(strings.TrimSpace(line), "?") {
+			continue
+		}
+		isAff := trustAffirmativeRe.MatchString(line)
+		isDec := trustDeclineRe.MatchString(line)
+		if !isAff && !isDec {
+			continue
+		}
+		if trustCursorRe.MatchString(line) && selected < 0 {
+			selected = idx
+		}
+		if isAff && affirmative < 0 {
+			affirmative = idx
+		}
+		idx++
+	}
+	if affirmative < 0 {
+		// No affirmative option in view: this is banner text or an unknown
+		// variant, not a list we can steer. Caller falls back to legacy Enter.
+		return 0, 0, false
+	}
+	if selected < 0 {
+		// Options are visible but the cursor is not (it may be rendered with
+		// terminal attributes rather than a glyph). Normalise deterministically:
+		// press Up past every option to land on the first, then descend.
+		return idx, affirmative, true
+	}
+	return 0, affirmative - selected, true
+}
+
 // AcceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
 // agents. Claude shows "Quick safety check"; Codex shows
 // "Do you trust the contents of this directory?". In both cases the safe
@@ -2014,7 +2067,32 @@ func (t *Tmux) AcceptWorkspaceTrustDialog(session string) error {
 		// Codex trust screens include a leading ">" banner line, so prompt
 		// detection alone would exit too early.
 		if containsWorkspaceTrustDialog(content) {
-			// Dialog found — accept it (option 1 is pre-selected, just press Enter)
+			// Dialog found. Locate the affirmative option by TEXT and move to it;
+			// never assume it is pre-selected.
+			// When the options are in view, steer to the affirmative one. When
+			// they are not (banner-only text, or an unrecognised variant) fall
+			// back to the historical bare Enter so this is never a regression.
+			if upFirst, steps, ok := trustDialogNavigation(content); ok {
+				press := func(key string, n int) error {
+					for i := 0; i < n; i++ {
+						if _, err := t.run("send-keys", "-t", session, key); err != nil {
+							return err
+						}
+						time.Sleep(60 * time.Millisecond)
+					}
+					return nil
+				}
+				if err := press("Up", upFirst); err != nil {
+					return err
+				}
+				key := "Down"
+				if steps < 0 {
+					key, steps = "Up", -steps
+				}
+				if err := press(key, steps); err != nil {
+					return err
+				}
+			}
 			if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
 				return err
 			}

--- a/internal/tmux/trust_dialog_nav_test.go
+++ b/internal/tmux/trust_dialog_nav_test.go
@@ -1,0 +1,64 @@
+package tmux
+
+import "testing"
+
+func TestTrustDialogNavigation(t *testing.T) {
+	cases := []struct {
+		name        string
+		content     string
+		wantUpFirst int
+		wantSteps   int
+		wantOK      bool
+	}{
+		{
+			// The real pane captured from liveop-refinery, 2026-08-31 (gt-ma1).
+			// Decline is FIRST and selected — a bare Enter here declines trust.
+			name:      "claude v2.1.252, decline preselected",
+			content:   "Quick safety check\n\n❯ No, exit\n  Yes, I trust this folder\n\nEnter to confirm",
+			wantSteps: 1,
+			wantOK:    true,
+		},
+		{
+			name:      "affirmative already selected",
+			content:   "Quick safety check\n\n❯ Yes, I trust this folder\n  No, exit\n",
+			wantSteps: 0,
+			wantOK:    true,
+		},
+		{
+			name:      "codex phrasing, decline preselected",
+			content:   "Do you trust the contents of this directory?\n\n> No, exit\n  Yes, proceed\n",
+			wantSteps: 1,
+			wantOK:    true,
+		},
+		{
+			// Cursor not rendered as a glyph: normalise to the top with Up
+			// presses, then descend to the affirmative option.
+			name:        "options visible, no cursor glyph",
+			content:     "Quick safety check\n\n  No, exit\n  Yes, I trust this folder\n",
+			wantUpFirst: 2,
+			wantSteps:   1,
+			wantOK:      true,
+		},
+		{
+			// Banner text only — what the legacy tests echo. Must fall back to
+			// the historical bare Enter rather than error.
+			name:    "banner only, no options -> legacy fallback",
+			content: "Quick safety check - do you trust this folder?\n",
+			wantOK:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upFirst, steps, ok := trustDialogNavigation(tc.content)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if upFirst != tc.wantUpFirst || steps != tc.wantSteps {
+				t.Fatalf("upFirst/steps = %d/%d, want %d/%d", upFirst, steps, tc.wantUpFirst, tc.wantSteps)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`AcceptWorkspaceTrustDialog` assumes *"the safe continue option is pre-selected, so Enter accepts the dialog."* That is no longer true. Claude Code v2.1.252 renders the trust dialog as:

```
❯ No, exit
  Yes, I trust this folder
```

The decline is first **and selected**, so the bare `Enter` **declines trust**. The session then refuses to start, `containsBlockingStartupDialog` reports `workspace trust prompt`, and `sling` rolls the whole spawn back.

Observed in `daemon.log` on two consecutive dispatches, each with a fresh worktree suffix:

```
✗ Could not start session: startup blocked: interactive startup dialog still
  visible in liveop-rust: workspace trust prompt, cleaning up partial state...
⚠ Session failed, rolling back spawned polecat rust...
✓ deleted local branch polecat/rust/liveop-2zp+mthvpdzl
```

It blocks **all** polecat dispatch, and it cannot be worked around by trusting folders: every dispatch creates a worktree at a path that has never existed, so each one raises a new prompt. Verified — the town root is trusted and a polecat underneath it still blocked.

## The fix

Locate the affirmative option by **text** and navigate to it. Position in another tool's TUI is not a contract it owes us; the option order moved and gt had no way to notice.

Deliberately non-regressive, three cases:

| pane state | behaviour |
|---|---|
| options visible, cursor glyph present | move the signed offset to the affirmative option, then `Enter` |
| options visible, no cursor glyph (drawn with terminal attributes) | press `Up` past every option to normalise to the first, then descend deterministically |
| no affirmative option in view (banner text, unknown variant) | **fall back to the historical bare `Enter`** rather than erroring |

I first made the third case a hard error. That broke the two existing dialog tests, which echo only the banner line and no options — and they were right to break. Erroring there would turn a harmless false-positive match into a failed session start, so the fallback is the correct behaviour.

Option matching is anchored to the start of the line and skips any line ending in `?`, because the dialog's own question contains the words "trust this folder" and was otherwise picked up as an option.

## Tests

Five cases in `internal/tmux/trust_dialog_nav_test.go`, including the exact captured pane text from the failing session. Full `internal/tmux` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYB6oHT1sjddYM6yEGGHQy