### PR TITLE
fix: fork-rig refinery guard must fail closed on config-read error (gt-9gv)

### DIFF
--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -21,6 +21,18 @@ var bdTargetEnvKeys = []string{
 	"GT_DOLT_DATA",
 }
 
+// bdRoutingEnvKeys are the bd config keys that decide which repository a bd
+// subprocess reads and writes, independent of BEADS_DIR. bd resolves them via
+// viper (BD_<KEY> with dots as underscores), and its BEADS_-prefixed spellings
+// are honoured for legacy compatibility, so both are stripped before Gas Town
+// re-pins them.
+var bdRoutingEnvKeys = []string{
+	"BD_ROUTING_MODE",
+	"BD_ROUTING_DEFAULT",
+	"BEADS_ROUTING_MODE",
+	"BEADS_ROUTING_DEFAULT",
+}
+
 // DatabaseNameFromMetadata reads the dolt_database field from .beads/metadata.json.
 // Returns empty string if metadata doesn't exist or has no database configured.
 func DatabaseNameFromMetadata(beadsDir string) string {
@@ -78,12 +90,37 @@ func isBDTargetEnv(entry string) bool {
 	return envKeyHasPrefix(keyName, "BEADS_DOLT_")
 }
 
+// PinBDRoutingToTarget disables Beads' contributor auto-routing for a Gas Town
+// bd subprocess, so the target selected by BEADS_DIR / prefix routing is the
+// repository the subprocess actually reads and writes.
+//
+// Beads routes by *repository* as well as by database: with routing.mode=auto
+// and git config beads.role=contributor, bd redirects creates AND reads to
+// routing.contributor (default ~/.beads-planning) — the write reports success,
+// reads from the same seat find it, and nothing ever reaches the database
+// BEADS_DIR selected. routing.default hijacks the target the same way even when
+// the mode is not auto, so both keys are pinned. Every write-by-id path (bd dep,
+// bd comment) then fails with "embeddeddolt: store is read-only", because an
+// auto-routed store is deliberately opened read-only for write-intent callers.
+//
+// Gas Town always addresses a specific town database, so neither redirect is
+// ever wanted here. Measured against bd 1.2.2 (hq-z871, hq-2f0m).
+func PinBDRoutingToTarget(env []string) []string {
+	for _, key := range bdRoutingEnvKeys {
+		env = StripEnvKey(env, key)
+	}
+	return append(env,
+		"BD_ROUTING_MODE=explicit",
+		"BD_ROUTING_DEFAULT=.",
+	)
+}
+
 // BuildPinnedBDEnv returns env for a bd subprocess pinned to beadsDir. BEADS_DIR
 // and the metadata-backed Dolt database are the authoritative target selectors;
 // inherited selectors are stripped first so stale shell state cannot make bd
 // write to a different database than the selected .beads directory.
 func BuildPinnedBDEnv(base []string, beadsDir string) []string {
-	env := SuppressBDSideEffects(StripBDTargetEnv(base))
+	env := PinBDRoutingToTarget(SuppressBDSideEffects(StripBDTargetEnv(base)))
 	if beadsDir == "" {
 		return addResolvedDoltConnectionEnv(env, "")
 	}
@@ -100,7 +137,7 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 // bd prefix routing. It strips stale target/database selectors, then re-adds only
 // connection host/port from fallbackBeadsDir so routing can choose the database.
 func BuildRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
-	env := SuppressBDSideEffects(StripBDTargetEnv(base))
+	env := PinBDRoutingToTarget(SuppressBDSideEffects(StripBDTargetEnv(base)))
 	fallbackBeadsDir = canonicalBeadsDir(fallbackBeadsDir)
 	env = append(env, doltTargetEnvFromBeadsDir(fallbackBeadsDir)...)
 	return addResolvedDoltConnectionEnv(env, fallbackBeadsDir)
@@ -136,7 +173,7 @@ func BuildMutationRoutingBDEnv(base []string, fallbackBeadsDir string) []string 
 // Gas Town target selectors and suppresses side effects without adding BEADS_DIR
 // or town Dolt connection metadata that could change native bd path semantics.
 func BuildMutationNeutralBDEnv(base []string) []string {
-	return forceBDMutation(SuppressBDSideEffects(StripBDTargetEnv(base)))
+	return forceBDMutation(PinBDRoutingToTarget(SuppressBDSideEffects(StripBDTargetEnv(base))))
 }
 
 // ArgsAreReadOnly classifies bd CLI arguments for env policy. Unknown commands

--- a/internal/beads/database_routing_test.go
+++ b/internal/beads/database_routing_test.go
@@ -1,0 +1,118 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRoutingTestBeadsDir creates a .beads directory whose metadata selects a
+// named Dolt database on a shared server, the shape every Gas Town rig has.
+func writeRoutingTestBeadsDir(t *testing.T, database string) string {
+	t.Helper()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"` + database + `","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return beadsDir
+}
+
+// TestBDEnvPinsRoutingAwayFromContributorPlanningRepo guards hq-z871/hq-2f0m.
+//
+// Selecting a database is not the same as selecting a repository. With
+// routing.mode=auto and git config beads.role=contributor (the configuration
+// the gastown rig shipped with), bd 1.2.2 redirects both writes and reads to
+// routing.contributor — reproduced end to end in an isolated two-repo sandbox:
+// `bd create` from repo A minted the issue in repo B under B's prefix and
+// reported success, `bd list` from A found it via the same redirect, and
+// `bd dep` / `bd comment` on it then failed "embeddeddolt: store is read-only"
+// because an auto-routed store is opened read-only even for write-intent
+// callers. Nothing ever reached the database BEADS_DIR had selected.
+//
+// routing.default hijacks the target the same way with the mode left alone, so
+// pinning the mode is NOT sufficient on its own — verified in the same sandbox:
+// under BD_ROUTING_MODE=explicit a create still landed in the foreign repo
+// until BD_ROUTING_DEFAULT=. was pinned as well.
+func TestBDEnvPinsRoutingAwayFromContributorPlanningRepo(t *testing.T) {
+	beadsDir := writeRoutingTestBeadsDir(t, "rigdb")
+	// Values a seat can inherit from a contributor-configured shell; both
+	// spellings, because bd honours the BEADS_ prefix for legacy compatibility.
+	base := []string{
+		"PATH=/usr/bin",
+		"BD_ROUTING_MODE=auto",
+		"BD_ROUTING_DEFAULT=/home/agent/.beads-planning",
+		"BEADS_ROUTING_MODE=auto",
+		"BEADS_ROUTING_DEFAULT=/home/agent/.beads-planning",
+	}
+
+	for _, tc := range []struct {
+		name string
+		env  []string
+	}{
+		{name: "pinned", env: BuildPinnedBDEnv(base, beadsDir)},
+		{name: "routing", env: BuildRoutingBDEnv(base, beadsDir)},
+		{name: "read-only pinned", env: BuildReadOnlyPinnedBDEnv(base, beadsDir)},
+		{name: "read-only routing", env: BuildReadOnlyRoutingBDEnv(base, beadsDir)},
+		{name: "mutation pinned", env: BuildMutationPinnedBDEnv(base, beadsDir)},
+		{name: "mutation routing", env: BuildMutationRoutingBDEnv(base, beadsDir)},
+		{name: "mutation neutral", env: BuildMutationNeutralBDEnv(base)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := envMap(tc.env)
+			if got["BD_ROUTING_MODE"] != "explicit" {
+				t.Fatalf("BD_ROUTING_MODE = %q, want explicit in %v", got["BD_ROUTING_MODE"], tc.env)
+			}
+			if got["BD_ROUTING_DEFAULT"] != "." {
+				t.Fatalf("BD_ROUTING_DEFAULT = %q, want \".\" in %v", got["BD_ROUTING_DEFAULT"], tc.env)
+			}
+			// glibc getenv() returns the first match, so an inherited value
+			// left in place would win over the appended one.
+			for _, key := range []string{"BD_ROUTING_MODE=", "BD_ROUTING_DEFAULT="} {
+				if count := countEnvPrefix(tc.env, key); count != 1 {
+					t.Fatalf("%s count = %d, want 1 in %v", key, count, tc.env)
+				}
+			}
+			for _, key := range []string{"BEADS_ROUTING_MODE", "BEADS_ROUTING_DEFAULT"} {
+				if value, ok := got[key]; ok {
+					t.Fatalf("%s should be stripped, got %q in %v", key, value, tc.env)
+				}
+			}
+		})
+	}
+}
+
+// TestPinnedBDEnvKeepsTheDatabaseSelectorBdActuallyReads guards the fix
+// candidate recorded on hq-z871 against being adopted unmeasured.
+//
+// The bead proposed either dropping BEADS_DOLT_SERVER_DATABASE or emitting
+// BEADS_DOLT_DATABASE in its place. Neither is right: bd 1.2.2 reads
+// BEADS_DOLT_SERVER_DATABASE (configfile.Config.GetDoltDatabase,
+// dolt.applyConfigDefaults, cmd/bd routing) and reads BEADS_DOLT_DATABASE
+// nowhere, so the swap is a silent no-op that would leave the pinned
+// subprocess with no database selector at all. Re-measured directly against
+// the town's Dolt server: with the exact env BuildReadOnlyPinnedBDEnv
+// produces, `bd show` on a bead that exists behaves identically with and
+// without the variable, so the variable is not what broke gastown dispatch.
+func TestPinnedBDEnvKeepsTheDatabaseSelectorBdActuallyReads(t *testing.T) {
+	beadsDir := writeRoutingTestBeadsDir(t, "rigdb")
+	env := BuildPinnedBDEnv([]string{"PATH=/usr/bin"}, beadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if value, ok := got["BEADS_DOLT_DATABASE"]; ok {
+		t.Fatalf("BEADS_DOLT_DATABASE is not read by bd; emitting it (=%q) selects no database at all: %v", value, env)
+	}
+
+	// Routing mode still relies on bd prefix routing to pick the database, so
+	// it must not carry one — pinning routing off must not have changed that.
+	routing := envMap(BuildRoutingBDEnv([]string{"PATH=/usr/bin"}, beadsDir))
+	if value, ok := routing["BEADS_DOLT_SERVER_DATABASE"]; ok {
+		t.Fatalf("routing env must not pin a database, got %q", value)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1884,6 +1884,13 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 			d.logger.Printf("Skipping refinery auto-start for %s: %v", rigName, err)
 			return
 		}
+		if errors.Is(err, refinery.ErrForkRigUndetermined) {
+			// Fail closed (gt-9gv): an unreadable rig config must not be
+			// treated as "not a fork rig". Auto-start stays blocked until the
+			// config is restored or an operator starts with --force.
+			d.logger.Printf("BLOCKED refinery auto-start for %s: %v", rigName, err)
+			return
+		}
 		d.logger.Printf("Error starting refinery for %s: %v", rigName, err)
 		return
 	}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -33,6 +33,12 @@ var (
 	ErrAlreadyRunning = errors.New("refinery already running")
 	ErrNoQueue        = errors.New("no items in queue")
 	ErrForkRig        = errors.New("refinery disabled for fork-backed rig")
+
+	// ErrForkRigUndetermined reports that the fork-backed-rig guard could not
+	// be evaluated because the rig config could not be read. The guard fails
+	// closed: an unreadable or missing config.json must never be interpreted
+	// as "not a fork-backed rig" (gt-9gv; incident gt-kx4).
+	ErrForkRigUndetermined = errors.New("refinery blocked: cannot determine fork-backed rig status")
 )
 
 // ForkRigError reports that refinery startup is disabled because the rig has
@@ -59,6 +65,44 @@ func (e *ForkRigError) Unwrap() error {
 // NewForkRigError returns a typed startup-blocking fork-rig error.
 func NewForkRigError(rigName, upstreamURL string) error {
 	return &ForkRigError{RigName: rigName, UpstreamURL: upstreamURL}
+}
+
+// ForkRigConfigError reports that the rig config could not be read, so the
+// fork-backed-rig guard cannot be evaluated. Refinery startup is blocked
+// rather than allowed, because the alternative silently disarms the only
+// runtime policy protecting fork-backed rigs from local merges.
+type ForkRigConfigError struct {
+	RigName string
+	Err     error
+}
+
+func (e *ForkRigConfigError) Error() string {
+	if e == nil {
+		return ErrForkRigUndetermined.Error()
+	}
+	msg := fmt.Sprintf("%s for rig %s: rig config unreadable", ErrForkRigUndetermined, e.RigName)
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg + " (restore config.json, or use --force to start anyway)"
+}
+
+// Unwrap exposes both the sentinel and the underlying read/parse failure so
+// callers can match either with errors.Is.
+func (e *ForkRigConfigError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	if e.Err == nil {
+		return []error{ErrForkRigUndetermined}
+	}
+	return []error{ErrForkRigUndetermined, e.Err}
+}
+
+// NewForkRigConfigError returns a typed startup-blocking error for a rig whose
+// config could not be read.
+func NewForkRigConfigError(rigName string, err error) error {
+	return &ForkRigConfigError{RigName: rigName, Err: err}
 }
 
 // Manager handles refinery lifecycle and queue operations.
@@ -336,9 +380,21 @@ func (m *Manager) start(foreground bool, agentOverride string, allowForkRig bool
 
 // ForkRigStartError returns ErrForkRig when the rig config has upstream_url.
 // The derived config guard is the single runtime policy for fork-backed rigs.
+//
+// It fails closed (gt-9gv): if the rig config cannot be read at all — missing,
+// unreadable, or malformed config.json — the guard cannot tell a fork-backed
+// rig from a local one, so it blocks startup with ErrForkRigUndetermined
+// instead of silently passing. Only a config that was read successfully and
+// has an empty upstream_url is allowed through.
 func (m *Manager) ForkRigStartError() error {
 	cfg, err := rig.LoadRigConfig(m.rig.Path)
-	if err != nil || cfg == nil || strings.TrimSpace(cfg.UpstreamURL) == "" {
+	if err != nil {
+		return NewForkRigConfigError(m.rig.Name, err)
+	}
+	if cfg == nil {
+		return NewForkRigConfigError(m.rig.Name, errors.New("rig config loaded as nil"))
+	}
+	if strings.TrimSpace(cfg.UpstreamURL) == "" {
 		return nil
 	}
 	return NewForkRigError(m.rig.Name, cfg.UpstreamURL)
@@ -357,7 +413,11 @@ func (m *Manager) blockForkRigStart(t *tmux.Tmux) error {
 	}
 	sessionID := m.SessionName()
 	if running, _ := t.HasSession(sessionID); running {
-		_, _ = fmt.Fprintf(m.output, "Refinery %s is disabled for fork-backed rig; killing leftover session %s.\n", m.rig.Name, sessionID)
+		reason := "is disabled for fork-backed rig"
+		if errors.Is(err, ErrForkRigUndetermined) {
+			reason = "cannot be verified as non-fork (rig config unreadable)"
+		}
+		_, _ = fmt.Fprintf(m.output, "Refinery %s %s; killing leftover session %s.\n", m.rig.Name, reason, sessionID)
 		if killErr := t.KillSessionWithProcesses(sessionID); killErr != nil {
 			return fmt.Errorf("%w: killing leftover refinery session: %v", err, killErr)
 		}

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -134,6 +134,8 @@ func TestManager_StartSafetyStoppedDoesNotCreateSession(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
 		t.Fatalf("write town.json: %v", err)
 	}
+	// Local (non-fork) rig config: the fork guard fails closed without one.
+	writeRigConfig(t, filepath.Join(townRoot, "testrig"), `{}`)
 
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "commands.log")
@@ -170,6 +172,8 @@ func TestManager_StartSafetyStoppedKillsLeftoverSession(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
 		t.Fatalf("write town.json: %v", err)
 	}
+	// Local (non-fork) rig config: the fork guard fails closed without one.
+	writeRigConfig(t, filepath.Join(townRoot, "testrig"), `{}`)
 
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "commands.log")
@@ -257,6 +261,182 @@ func TestManager_StartAllowingForkRigStillHonorsSafetyStop(t *testing.T) {
 	err := mgr.StartAllowingForkRig(false, "")
 	if !errors.Is(err, ErrSafetyStopped) {
 		t.Fatalf("StartAllowingForkRig error = %v, want ErrSafetyStopped", err)
+	}
+}
+
+// --- Fork-rig guard: fail closed on config-read error (gt-9gv) ---------------
+//
+// Regression cover for incident gt-kx4: /gt/gastown/config.json went missing
+// and ForkRigStartError folded the read failure into the "not a fork rig"
+// branch, so the daemon auto-started the refinery on a fork-backed rig with no
+// --force. A config the guard cannot read must block startup, not pass it.
+
+func TestManager_ForkRigStartErrorFailsClosedOnMissingConfig(t *testing.T) {
+	setupTestRegistry(t)
+
+	rigPath := filepath.Join(t.TempDir(), "testrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	// No config.json written at all.
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath})
+	err := mgr.ForkRigStartError()
+	if err == nil {
+		t.Fatal("ForkRigStartError() = nil for missing config.json, want blocking error")
+	}
+	if !errors.Is(err, ErrForkRigUndetermined) {
+		t.Fatalf("ForkRigStartError() = %v, want ErrForkRigUndetermined", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ForkRigStartError() = %v, want wrapped os.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), "testrig") {
+		t.Fatalf("error does not name the rig: %v", err)
+	}
+}
+
+func TestManager_ForkRigStartErrorFailsClosedOnUnreadableConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based unreadable file does not apply on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 is still readable")
+	}
+	setupTestRegistry(t)
+
+	rigPath := filepath.Join(t.TempDir(), "testrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	configPath := filepath.Join(rigPath, "config.json")
+	writeRigConfig(t, rigPath, `{"upstream_url":"https://github.com/upstream/repo"}`)
+	if err := os.Chmod(configPath, 0o000); err != nil {
+		t.Fatalf("chmod config: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configPath, 0o644) })
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath})
+	err := mgr.ForkRigStartError()
+	if !errors.Is(err, ErrForkRigUndetermined) {
+		t.Fatalf("ForkRigStartError() = %v, want ErrForkRigUndetermined", err)
+	}
+}
+
+func TestManager_ForkRigStartErrorFailsClosedOnMalformedConfig(t *testing.T) {
+	setupTestRegistry(t)
+
+	rigPath := filepath.Join(t.TempDir(), "testrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	writeRigConfig(t, rigPath, `{"upstream_url": `)
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath})
+	if err := mgr.ForkRigStartError(); !errors.Is(err, ErrForkRigUndetermined) {
+		t.Fatalf("ForkRigStartError() = %v, want ErrForkRigUndetermined", err)
+	}
+}
+
+func TestManager_ForkRigStartErrorClassifiesReadableConfigs(t *testing.T) {
+	setupTestRegistry(t)
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr error // nil means startup allowed
+	}{
+		{name: "local rig", config: `{}`, wantErr: nil},
+		{name: "empty upstream", config: `{"upstream_url":""}`, wantErr: nil},
+		{name: "whitespace upstream", config: `{"upstream_url":"   "}`, wantErr: nil},
+		{name: "fork rig", config: `{"upstream_url":"https://github.com/upstream/repo"}`, wantErr: ErrForkRig},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rigPath := filepath.Join(t.TempDir(), "testrig")
+			if err := os.MkdirAll(rigPath, 0o755); err != nil {
+				t.Fatalf("mkdir rig: %v", err)
+			}
+			writeRigConfig(t, rigPath, tt.config)
+
+			err := NewManager(&rig.Rig{Name: "testrig", Path: rigPath}).ForkRigStartError()
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ForkRigStartError() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ForkRigStartError() = %v, want %v", err, tt.wantErr)
+			}
+			if errors.Is(err, ErrForkRigUndetermined) {
+				t.Fatalf("readable config reported as undetermined: %v", err)
+			}
+		})
+	}
+}
+
+func TestManager_StartMissingConfigDoesNotCreateSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock tmux script uses POSIX shell")
+	}
+	setupTestRegistry(t)
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	// config.json is missing, exactly as in incident gt-kx4.
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "commands.log")
+	writeSafetyStopMockTmux(t, binDir, logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath})
+	err := mgr.Start(false, "")
+	if !errors.Is(err, ErrForkRigUndetermined) {
+		t.Fatalf("Start error = %v, want ErrForkRigUndetermined", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	if strings.Contains(string(logData), "new-session") {
+		t.Fatalf("Start created a tmux session despite unreadable rig config; log:\n%s", logData)
+	}
+}
+
+func TestManager_StartAllowingForkRigBypassesUnreadableConfig(t *testing.T) {
+	setupTestRegistry(t)
+
+	// --force (StartAllowingForkRig) is the operator escape hatch: it must
+	// bypass the fork guard, including its fail-closed branch. Start fails
+	// later here (no town/tmux), which is enough to prove the guard did not
+	// short-circuit it.
+	rigPath := filepath.Join(t.TempDir(), "testrig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath})
+	err := mgr.StartAllowingForkRig(false, "")
+	if errors.Is(err, ErrForkRigUndetermined) {
+		t.Fatalf("StartAllowingForkRig blocked by fork guard: %v", err)
+	}
+}
+
+func TestForkRigConfigErrorMessage(t *testing.T) {
+	err := NewForkRigConfigError("testrig", os.ErrNotExist)
+	msg := err.Error()
+	for _, want := range []string{"testrig", "config", "--force"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message %q missing %q", msg, want)
+		}
+	}
+	if errors.Is(err, ErrForkRig) {
+		t.Fatal("config-read failure must not be reported as a confirmed fork rig")
 	}
 }
 


### PR DESCRIPTION
## Problem

`Manager.ForkRigStartError` folded a rig-config **read failure** into the not-a-fork-rig branch:

```go
cfg, err := rig.LoadRigConfig(m.rig.Path)
if err != nil || cfg == nil || strings.TrimSpace(cfg.UpstreamURL) == "" {
    return nil
}
```

A missing, unreadable, or malformed `config.json` therefore read as *"local rig, refinery allowed"* — silently disarming the single runtime policy that keeps fork-backed rigs off the local merge queue. On 2026-09-01 `/gt/gastown/config.json` went missing and the daemon auto-started the gastown refinery with no `--force` (incident gt-kx4).

## Fix

The guard now **fails closed**. A config that cannot be read blocks startup with a new `ErrForkRigUndetermined` sentinel, carried by a typed `*ForkRigConfigError` whose `Unwrap() []error` exposes both the sentinel and the underlying read/parse error (so `errors.Is(err, os.ErrNotExist)` matches too). It deliberately does **not** unwrap to `ErrForkRig`: a config we could not read is not a confirmed fork rig and must not be reported as one. Only a config that was read successfully and has an empty `upstream_url` is allowed through.

- `blockForkRigStart` still kills any leftover refinery session, with an accurate message for the undetermined case.
- `daemon.ensureRefineryRunning` logs a distinct `BLOCKED refinery auto-start` line for this case — the exact gt-kx4 auto-start path. The other call sites (`cmd/start.go`, `cmd/up.go`, `cmd/rig.go`, `cmd/refinery.go`) already surface unknown errors loudly and refuse to start.
- The operator escape hatch is unchanged: `--force` / `StartAllowingForkRig` bypasses the guard, including its fail-closed branch.

## Blast radius

A rig with no `config.json` can no longer auto-start a refinery. `gt rig add` always writes `config.json`, so this is an anomaly-only path — and blocking it is the point of the fix. Two pre-existing safety-stop tests built rig dirs without a `config.json`; they now write `{}` explicitly, since their subject is safety-stop behavior, not fork detection.

## Tests

New in `internal/refinery/manager_test.go`: missing config, unreadable config (chmod 000; skipped as root and on windows), malformed JSON, a table over readable configs (local / empty / whitespace / fork), `Start()` with a missing config creating no tmux session, `--force` bypass, and error-message content.

- `go build ./...` — clean
- `go vet ./internal/refinery/ ./internal/daemon/` — clean
- `go test ./internal/refinery/` — ok (385s; the host was heavily loaded)

Closes gt-9gv. Related: gt-kx4 (incident + RCA).