### PR TITLE
fix(scheduler): reconcile capacity dispositions so dispatch stops refusing a free pool (gt-b3a2)

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -445,7 +445,6 @@ func polecatReuseStatus(state polecat.State, cleanupStatus, activeMR, branch str
 	return polecat.DecideWorkstate(input).ReuseStatus
 }
 
-// getPolecatManager creates a polecat manager for the given rig.
 // dispositionBlockedOnlyByMissingCleanup reports whether the sole reason a
 // polecat is being held is that its agent bead carries no cleanup_status.
 //
@@ -469,6 +468,41 @@ func dispositionBlockedOnlyByMissingCleanup(d polecat.WorkstateDisposition) bool
 	return strings.HasPrefix(d.Blockers[0], "cleanup_status=")
 }
 
+// reconcilePolecatDisposition returns the disposition a caller should ACT on,
+// as opposed to the cheap one the bead-only inventory path can produce.
+//
+// Every caller that gates behaviour on a disposition must go through here.
+// gt-b3a2 exists because that was not true: #4798 taught `gt polecat list` to
+// escalate the missing-cleanup case inline, and the scheduler's capacity path —
+// which builds its disposition from the very same buildPolecatInventoryItem —
+// was left on the raw value. For four hours the two answered the same question
+// differently in the same second: list reported counts_toward_capacity=false for
+// every polecat in the pool while the scheduler counted all of them as
+// recovery-blocked and refused to dispatch a single ready bead.
+//
+// Keeping the escalation in one function is the actual fix. Duplicating it at
+// each call site would restore the identical drift the moment a third caller
+// appears.
+func reconcilePolecatDisposition(rigName, polecatName string, item polecatInventoryItem) polecat.WorkstateDisposition {
+	d := item.Disposition
+	if !dispositionBlockedOnlyByMissingCleanup(d) {
+		return d
+	}
+	// The bead cannot answer this one, so ask the worktree. A failure here is
+	// not fatal: fall back to the cheap disposition, which errs toward holding
+	// the polecat rather than freeing one that may have work at risk.
+	mgr, _, err := getPolecatManager(rigName)
+	if err != nil || mgr == nil {
+		return d
+	}
+	return mgr.WorkstateDispositionForPolecat(polecatName, item.State, item.Issue)
+}
+
+// Indirected so tests can assert that every gating caller routes through the
+// single reconciler rather than reading item.Disposition directly (gt-b3a2).
+var reconcilePolecatDispositionFn = reconcilePolecatDisposition
+
+// getPolecatManager creates a polecat manager for the given rig.
 func getPolecatManager(rigName string) (*polecat.Manager, *rig.Rig, error) {
 	_, r, err := getRig(rigName)
 	if err != nil {
@@ -541,25 +575,15 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 			if activeWorkErr != nil {
 				item = buildPolecatInventoryItemFromEvidence(r.Name, name, fields, polecatActiveWorkLookupError(activeWorkErr), sessions)
 			}
-			disposition := item.Disposition
 			// gt-3up: the inventory path above is deliberately cheap — it reads
 			// agent beads and never touches git. That is fine until the ONLY
 			// thing blocking a polecat is that its cleanup metadata is missing,
 			// because then this view asserts NEEDS_RECOVERY, safe_to_nuke=false
 			// and counts_toward_capacity=true from evidence it never gathered.
-			// check-recovery, which does inspect the worktree, calls the same
-			// polecats clean and SAFE_TO_NUKE. The two disagreed indefinitely and
-			// the pool stayed pinned at capacity on a blocker that did not exist.
-			//
-			// Escalate to the authoritative disposition for exactly that case.
-			// It is rare (legacy polecats and ones whose agent bead lost the
-			// field), so the extra git I/O is bounded, and every other polecat
-			// keeps the cheap path.
-			if dispositionBlockedOnlyByMissingCleanup(disposition) {
-				if mgr, _, mgrErr := getPolecatManager(r.Name); mgrErr == nil && mgr != nil {
-					disposition = mgr.WorkstateDispositionForPolecat(name, item.State, item.Issue)
-				}
-			}
+			// reconcilePolecatDisposition escalates exactly that case, and is
+			// shared with the scheduler capacity path so the two cannot drift
+			// apart again (gt-b3a2).
+			disposition := reconcilePolecatDispositionFn(r.Name, name, item)
 			state := effectivePolecatState(PolecatListItem{
 				State:                item.State,
 				Issue:                item.Issue,

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -446,6 +446,29 @@ func polecatReuseStatus(state polecat.State, cleanupStatus, activeMR, branch str
 }
 
 // getPolecatManager creates a polecat manager for the given rig.
+// dispositionBlockedOnlyByMissingCleanup reports whether the sole reason a
+// polecat is being held is that its agent bead carries no cleanup_status.
+//
+// This is the narrow gt-3up case. It must stay narrow: if anything else is also
+// blocking (a hook bead, a failed push, active work, a dirty worktree) the cheap
+// disposition is already correct and there is nothing to reconcile. Only when
+// "cleanup is unknown" is the WHOLE story is the bead-only view unable to answer,
+// and only then is it worth paying for the git check.
+func dispositionBlockedOnlyByMissingCleanup(d polecat.WorkstateDisposition) bool {
+	if d.Verdict != polecat.WorkstateVerdictNeedsRecovery {
+		return false
+	}
+	if d.Reason != "cleanup-unknown" {
+		return false
+	}
+	// Exactly one blocker, and it is the cleanup one. More than one means other
+	// evidence is in play and the cheap verdict stands.
+	if len(d.Blockers) != 1 {
+		return false
+	}
+	return strings.HasPrefix(d.Blockers[0], "cleanup_status=")
+}
+
 func getPolecatManager(rigName string) (*polecat.Manager, *rig.Rig, error) {
 	_, r, err := getRig(rigName)
 	if err != nil {
@@ -519,6 +542,24 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 				item = buildPolecatInventoryItemFromEvidence(r.Name, name, fields, polecatActiveWorkLookupError(activeWorkErr), sessions)
 			}
 			disposition := item.Disposition
+			// gt-3up: the inventory path above is deliberately cheap — it reads
+			// agent beads and never touches git. That is fine until the ONLY
+			// thing blocking a polecat is that its cleanup metadata is missing,
+			// because then this view asserts NEEDS_RECOVERY, safe_to_nuke=false
+			// and counts_toward_capacity=true from evidence it never gathered.
+			// check-recovery, which does inspect the worktree, calls the same
+			// polecats clean and SAFE_TO_NUKE. The two disagreed indefinitely and
+			// the pool stayed pinned at capacity on a blocker that did not exist.
+			//
+			// Escalate to the authoritative disposition for exactly that case.
+			// It is rare (legacy polecats and ones whose agent bead lost the
+			// field), so the extra git I/O is bounded, and every other polecat
+			// keeps the cheap path.
+			if dispositionBlockedOnlyByMissingCleanup(disposition) {
+				if mgr, _, mgrErr := getPolecatManager(r.Name); mgrErr == nil && mgr != nil {
+					disposition = mgr.WorkstateDispositionForPolecat(name, item.State, item.Issue)
+				}
+			}
 			state := effectivePolecatState(PolecatListItem{
 				State:                item.State,
 				Issue:                item.Issue,

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -264,7 +264,10 @@ func listPolecatDirectoryNames(rigPath string) ([]string, error) {
 
 func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigName, polecatName string, fields *beads.AgentFields, activeWork *beads.Issue, sessions polecatSessionSet) {
 	item := buildPolecatInventoryItem(rigName, polecatName, fields, activeWork, sessions)
-	applyWorkstateDispositionToCapacitySnapshot(snapshot, item.State, item.Disposition)
+	// gt-b3a2: this is a GATE, not a display. It must consult the same
+	// reconciled disposition `gt polecat list` shows, or the scheduler refuses
+	// to dispatch against polecats the rest of the CLI reports as free.
+	applyWorkstateDispositionToCapacitySnapshot(snapshot, item.State, reconcilePolecatDispositionFn(rigName, polecatName, item))
 }
 
 func applyWorkstateDispositionToCapacitySnapshot(snapshot *polecatCapacitySnapshot, state polecat.State, disposition polecat.WorkstateDisposition) {

--- a/internal/cmd/polecat_cleanup_escalation_test.go
+++ b/internal/cmd/polecat_cleanup_escalation_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/polecat"
+)
+
+// gt-3up: `gt polecat list` and `gt polecat check-recovery` returned opposite
+// verdicts for the same polecat, seconds apart. list reads agent beads only and
+// never touches git, so a polecat whose bead lost its cleanup_status was pinned
+// at NEEDS_RECOVERY / safe_to_nuke=false / counts_toward_capacity=true — on a
+// blocker that check-recovery, which does inspect the worktree, proved did not
+// exist. The pool stayed at capacity indefinitely.
+//
+// The list path now escalates to the authoritative disposition for exactly that
+// case. These pin the predicate that decides when to escalate: it must fire on
+// the missing-cleanup case and must NOT fire when other evidence is in play,
+// because then the cheap verdict is already correct and the git I/O is waste.
+func TestDispositionBlockedOnlyByMissingCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   polecat.WorkstateDisposition
+		want bool
+	}{
+		{
+			name: "the gt-3up case: cleanup is the whole story",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=<missing>"},
+			},
+			want: true,
+		},
+		{
+			name: "same, with the enum spelling rather than <missing>",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=unknown"},
+			},
+			want: true,
+		},
+		{
+			name: "a hook bead is also blocking — cheap verdict already correct",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"cleanup_status=<missing>", "has work on hook (gt-abc)"},
+			},
+			want: false,
+		},
+		{
+			name: "real dirty worktree must never be escalated away",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-has_uncommitted",
+				Blockers: []string{"cleanup_status=has_uncommitted"},
+			},
+			want: false,
+		},
+		{
+			name: "a stash is work at risk, not missing metadata",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-has_stash",
+				Blockers: []string{"cleanup_status=has_stash"},
+			},
+			want: false,
+		},
+		{
+			name: "already safe to nuke — nothing to reconcile",
+			in: polecat.WorkstateDisposition{
+				Verdict: polecat.WorkstateVerdictSafeToNuke,
+			},
+			want: false,
+		},
+		{
+			name: "no blockers recorded at all",
+			in: polecat.WorkstateDisposition{
+				Verdict: polecat.WorkstateVerdictNeedsRecovery,
+				Reason:  "cleanup-unknown",
+			},
+			want: false,
+		},
+		{
+			name: "a differently-named single blocker is not ours",
+			in: polecat.WorkstateDisposition{
+				Verdict:  polecat.WorkstateVerdictNeedsRecovery,
+				Reason:   "cleanup-unknown",
+				Blockers: []string{"push_failed=true"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dispositionBlockedOnlyByMissingCleanup(tc.in); got != tc.want {
+				t.Fatalf("dispositionBlockedOnlyByMissingCleanup() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/polecat_cleanup_escalation_test.go
+++ b/internal/cmd/polecat_cleanup_escalation_test.go
@@ -102,3 +102,89 @@ func TestDispositionBlockedOnlyByMissingCleanup(t *testing.T) {
 		})
 	}
 }
+
+// gt-b3a2: #4798 fixed the missing-cleanup escalation in `gt polecat list` and
+// left the scheduler's capacity path reading the raw, unreconciled disposition.
+// Both build their disposition from the SAME buildPolecatInventoryItem, so for
+// four hours the two answered the same question differently in the same second:
+// list reported counts_toward_capacity=false for every polecat in the pool while
+// the scheduler counted all of them recovery-blocked and dispatched nothing.
+//
+// The invariant that was violated is not "capacity computes X". It is that every
+// caller which GATES on a disposition reconciles it first. This pins that: stub
+// the reconciler, and prove the capacity path consults it rather than reading
+// item.Disposition directly. It fails if anyone reverts that call site.
+func TestCapacitySnapshotUsesReconciledDisposition(t *testing.T) {
+	orig := reconcilePolecatDispositionFn
+	t.Cleanup(func() { reconcilePolecatDispositionFn = orig })
+
+	var sawRig, sawName string
+	calls := 0
+	// The reconciler stands in for the authoritative check: the bead-only view
+	// said "recovery, counts toward capacity"; the worktree says it is reusable.
+	reconcilePolecatDispositionFn = func(rigName, polecatName string, item polecatInventoryItem) polecat.WorkstateDisposition {
+		calls++
+		sawRig, sawName = rigName, polecatName
+		return polecat.WorkstateDisposition{
+			Verdict:              polecat.WorkstateVerdictSafeToNuke,
+			Reason:               "reusable",
+			Reusable:             true,
+			SafeToNuke:           true,
+			CountsTowardCapacity: false,
+			ReuseStatus:          "idle-preserved",
+		}
+	}
+
+	snapshot := polecatCapacitySnapshot{Max: 4}
+	applyAgentFieldsToCapacitySnapshot(&snapshot, "liveop", "chrome", nil, nil, nil)
+
+	if calls != 1 {
+		t.Fatalf("capacity path called the reconciler %d times, want exactly 1 — it is reading item.Disposition directly (gt-b3a2)", calls)
+	}
+	if sawRig != "liveop" || sawName != "chrome" {
+		t.Fatalf("reconciler got (%q, %q), want (\"liveop\", \"chrome\")", sawRig, sawName)
+	}
+	if snapshot.RecoveryBlocked != 0 {
+		t.Fatalf("snapshot = %+v, want recovery_blocked=0: a reusable polecat must not be counted as recovery-blocked", snapshot)
+	}
+	if snapshot.ReusableIdle != 1 {
+		t.Fatalf("snapshot = %+v, want reusable_idle=1", snapshot)
+	}
+	if snapshot.occupied() != 0 {
+		t.Fatalf("snapshot occupied=%d, want 0: a reusable polecat must not consume capacity", snapshot.occupied())
+	}
+}
+
+// The reconciler must be a no-op for every disposition that is NOT the narrow
+// missing-cleanup case. If it were not, it would pay for git I/O on every
+// polecat in the town on every capacity check — and, worse, could override a
+// verdict that was already correct.
+func TestReconcilePolecatDispositionPassesThroughWhenNotTheGt3upCase(t *testing.T) {
+	for _, d := range []polecat.WorkstateDisposition{
+		{
+			Verdict:              polecat.WorkstateVerdictNeedsRecovery,
+			Reason:               "cleanup-has_uncommitted",
+			Blockers:             []string{"cleanup_status=has_uncommitted"},
+			NeedsRecovery:        true,
+			CountsTowardCapacity: true,
+		},
+		{
+			Verdict:              polecat.WorkstateVerdictNeedsRecovery,
+			Reason:               "cleanup-unknown",
+			Blockers:             []string{"cleanup_status=<missing>", "has work on hook (gt-abc)"},
+			NeedsRecovery:        true,
+			CountsTowardCapacity: true,
+		},
+		{
+			Verdict:    polecat.WorkstateVerdictSafeToNuke,
+			Reason:     "reusable",
+			Reusable:   true,
+			SafeToNuke: true,
+		},
+	} {
+		got := reconcilePolecatDisposition("liveop", "chrome", polecatInventoryItem{Disposition: d})
+		if got.Verdict != d.Verdict || got.Reason != d.Reason || got.CountsTowardCapacity != d.CountsTowardCapacity {
+			t.Fatalf("reconcile(%+v) = %+v, want it returned unchanged", d, got)
+		}
+	}
+}


### PR DESCRIPTION
**Stacked on #4798** — it branches from that PR's head, so until #4798 merges this diff shows both commits. Mine is the second one (`fix(scheduler): reconcile capacity dispositions...`). Merge #4798 first.

## The outage

Dispatch was dead for 4h27m — four ready beads, four idle polecats, and `gt scheduler run` answering `No capacity: 0 free of 4 (recovery_blocked: 4)` every time.

## Root cause: a fix that landed in one of two callers

#4798 established that the bead-only inventory path asserts `NEEDS_RECOVERY` / `counts_toward_capacity=true` for a polecat whose agent bead merely lost its `cleanup_status` — a blocker `check-recovery` proves does not exist. It fixed that by escalating to the authoritative disposition **inside `runPolecatList`**.

The scheduler's capacity path builds its disposition from the very same `buildPolecatInventoryItem` and was left reading `item.Disposition` raw. So the two answered the same question differently, in the same second, from the same binary:

```
gt polecat list liveop --json    all four: reusable=true, counts_toward_capacity=false
gt scheduler status              recovery 4, reusable_idle 0, free 0 of 4
```

Everything a human or an agent could inspect said the pool was free. The one path that gates dispatch said it was full — and it was the only one nobody was reading.

## The fix

Extract the escalation into `reconcilePolecatDisposition` and route **both** callers through it.

The point is not that capacity now computes the right number. It is that there is **one** reconciler, so a display path and a gate path cannot drift apart again. Duplicating the block at the second call site would have restored the identical bug the moment a third caller appeared.

Behaviour is unchanged for every polecat that is not the narrow gt-3up case: the predicate still requires `NEEDS_RECOVERY` with `cleanup-unknown` as the *sole* blocker, so a dirty worktree, a stash, a hook bead or unsubmitted MQ work all keep the cheap verdict and stay blocked. The escalation's git I/O stays bounded to the rare case, and a manager error falls back to the cheap disposition — erring toward holding a polecat rather than freeing one whose work may be at risk.

## Verified against the live pool

Same rig, same minute, both binaries:

| binary | result |
|---|---|
| installed (1121e38) | `No capacity: 0 free of 4 (recovery_blocked: 4), 4 ready bead(s) waiting` |
| patched | `Would dispatch 1 bead(s) (capacity: 4 free of 4, recovery_blocked: 0, reusable_idle: 4)` → `liveop-l4a.4 → liveop` |

**On nitro**, which #4798 deliberately kept blocked: all four liveop polecats are genuinely reusable *at this moment*, nitro included — `check-recovery` reports it clean, MQ submitted, 0 unpushed, after its work landed earlier today. It was legitimately blocked when gt-b3a2 was filed; this fix does not free it, its own state changed. `TestReconcilePolecatDispositionPassesThroughWhenNotTheGt3upCase` pins that a polecat in nitro's former condition is still held.

## Tests

`TestCapacitySnapshotUsesReconciledDisposition` stubs the reconciler and asserts the capacity path consults it. I verified it actually catches the regression by reverting the one-line call site — it fails with `called the reconciler 0 times, want exactly 1`.

`internal/cmd` suite: the same 8 pre-existing failures before and after (they need a live beads environment); zero new. Failure sets diffed, not counted.

## Not done here

The patched binary is **not installed**. Swapping the town's `gt` affects every agent, so that is a deliberate call for Marc or the Mayor, not a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hdQ5AMFZ3QnsvZwYp3p5n