### PR TITLE
fix(polecat): list pinned polecats at capacity on a blocker it never checked (gt-3up)

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -446,6 +446,29 @@ func polecatReuseStatus(state polecat.State, cleanupStatus, activeMR, branch str
 }
 
 // getPolecatManager creates a polecat manager for the given rig.
+// dispositionBlockedOnlyByMissingCleanup reports whether the sole reason a
+// polecat is being held is that its agent bead carries no cleanup_status.
+//
+// This is the narrow gt-3up case. It must stay narrow: if anything else is also
+// blocking (a hook bead, a failed push, active work, a dirty worktree) the cheap
+// disposition is already correct and there is nothing to reconcile. Only when
+// "cleanup is unknown" is the WHOLE story is the bead-only view unable to answer,
+// and only then is it worth paying for the git check.
+func dispositionBlockedOnlyByMissingCleanup(d polecat.WorkstateDisposition) bool {
+	if d.Verdict != polecat.WorkstateVerdictNeedsRecovery {
+		return false
+	}
+	if d.Reason != "cleanup-unknown" {
+		return false
+	}
+	// Exactly one blocker, and it is the cleanup one. More than one means other
+	// evidence is in play and the cheap verdict stands.
+	if len(d.Blockers) != 1 {
+		return false
+	}
+	return strings.HasPrefix(d.Blockers[0], "cleanup_status=")
+}
+
 func getPolecatManager(rigName string) (*polecat.Manager, *rig.Rig, error) {
 	_, r, err := getRig(rigName)
 	if err != nil {
@@ -519,6 +542,24 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 				item = buildPolecatInventoryItemFromEvidence(r.Name, name, fields, polecatActiveWorkLookupError(activeWorkErr), sessions)
 			}
 			disposition := item.Disposition
+			// gt-3up: the inventory path above is deliberately cheap — it reads
+			// agent beads and never touches git. That is fine until the ONLY
+			// thing blocking a polecat is that its cleanup metadata is missing,
+			// because then this view asserts NEEDS_RECOVERY, safe_to_nuke=false
+			// and counts_toward_capacity=true from evidence it never gathered.
+			// check-recovery, which does inspect the worktree, calls the same
+			// polecats clean and SAFE_TO_NUKE. The two disagreed indefinitely and
+			// the pool stayed pinned at capacity on a blocker that did not exist.
+			//
+			// Escalate to the authoritative disposition for exactly that case.
+			// It is rare (legacy polecats and ones whose agent bead lost the
+			// field), so the extra git I/O is bounded, and every other polecat
+			// keeps the cheap path.
+			if dispositionBlockedOnlyByMissingCleanup(disposition) {
+				if mgr, _, mgrErr := getPolecatManager(r.Name); mgrErr == nil && mgr != nil {
+					disposition = mgr.WorkstateDispositionForPolecat(name, item.State, item.Issue)
+				}
+			}
 			state := effectivePolecatState(PolecatListItem{
 				State:                item.State,
 				Issue:                item.Issue,

--- a/internal/cmd/polecat_cleanup_escalation_test.go
+++ b/internal/cmd/polecat_cleanup_escalation_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/polecat"
+)
+
+// gt-3up: `gt polecat list` and `gt polecat check-recovery` returned opposite
+// verdicts for the same polecat, seconds apart. list reads agent beads only and
+// never touches git, so a polecat whose bead lost its cleanup_status was pinned
+// at NEEDS_RECOVERY / safe_to_nuke=false / counts_toward_capacity=true — on a
+// blocker that check-recovery, which does inspect the worktree, proved did not
+// exist. The pool stayed at capacity indefinitely.
+//
+// The list path now escalates to the authoritative disposition for exactly that
+// case. These pin the predicate that decides when to escalate: it must fire on
+// the missing-cleanup case and must NOT fire when other evidence is in play,
+// because then the cheap verdict is already correct and the git I/O is waste.
+func TestDispositionBlockedOnlyByMissingCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   polecat.WorkstateDisposition
+		want bool
+	}{
+		{
+			name: "the gt-3up case: cleanup is the whole story",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=<missing>"},
+			},
+			want: true,
+		},
+		{
+			name: "same, with the enum spelling rather than <missing>",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=unknown"},
+			},
+			want: true,
+		},
+		{
+			name: "a hook bead is also blocking — cheap verdict already correct",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=<missing>", "has work on hook (gt-abc)"},
+			},
+			want: false,
+		},
+		{
+			name: "real dirty worktree must never be escalated away",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-has_uncommitted",
+				Blockers: []string{"cleanup_status=has_uncommitted"},
+			},
+			want: false,
+		},
+		{
+			name: "a stash is work at risk, not missing metadata",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-has_stash",
+				Blockers: []string{"cleanup_status=has_stash"},
+			},
+			want: false,
+		},
+		{
+			name: "already safe to nuke — nothing to reconcile",
+			in: polecat.WorkstateDisposition{
+				Verdict: polecat.WorkstateVerdictSafeToNuke,
+			},
+			want: false,
+		},
+		{
+			name: "no blockers recorded at all",
+			in: polecat.WorkstateDisposition{
+				Verdict: polecat.WorkstateVerdictNeedsRecovery,
+				Reason:  "cleanup-unknown",
+			},
+			want: false,
+		},
+		{
+			name: "a differently-named single blocker is not ours",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"push_failed=true"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dispositionBlockedOnlyByMissingCleanup(tc.in); got != tc.want {
+				t.Fatalf("dispositionBlockedOnlyByMissingCleanup() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`gt polecat list` and `gt polecat check-recovery` return **opposite verdicts for the same polecat**, run seconds apart. Deacon observed it across two patrol cycles; the pool sat at capacity the whole time.

## Root cause

The two commands build their `WorkstateInput` from different evidence.

**`buildPolecatInventoryItemFromEvidence`** (the `list` path) reads agent beads and **never touches git**. When a bead carries no `cleanup_status`, the input keeps the Go zero value, `DecideWorkstate` takes the `""` branch, and the polecat is reported `NEEDS_RECOVERY` / `safe_to_nuke=false` / `counts_toward_capacity=true`, with the single blocker `cleanup_status=<missing>`.

**`workstateInputForPolecat`** (the `check-recovery` path) inspects the actual worktree — `CheckUncommittedWork`, `BranchPreservationStatus` — and reconciles missing metadata against it: if git proves nothing is at risk, the unknown status becomes `CleanupClean`. Same polecat, same second: *clean, SAFE_TO_NUKE*.

So `list` asserts a **blocking verdict from evidence it never gathered** — and `list` is the view that feeds capacity accounting. Polecats the authoritative check calls safe are held indefinitely on a blocker that does not exist.

This is also the likely mechanism behind the Witness declining to clean them up: reading `list`, it sees `safe_to_nuke=false` and correctly refuses to act.

## The fix

`list` escalates to the authoritative disposition **for exactly the case it cannot answer** — where missing cleanup metadata is the whole story.

The predicate stays deliberately narrow. Any second blocker (a hook bead, a push failure, active work, a genuinely dirty worktree) means the cheap verdict is already correct and nothing is reconciled. Every other polecat keeps the bead-only path, so the extra git I/O is bounded to the rare case (legacy polecats, and ones whose agent bead lost the field).

## Verified against a live pool — same rig, same moment

| | chrome | guzzle | nitro | rust |
|---|---|---|---|---|
| **before** | NEEDS_RECOVERY | NEEDS_RECOVERY | NEEDS_RECOVERY | NEEDS_RECOVERY |
| **after** | SAFE_TO_NUKE | SAFE_TO_NUKE | **NEEDS_MQ_SUBMIT** | SAFE_TO_NUKE |
| `check-recovery` | SAFE_TO_NUKE | SAFE_TO_NUKE | NEEDS_MQ_SUBMIT | SAFE_TO_NUKE |

Before, all four carried `cap=true` and the blocker `cleanup_status=<missing>`. After, the patched `list` agrees with `check-recovery` on **all four**.

**`nitro` is the important column**: it is genuinely blocked on unsubmitted work, and the fix keeps holding it. This reconciles `list` with the authority rather than clearing the pool.

## Tests

New table test pins the predicate — it must fire on the missing-cleanup case and must **not** fire when a stash, uncommitted work, a hook bead, or any second blocker is present.

The `internal/cmd` suite shows the same 8 pre-existing failures before and after (they need a live beads environment); zero new.