### PR TITLE
Unify agent address handling behind one canonical type (gt-cw1)

### DIFF
--- a/internal/agentaddr/address.go
+++ b/internal/agentaddr/address.go
@@ -1,0 +1,263 @@
+// Package agentaddr provides the canonical representation of a Gas Town agent
+// address, together with a single parse and a single format.
+//
+// Gas Town writes an agent's address as a bare string in bead assignees, hook
+// records, mail identities and lock names. Historically each command built that
+// string its own way, so the same agent was stored under several spellings —
+// "deacon" from `gt patrol`, "deacon/" from `gt sling` — and exact-match
+// lookups missed rows that plainly existed. That mismatch stranded patrol wisps
+// and produced the wisp backlog described in gt-cw1.
+//
+// There is exactly one correct string form for an address, and it is produced
+// by Address.String. Callers that write an assignee should write Canonical(s);
+// callers that read one should query Variants(s) so that rows written by older
+// builds are still found.
+package agentaddr
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Role identifies the kind of agent an address points at.
+type Role string
+
+const (
+	RoleMayor    Role = "mayor"
+	RoleDeacon   Role = "deacon"
+	RoleOverseer Role = "overseer"
+	RoleWitness  Role = "witness"
+	RoleRefinery Role = "refinery"
+	RoleCrew     Role = "crew"
+	RolePolecat  Role = "polecats"
+	RoleDog      Role = "dogs"
+)
+
+// bootName is the deacon variant that runs the boot watchdog.
+const bootName = "boot"
+
+// Address is the canonical, parsed form of a Gas Town agent address.
+//
+// Any of the fields may be empty:
+//   - Rig is empty for town-level agents (mayor, deacon, boot, dogs, overseer).
+//   - Name is empty for singleton roles (mayor, deacon, witness, refinery) and
+//     for the bare dog-pool address "deacon/dogs".
+type Address struct {
+	Rig  string // rig name; empty means town level
+	Role Role   // agent role
+	Name string // worker name within the role; empty for singletons
+}
+
+// IsTownLevel reports whether the address names a town-level agent, i.e. one
+// that is not scoped to a rig.
+func (a Address) IsTownLevel() bool {
+	return a.Rig == ""
+}
+
+// IsZero reports whether the address is empty.
+func (a Address) IsZero() bool {
+	return a.Rig == "" && a.Role == "" && a.Name == ""
+}
+
+// String returns the canonical string form of the address.
+//
+//	mayor            → "mayor/"
+//	deacon           → "deacon/"
+//	boot             → "deacon/boot"
+//	dog pool         → "deacon/dogs"
+//	dog alpha        → "deacon/dogs/alpha"
+//	overseer         → "overseer"
+//	witness          → "gastown/witness"
+//	refinery         → "gastown/refinery"
+//	crew max         → "gastown/crew/max"
+//	polecat quartz   → "gastown/polecats/quartz"
+//
+// Town-level singletons keep the trailing slash: that is the form `gt sling`
+// has always written and the form `gt mail` resolves against.
+func (a Address) String() string {
+	switch a.Role {
+	case RoleOverseer:
+		return "overseer"
+	case RoleMayor:
+		return "mayor/"
+	case RoleDeacon:
+		if a.Name != "" {
+			return "deacon/" + a.Name
+		}
+		return "deacon/"
+	case RoleDog:
+		if a.Name != "" {
+			return "deacon/dogs/" + a.Name
+		}
+		return "deacon/dogs"
+	case RoleWitness, RoleRefinery:
+		if a.Rig == "" {
+			return ""
+		}
+		return a.Rig + "/" + string(a.Role)
+	case RoleCrew, RolePolecat:
+		if a.Rig == "" || a.Name == "" {
+			return ""
+		}
+		return a.Rig + "/" + string(a.Role) + "/" + a.Name
+	default:
+		return ""
+	}
+}
+
+// Parse converts any accepted spelling of an agent address into its canonical
+// form. It is liberal in what it accepts (Postel's law): surrounding space,
+// trailing slashes, mixed case in the role segment, the legacy singular
+// "polecat" path segment, and the rig-scoped spelling of a town-level singleton
+// ("gastown/deacon") all resolve to the same Address.
+func Parse(addr string) (Address, error) {
+	s := strings.TrimSpace(addr)
+	s = strings.TrimRight(s, "/")
+	if s == "" {
+		return Address{}, fmt.Errorf("empty agent address %q", addr)
+	}
+
+	parts := strings.Split(s, "/")
+	for _, part := range parts {
+		if part == "" {
+			return Address{}, fmt.Errorf("invalid agent address %q: empty path segment", addr)
+		}
+	}
+
+	switch len(parts) {
+	case 1:
+		switch strings.ToLower(parts[0]) {
+		case string(RoleOverseer):
+			return Address{Role: RoleOverseer}, nil
+		case string(RoleMayor):
+			return Address{Role: RoleMayor}, nil
+		case string(RoleDeacon):
+			return Address{Role: RoleDeacon}, nil
+		}
+		return Address{}, fmt.Errorf("invalid agent address %q: bare role is not addressable", addr)
+
+	case 2:
+		head, tail := parts[0], parts[1]
+		if strings.EqualFold(head, string(RoleDeacon)) {
+			switch strings.ToLower(tail) {
+			case bootName:
+				return Address{Role: RoleDeacon, Name: bootName}, nil
+			case string(RoleDog):
+				return Address{Role: RoleDog}, nil
+			}
+			return Address{}, fmt.Errorf("invalid agent address %q: unknown deacon sub-agent %q", addr, tail)
+		}
+		// A rig-scoped spelling of a town-level singleton resolves to the
+		// singleton: mayor and deacon are one per town, not one per rig.
+		switch strings.ToLower(tail) {
+		case string(RoleMayor):
+			return Address{Role: RoleMayor}, nil
+		case string(RoleDeacon):
+			return Address{Role: RoleDeacon}, nil
+		case string(RoleWitness):
+			return Address{Rig: head, Role: RoleWitness}, nil
+		case string(RoleRefinery):
+			return Address{Rig: head, Role: RoleRefinery}, nil
+		case string(RoleCrew), string(RolePolecat), "polecat":
+			return Address{}, fmt.Errorf("invalid agent address %q: missing worker name", addr)
+		}
+		// "rig/name" is the shorthand for a polecat.
+		return Address{Rig: head, Role: RolePolecat, Name: tail}, nil
+
+	case 3:
+		rig, kind, name := parts[0], parts[1], parts[2]
+		if strings.EqualFold(rig, string(RoleDeacon)) && strings.EqualFold(kind, string(RoleDog)) {
+			return Address{Role: RoleDog, Name: name}, nil
+		}
+		switch strings.ToLower(kind) {
+		case string(RoleCrew):
+			return Address{Rig: rig, Role: RoleCrew, Name: name}, nil
+		case string(RolePolecat), "polecat":
+			return Address{Rig: rig, Role: RolePolecat, Name: name}, nil
+		}
+		return Address{}, fmt.Errorf("invalid agent address %q: unknown agent kind %q", addr, kind)
+
+	default:
+		return Address{}, fmt.Errorf("invalid agent address %q: too many path segments", addr)
+	}
+}
+
+// Canonical returns the canonical form of addr. Inputs that cannot be parsed
+// are returned trimmed and otherwise unchanged, so that callers writing an
+// address never silently lose an unrecognised value.
+func Canonical(addr string) string {
+	parsed, err := Parse(addr)
+	if err != nil {
+		return strings.TrimSpace(addr)
+	}
+	canonical := parsed.String()
+	if canonical == "" {
+		return strings.TrimSpace(addr)
+	}
+	return canonical
+}
+
+// Variants returns every spelling of addr that may appear in storage written by
+// an older build, canonical form first. Readers should query all of them and
+// merge the results; writers should use Canonical.
+//
+// Only town-level singletons have a legacy variant: `gt patrol` wrote a bare
+// "deacon" where `gt sling` wrote "deacon/", which is the split that stranded
+// patrol wisps. Rig-scoped addresses have only ever had one spelling.
+func Variants(addr string) []string {
+	canonical := Canonical(addr)
+	variants := []string{canonical}
+
+	switch canonical {
+	case "mayor/":
+		variants = append(variants, "mayor")
+	case "deacon/":
+		variants = append(variants, "deacon")
+	}
+
+	// Preserve a caller-supplied spelling that canonicalization changed, so a
+	// lookup never loses rows written under the exact string it was given.
+	trimmed := strings.TrimSpace(addr)
+	if trimmed != "" && !contains(variants, trimmed) {
+		variants = append(variants, trimmed)
+	}
+	return variants
+}
+
+// Equal reports whether two addresses name the same agent, regardless of
+// spelling.
+func Equal(a, b string) bool {
+	canonicalA, errA := Parse(a)
+	canonicalB, errB := Parse(b)
+	if errA != nil || errB != nil {
+		return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+	}
+	return strings.EqualFold(canonicalA.String(), canonicalB.String())
+}
+
+// NormalizeForCompare lowercases an address and trims a trailing slash so that
+// "Mayor/" and "mayor" compare equal. This is the loose, comparison-only
+// normalization the mail reply matcher has always used; it is deliberately
+// separate from Canonical, which produces the storage form.
+func NormalizeForCompare(addr string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(addr)), "/")
+}
+
+// Rig returns the rig an address belongs to, or "" for town-level agents and
+// for addresses that cannot be parsed.
+func Rig(addr string) string {
+	parsed, err := Parse(addr)
+	if err != nil {
+		return ""
+	}
+	return parsed.Rig
+}
+
+func contains(list []string, want string) bool {
+	for _, item := range list {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agentaddr/address_test.go
+++ b/internal/agentaddr/address_test.go
@@ -1,0 +1,218 @@
+package agentaddr
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCanonicalForms(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want Address
+		str  string
+	}{
+		// Town-level singletons — the trailing-slash split behind gt-cw1.
+		{"bare deacon", "deacon", Address{Role: RoleDeacon}, "deacon/"},
+		{"deacon trailing slash", "deacon/", Address{Role: RoleDeacon}, "deacon/"},
+		{"deacon padded", "  deacon  ", Address{Role: RoleDeacon}, "deacon/"},
+		{"deacon mixed case", "Deacon/", Address{Role: RoleDeacon}, "deacon/"},
+		{"deacon repeated slashes", "deacon///", Address{Role: RoleDeacon}, "deacon/"},
+		{"bare mayor", "mayor", Address{Role: RoleMayor}, "mayor/"},
+		{"mayor trailing slash", "mayor/", Address{Role: RoleMayor}, "mayor/"},
+		{"rig scoped mayor", "gastown/mayor", Address{Role: RoleMayor}, "mayor/"},
+		{"rig scoped deacon", "gastown/deacon", Address{Role: RoleDeacon}, "deacon/"},
+		{"overseer", "overseer", Address{Role: RoleOverseer}, "overseer"},
+		{"boot", "deacon/boot", Address{Role: RoleDeacon, Name: "boot"}, "deacon/boot"},
+
+		// Dogs live under the deacon, not under a rig.
+		{"dog pool", "deacon/dogs", Address{Role: RoleDog}, "deacon/dogs"},
+		{"dog named", "deacon/dogs/alpha", Address{Role: RoleDog, Name: "alpha"}, "deacon/dogs/alpha"},
+
+		// Rig-scoped singletons.
+		{"witness", "gastown/witness", Address{Rig: "gastown", Role: RoleWitness}, "gastown/witness"},
+		{"witness trailing slash", "gastown/witness/", Address{Rig: "gastown", Role: RoleWitness}, "gastown/witness"},
+		{"refinery", "sandbox/refinery", Address{Rig: "sandbox", Role: RoleRefinery}, "sandbox/refinery"},
+
+		// Named workers.
+		{"polecat", "gastown/polecats/quartz", Address{Rig: "gastown", Role: RolePolecat, Name: "quartz"}, "gastown/polecats/quartz"},
+		{"polecat legacy singular", "gastown/polecat/quartz", Address{Rig: "gastown", Role: RolePolecat, Name: "quartz"}, "gastown/polecats/quartz"},
+		{"polecat shorthand", "gastown/quartz", Address{Rig: "gastown", Role: RolePolecat, Name: "quartz"}, "gastown/polecats/quartz"},
+		{"crew", "gastown/crew/max", Address{Rig: "gastown", Role: RoleCrew, Name: "max"}, "gastown/crew/max"},
+		{"worker name case preserved", "gastown/polecats/Toast", Address{Rig: "gastown", Role: RolePolecat, Name: "Toast"}, "gastown/polecats/Toast"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := Parse(c.in)
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", c.in, err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", c.in, got, c.want)
+			}
+			if str := got.String(); str != c.str {
+				t.Errorf("Parse(%q).String() = %q, want %q", c.in, str, c.str)
+			}
+			if canonical := Canonical(c.in); canonical != c.str {
+				t.Errorf("Canonical(%q) = %q, want %q", c.in, canonical, c.str)
+			}
+		})
+	}
+}
+
+func TestParseRejectsUnaddressableInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"only slashes", "///"},
+		{"bare pool role", "dog"},
+		{"bare witness", "witness"},
+		{"bare refinery", "refinery"},
+		{"missing rig", "/witness"},
+		{"polecats without name", "gastown/polecats"},
+		{"crew without name", "gastown/crew"},
+		{"unknown deacon sub-agent", "deacon/kennel"},
+		{"unknown kind", "gastown/mechanics/joe"},
+		{"too deep", "gastown/polecats/quartz/extra"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got, err := Parse(c.in); err == nil {
+				t.Errorf("Parse(%q) = %+v, want error", c.in, got)
+			}
+		})
+	}
+}
+
+// Canonical must never discard a value it does not understand: an unparseable
+// assignee is passed through so a write cannot silently blank a bead.
+func TestCanonicalPassesThroughUnparseableInput(t *testing.T) {
+	for _, in := range []string{"dog", "queue:releases", "channel:town-square", "  announce:all  "} {
+		want := trimmed(in)
+		if got := Canonical(in); got != want {
+			t.Errorf("Canonical(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsTownLevel(t *testing.T) {
+	cases := map[string]bool{
+		"deacon":                 true,
+		"deacon/":                true,
+		"mayor/":                 true,
+		"deacon/dogs/alpha":      true,
+		"deacon/boot":            true,
+		"overseer":               true,
+		"gastown/witness":        false,
+		"gastown/polecats/toast": false,
+		"gastown/crew/max":       false,
+	}
+	for in, want := range cases {
+		parsed, err := Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", in, err)
+		}
+		if got := parsed.IsTownLevel(); got != want {
+			t.Errorf("Parse(%q).IsTownLevel() = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// Variants is what lets a reader still find rows written by an older build.
+// The town-level pair is the exact split that stranded patrol wisps: `gt sling`
+// wrote "deacon/" while `gt patrol` wrote and matched a bare "deacon".
+func TestVariants(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"deacon", []string{"deacon/", "deacon"}},
+		{"deacon/", []string{"deacon/", "deacon"}},
+		{"mayor", []string{"mayor/", "mayor"}},
+		{"gastown/witness", []string{"gastown/witness"}},
+		{"gastown/polecats/quartz", []string{"gastown/polecats/quartz"}},
+		{"gastown/polecat/quartz", []string{"gastown/polecats/quartz", "gastown/polecat/quartz"}},
+		{"dog", []string{"dog"}},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := Variants(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Variants(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"deacon", "deacon/", true},
+		{"Deacon/", "deacon", true},
+		{"gastown/deacon", "deacon/", true},
+		{"gastown/polecats/quartz", "gastown/quartz", true},
+		{"gastown/polecat/quartz", "gastown/polecats/quartz", true},
+		{"deacon", "mayor", false},
+		{"gastown/witness", "sandbox/witness", false},
+		{"deacon/dogs/alpha", "deacon/dogs/beta", false},
+		{"dog", "dog", true},
+		{"dog", "deacon/dogs", false},
+	}
+	for _, c := range cases {
+		if got := Equal(c.a, c.b); got != c.want {
+			t.Errorf("Equal(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestRig(t *testing.T) {
+	cases := map[string]string{
+		"deacon/":                "",
+		"deacon":                 "",
+		"mayor/":                 "",
+		"deacon/dogs/alpha":      "",
+		"gastown/witness":        "gastown",
+		"sandbox/refinery":       "sandbox",
+		"gastown/polecats/toast": "gastown",
+		"dog":                    "",
+	}
+	for in, want := range cases {
+		if got := Rig(in); got != want {
+			t.Errorf("Rig(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// NormalizeForCompare must keep the exact semantics the mail reply matcher
+// relied on before it was moved here.
+func TestNormalizeForCompare(t *testing.T) {
+	cases := map[string]string{
+		"mayor/":                 "mayor",
+		"Mayor/":                 "mayor",
+		"mayor":                  "mayor",
+		"  deacon/  ":            "deacon",
+		"gastown/polecats/Toast": "gastown/polecats/toast",
+		"":                       "",
+	}
+	for in, want := range cases {
+		if got := NormalizeForCompare(in); got != want {
+			t.Errorf("NormalizeForCompare(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func trimmed(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/cmd/agent_address_test.go
+++ b/internal/cmd/agent_address_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/agentaddr"
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+// The wisp leak in gt-cw1 was a write/write disagreement: `gt sling deacon`
+// stored the assignee as "deacon/" while `gt patrol` stored and matched a bare
+// "deacon", so patrol report could not see the wisp on its own hook. Both sides
+// now derive the address from agentaddr, and this test fails if they drift.
+func TestPatrolAssigneeMatchesSlingAssignee(t *testing.T) {
+	cases := []struct {
+		name          string
+		identity      *session.AgentIdentity
+		patrolConfig  PatrolConfig
+		wantAssignee  string
+		wantPatrolRig string
+	}{
+		{
+			name:          "deacon",
+			identity:      &session.AgentIdentity{Role: session.RoleDeacon},
+			patrolConfig:  PatrolConfig{RoleName: "deacon", Assignee: "deacon"},
+			wantAssignee:  "deacon/",
+			wantPatrolRig: "",
+		},
+		{
+			name:          "witness",
+			identity:      &session.AgentIdentity{Role: session.RoleWitness, Rig: "gastown"},
+			patrolConfig:  PatrolConfig{RoleName: "witness", Assignee: "gastown/witness"},
+			wantAssignee:  "gastown/witness",
+			wantPatrolRig: "gastown",
+		},
+		{
+			name:          "refinery",
+			identity:      &session.AgentIdentity{Role: session.RoleRefinery, Rig: "sandbox"},
+			patrolConfig:  PatrolConfig{RoleName: "refinery", Assignee: "sandbox/refinery"},
+			wantAssignee:  "sandbox/refinery",
+			wantPatrolRig: "sandbox",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			slingAssignee := canonicalAssigneeAddress(c.identity)
+			if slingAssignee != c.wantAssignee {
+				t.Errorf("sling assignee = %q, want %q", slingAssignee, c.wantAssignee)
+			}
+			patrolAssignee := c.patrolConfig.assigneeAddress()
+			if patrolAssignee != c.wantAssignee {
+				t.Errorf("patrol assignee = %q, want %q", patrolAssignee, c.wantAssignee)
+			}
+			if patrolAssignee != slingAssignee {
+				t.Errorf("patrol assignee %q != sling assignee %q", patrolAssignee, slingAssignee)
+			}
+			if got := patrolRigName(c.patrolConfig); got != c.wantPatrolRig {
+				t.Errorf("patrolRigName = %q, want %q", got, c.wantPatrolRig)
+			}
+		})
+	}
+}
+
+// A patrol reader must still find rows written by an older build, which stored
+// the town-level assignee without its trailing slash.
+func TestPatrolAssigneeVariantsCoverLegacyRows(t *testing.T) {
+	variants := agentaddr.Variants(PatrolConfig{Assignee: "deacon"}.assigneeAddress())
+
+	wantAll := []string{"deacon/", "deacon"}
+	for _, want := range wantAll {
+		found := false
+		for _, got := range variants {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("variants %v missing %q", variants, want)
+		}
+	}
+	if variants[0] != "deacon/" {
+		t.Errorf("variants[0] = %q, want the canonical form %q", variants[0], "deacon/")
+	}
+}
+
+// Dispatch resolves the agent; bd writes the step wisps without knowing it. A
+// molecule dispatched to a dog left its steps assigned to the bare pool role
+// "dog", where no per-agent lookup could reach them.
+func TestStepsNeedingAssignee(t *testing.T) {
+	target := "deacon/dogs/alpha"
+	steps := []*beads.Issue{
+		{ID: "hq-wisp-b97", Status: "open", Assignee: "dog"},
+		{ID: "hq-wisp-c12", Status: "in_progress", Assignee: ""},
+		{ID: "hq-wisp-d34", Status: "open", Assignee: "deacon/dogs/alpha"},
+		{ID: "hq-wisp-e56", Status: "closed", Assignee: "dog"},
+		{ID: "", Status: "open", Assignee: "dog"},
+		nil,
+	}
+
+	got := stepsNeedingAssignee(steps, target)
+	want := []string{"hq-wisp-b97", "hq-wisp-c12"}
+	if len(got) != len(want) {
+		t.Fatalf("stepsNeedingAssignee = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stepsNeedingAssignee = %v, want %v", got, want)
+		}
+	}
+}
+
+// A step already pointing at the agent under a different spelling is left
+// alone: re-pointing it would cost a Dolt commit and change nothing.
+func TestStepsNeedingAssigneeIgnoresEquivalentSpellings(t *testing.T) {
+	cases := []struct {
+		stepAssignee string
+		target       string
+	}{
+		{"deacon", "deacon/"},
+		{"deacon/", "deacon"},
+		{"gastown/polecat/quartz", "gastown/polecats/quartz"},
+		{"gastown/quartz", "gastown/polecats/quartz"},
+	}
+
+	for _, c := range cases {
+		step := &beads.Issue{ID: "hq-wisp-1", Status: "open", Assignee: c.stepAssignee}
+		if stepNeedsAssignee(step, c.target) {
+			t.Errorf("step assigned %q considered stale against target %q", c.stepAssignee, c.target)
+		}
+	}
+}

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -20,6 +20,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	convoyops "github.com/steveyegge/gastown/internal/convoy"
@@ -2841,26 +2842,26 @@ func getWorkersForIssues(issueIDs []string) map[string]*workerInfo {
 }
 
 // parseWorkerFromAgentBead extracts worker identity from agent bead ID.
-// Input: "gt-gastown-polecat-nux" -> Output: "gastown/polecat/nux"
+// Input: "gt-gastown-polecat-nux" -> Output: "gastown/polecats/nux"
 // Input: "gt-beads-crew-amber" -> Output: "beads/crew/amber"
+//
+// The components are reassembled through agentaddr rather than by string
+// concatenation, so a worker is shown under the same address the rest of the
+// town stores it under (gt-cw1).
 func parseWorkerFromAgentBead(agentID string) string {
 	rig, role, name, ok := beads.ParseAgentBeadID(agentID)
 	if !ok {
 		return ""
 	}
 
-	// Build path from parsed components
-	if rig == "" {
-		// Town-level
-		if name != "" {
-			return role + "/" + name
-		}
-		return role
-	}
+	assembled := role
 	if name != "" {
-		return rig + "/" + role + "/" + name
+		assembled = role + "/" + name
 	}
-	return rig + "/" + role
+	if rig != "" {
+		assembled = rig + "/" + assembled
+	}
+	return agentaddr.Canonical(assembled)
 }
 
 // formatWorkerAge formats a duration as a short string (e.g., "5m", "2h", "1d")

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -1135,40 +1136,39 @@ func runDeaconHealthState(cmd *cobra.Command, args []string) error {
 // agentAddressToIDs converts an agent address to bead ID and session name.
 // Supports formats: "gastown/polecats/max", "gastown/witness", "deacon", "mayor"
 // Note: Town-level agents (Mayor, Deacon) use hq- prefix bead IDs stored in town beads.
+//
+// Parsing is delegated to agentaddr so every spelling of an address resolves
+// here: a bare "deacon" and the canonical "deacon/" used to take different
+// branches, and the trailing-slash form fell through to the invalid-format
+// error (gt-cw1).
 func agentAddressToIDs(address string) (beadID, sessionName string, err error) {
-	switch address {
-	case constants.RoleDeacon:
-		return beads.DeaconBeadIDTown(), session.DeaconSessionName(), nil
-	case constants.RoleMayor:
-		return beads.MayorBeadIDTown(), session.MayorSessionName(), nil
+	parsed, parseErr := agentaddr.Parse(address)
+	if parseErr != nil {
+		return "", "", fmt.Errorf("invalid agent address format: %s (expected rig/type/name or rig/role)", address)
 	}
 
-	parts := strings.Split(address, "/")
-	switch len(parts) {
-	case 2:
-		// rig/role: "gastown/witness", "gastown/refinery"
-		rig, role := parts[0], parts[1]
-		switch role {
-		case constants.RoleWitness:
-			return session.WitnessSessionName(session.PrefixFor(rig)), session.WitnessSessionName(session.PrefixFor(rig)), nil
-		case constants.RoleRefinery:
-			return session.RefinerySessionName(session.PrefixFor(rig)), session.RefinerySessionName(session.PrefixFor(rig)), nil
-		default:
-			return "", "", fmt.Errorf("unknown role: %s", role)
+	switch parsed.Role {
+	case agentaddr.RoleDeacon:
+		if parsed.Name != "" {
+			return "", "", fmt.Errorf("unknown role: %s", parsed.Name)
 		}
-	case 3:
-		// rig/type/name: "gastown/polecats/max", "gastown/crew/alpha"
-		rig, agentType, name := parts[0], parts[1], parts[2]
-		switch agentType {
-		case "polecats":
-			return session.PolecatSessionName(session.PrefixFor(rig), name), session.PolecatSessionName(session.PrefixFor(rig), name), nil
-		case constants.RoleCrew:
-			return session.CrewSessionName(session.PrefixFor(rig), name), session.CrewSessionName(session.PrefixFor(rig), name), nil
-		default:
-			return "", "", fmt.Errorf("unknown agent type: %s", agentType)
-		}
+		return beads.DeaconBeadIDTown(), session.DeaconSessionName(), nil
+	case agentaddr.RoleMayor:
+		return beads.MayorBeadIDTown(), session.MayorSessionName(), nil
+	case agentaddr.RoleWitness:
+		name := session.WitnessSessionName(session.PrefixFor(parsed.Rig))
+		return name, name, nil
+	case agentaddr.RoleRefinery:
+		name := session.RefinerySessionName(session.PrefixFor(parsed.Rig))
+		return name, name, nil
+	case agentaddr.RolePolecat:
+		name := session.PolecatSessionName(session.PrefixFor(parsed.Rig), parsed.Name)
+		return name, name, nil
+	case agentaddr.RoleCrew:
+		name := session.CrewSessionName(session.PrefixFor(parsed.Rig), parsed.Name)
+		return name, name, nil
 	default:
-		return "", "", fmt.Errorf("invalid agent address format: %s (expected rig/type/name or rig/role)", address)
+		return "", "", fmt.Errorf("unknown role: %s", parsed.Role)
 	}
 }
 

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 )
 
@@ -53,6 +54,26 @@ func listAssignedActiveWork(b *beads.Beads, assignee string) ([]*beads.Issue, er
 		}
 	}
 	return nil, nil
+}
+
+// listAssignedActiveWorkForAgent lists active work for an agent across every
+// spelling its address has ever been stored under.
+//
+// Exact-match assignee queries are the reason patrol wisps leaked: `gt sling`
+// wrote "deacon/" while `gt patrol` matched a bare "deacon", so patrol report
+// structurally could not see the wisp on its own hook (gt-cw1). Querying the
+// canonical form alone would strand every row written by an older build, so
+// readers ask for all variants and merge.
+func listAssignedActiveWorkForAgent(b *beads.Beads, assignee string) ([]*beads.Issue, error) {
+	var assigned []*beads.Issue
+	for _, variant := range agentaddr.Variants(assignee) {
+		forVariant, err := listAssignedActiveWorkAcrossStatuses(b, variant)
+		if err != nil {
+			return nil, err
+		}
+		assigned = append(assigned, forVariant...)
+	}
+	return mergeBeadLists(assigned, nil), nil
 }
 
 func listAssignedActiveWorkAcrossStatuses(b *beads.Beads, assignee string) ([]*beads.Issue, error) {

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/mail"
@@ -278,8 +279,11 @@ func normalizeReplySubject(subject string) string {
 // normalizeAddress lowercases an address and trims a trailing slash so that
 // "Mayor/" and "mayor" compare equal. Matches identityVariants behavior in
 // mail.Mailbox without depending on its internals.
+//
+// The implementation lives in agentaddr so every subsystem shares one
+// definition; this wrapper keeps the local call sites readable.
 func normalizeAddress(addr string) string {
-	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(addr)), "/")
+	return agentaddr.NormalizeForCompare(addr)
 }
 
 // inferReplyTo searches the sender's mailbox for a single unambiguous message

--- a/internal/cmd/molecule_assignee.go
+++ b/internal/cmd/molecule_assignee.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/agentaddr"
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// maxStepPropagationDepth bounds the walk over a molecule's step tree so a
+// malformed parent chain cannot spin forever.
+const maxStepPropagationDepth = 8
+
+// stepNeedsAssignee reports whether a step wisp should be re-pointed at the
+// molecule's resolved address.
+//
+// Closed steps are left alone: their assignee is history, and rewriting it
+// costs a Dolt commit for no lookup benefit.
+func stepNeedsAssignee(step *beads.Issue, targetAgent string) bool {
+	if step == nil || step.ID == "" {
+		return false
+	}
+	if step.Status == "closed" {
+		return false
+	}
+	return !agentaddr.Equal(step.Assignee, targetAgent)
+}
+
+// stepsNeedingAssignee returns the IDs of the steps that should be re-pointed.
+func stepsNeedingAssignee(steps []*beads.Issue, targetAgent string) []string {
+	var ids []string
+	for _, step := range steps {
+		if stepNeedsAssignee(step, targetAgent) {
+			ids = append(ids, step.ID)
+		}
+	}
+	return ids
+}
+
+// propagateAssigneeToSteps points every open step wisp beneath rootID at the
+// same address as the root.
+//
+// `bd mol wisp` writes the child steps itself, and it has no way to know which
+// agent the molecule was dispatched to: the root gets the resolved address
+// while its steps inherit the bare pool role, so a molecule dispatched to
+// "deacon/dogs/alpha" leaves five steps assigned to "dog" (gt-cw1, symptom 2).
+// Those steps are then invisible to every per-agent lookup. Propagating after
+// the root is hooked closes that gap at the one place dispatch knows the answer.
+//
+// Returns the number of steps re-pointed. Errors are returned but callers treat
+// them as non-fatal: the molecule is already dispatched by this point.
+func propagateAssigneeToSteps(b *beads.Beads, rootID, targetAgent string) (int, error) {
+	if b == nil || rootID == "" || targetAgent == "" {
+		return 0, nil
+	}
+	canonical := agentaddr.Canonical(targetAgent)
+
+	updated := 0
+	var firstErr error
+	frontier := []string{rootID}
+	seen := map[string]bool{rootID: true}
+
+	for depth := 0; depth < maxStepPropagationDepth && len(frontier) > 0; depth++ {
+		var next []string
+		for _, parentID := range frontier {
+			children, err := listChildrenAcrossTables(b, parentID)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("listing steps of %s: %w", parentID, err)
+				}
+				continue
+			}
+			for _, child := range children {
+				if child == nil || child.ID == "" || seen[child.ID] {
+					continue
+				}
+				seen[child.ID] = true
+				next = append(next, child.ID)
+
+				if !stepNeedsAssignee(child, canonical) {
+					continue
+				}
+				if err := b.Update(child.ID, beads.UpdateOptions{Assignee: &canonical}); err != nil {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("assigning step %s to %s: %w", child.ID, canonical, err)
+					}
+					continue
+				}
+				updated++
+			}
+		}
+		frontier = next
+	}
+
+	return updated, firstErr
+}
+
+// propagateMoleculeAssignee points a dispatched molecule and its step wisps at
+// the agent the work was dispatched to.
+//
+// The root is only filled in when it has no assignee yet — in the
+// formula-on-bead path the hook lands on the base bead, leaving the bonded wisp
+// root blank — so an address resolved by dispatch is never overwritten here.
+//
+// Failures are reported as warnings: the work is already on the agent's hook by
+// the time this runs, and a missed step assignee degrades lookups rather than
+// losing the dispatch.
+func propagateMoleculeAssignee(townRoot, rootID, targetAgent, workDir string) {
+	if rootID == "" || targetAgent == "" {
+		return
+	}
+	canonical := agentaddr.Canonical(targetAgent)
+	b := beads.New(beads.ResolveHookDir(townRoot, rootID, workDir))
+
+	if root, err := b.Show(rootID); err == nil && root != nil && root.Assignee == "" {
+		if err := b.Update(rootID, beads.UpdateOptions{Assignee: &canonical}); err != nil {
+			style.PrintWarning("could not assign molecule root %s to %s: %v", rootID, canonical, err)
+		}
+	}
+
+	updated, err := propagateAssigneeToSteps(b, rootID, canonical)
+	if err != nil {
+		style.PrintWarning("could not propagate assignee to steps of %s: %v", rootID, err)
+	}
+	if updated > 0 {
+		fmt.Printf("%s Assigned %d molecule step(s) to %s\n", style.Bold.Render("\u2713"), updated, canonical)
+	}
+}

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -27,6 +28,16 @@ type PatrolConfig struct {
 	WorkLoopSteps []string     // role-specific instructions
 	ExtraVars     []string     // additional --var key=value args for wisp creation
 	Beads         *beads.Beads // optional injected beads instance (for test isolation)
+}
+
+// assigneeAddress returns the canonical storage form of the patrol assignee.
+//
+// Callers set Assignee from role literals ("deacon") and rig concatenation
+// ("gastown/witness"). Canonicalizing here, rather than at each construction
+// site, is what stops the two halves of `gt patrol` from drifting apart from
+// `gt sling` again (gt-cw1).
+func (cfg PatrolConfig) assigneeAddress() string {
+	return agentaddr.Canonical(cfg.Assignee)
 }
 
 // maxStalePurgePerRun caps the number of stale patrol beads cleaned up in a
@@ -55,7 +66,7 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 	}
 
 	// Find active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, listErr := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
+	hookedBeads, listErr := listAssignedActiveWorkForAgent(b, cfg.Assignee)
 	if listErr != nil {
 		return "", "", false, fmt.Errorf("listing active patrol work: %w", listErr)
 	}
@@ -160,7 +171,7 @@ func burnPreviousPatrolWisps(cfg PatrolConfig) {
 	}
 
 	// Find all active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, err := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
+	hookedBeads, err := listAssignedActiveWorkForAgent(b, cfg.Assignee)
 	if err != nil {
 		style.PrintWarning("burn: could not list active patrol work: %v", err)
 		return
@@ -292,7 +303,7 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	}
 
 	// Hook the wisp to the agent so gt mol status sees it
-	if err := BdCmd("update", patrolID, "--status=hooked", "--assignee="+cfg.Assignee).
+	if err := BdCmd("update", patrolID, "--status=hooked", "--assignee="+cfg.assigneeAddress()).
 		WithAutoCommit().
 		WithBeadsDir(resolvedBeadsDir).
 		Dir(cfg.BeadsDir).
@@ -324,12 +335,12 @@ func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
 	return renderFormulaRootAndStepsFull(cfg.PatrolMolName, cfg.BeadsDir, rigName, vars)
 }
 
+// patrolRigName returns the rig a patrol belongs to, or "" for town-level
+// patrols. Splitting on the first slash would read "deacon" as a rig name once
+// the deacon assignee carries its canonical trailing slash, so the rig comes
+// from the parsed address instead.
 func patrolRigName(cfg PatrolConfig) string {
-	rigName, _, ok := strings.Cut(cfg.Assignee, "/")
-	if !ok {
-		return ""
-	}
-	return rigName
+	return agentaddr.Rig(cfg.Assignee)
 }
 
 func updatePatrolWispDescription(cfg PatrolConfig, resolvedBeadsDir, patrolID, desc string) error {
@@ -406,8 +417,8 @@ func refineryPatrolSafetyStop(cfg PatrolConfig) (*refinery.SafetyStop, error) {
 	if cfg.RoleName != "refinery" {
 		return nil, nil
 	}
-	rigName := strings.TrimSuffix(cfg.Assignee, "/refinery")
-	if rigName == cfg.Assignee || rigName == "" {
+	rigName := agentaddr.Rig(cfg.Assignee)
+	if rigName == "" {
 		return nil, nil
 	}
 	return refinery.ActiveSafetyStop(cfg.BeadsDir, rigName)

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
@@ -252,7 +253,22 @@ func newSessionHealthReport(session string, status tmux.ZombieStatus, maxInactiv
 
 // parseAddress parses "rig/polecat" format.
 // If no "/" is present, attempts to infer rig from current directory.
+//
+// The canonical worker forms ("rig/polecats/name", "rig/crew/name") are
+// recognised through agentaddr, so the address a bead stores is also the
+// address these commands accept (gt-cw1). Anything else keeps the historic
+// split-on-first-slash behaviour, which callers rely on for rig-level roles
+// such as "gastown/witness".
 func parseAddress(addr string) (rigName, polecatName string, err error) {
+	if parsed, parseErr := agentaddr.Parse(addr); parseErr == nil {
+		switch parsed.Role {
+		case agentaddr.RolePolecat, agentaddr.RoleCrew:
+			if parsed.Rig != "" && parsed.Name != "" {
+				return parsed.Rig, parsed.Name, nil
+			}
+		}
+	}
+
 	parts := strings.SplitN(addr, "/", 2)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1053,6 +1053,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	fmt.Printf("%s Work attached to hook (status=hooked)\n", style.Bold.Render("✓"))
 
+	// The hook lands on the base bead here, so the bonded molecule and its step
+	// wisps still carry whatever bd wrote. Point them at the same agent so every
+	// per-agent lookup sees the whole molecule (gt-cw1).
+	propagateMoleculeAssignee(townRoot, attachedMoleculeID, targetAgent, hookWorkDir)
+
 	// Log sling event to activity feed
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadID, targetAgent))
 

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -397,6 +397,10 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 
 	fmt.Printf("  %s Work attached to %s\n", style.Bold.Render("✓"), spawnInfo.PolecatName)
 
+	// The hook lands on the base bead, so the bonded molecule and its step wisps
+	// still carry whatever bd wrote. Point them at the same agent (gt-cw1).
+	propagateMoleculeAssignee(townRoot, attachedMoleculeID, targetAgent, hookWorkDir)
+
 	// 8. Log sling event
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadToHook, targetAgent))
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -507,6 +507,11 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 	}
 	fmt.Printf("%s Attached to hook (status=hooked)\n", style.Bold.Render("✓"))
 
+	// Step wisps are written by bd, which does not know the dispatch target, so
+	// they inherit the bare pool role and become invisible to per-agent lookups
+	// until dispatch points them at the resolved address (gt-cw1).
+	propagateMoleculeAssignee(townRoot, wispRootID, targetAgent, formulaWorkDir)
+
 	// Log sling event to activity feed (formula slinging)
 	actor := detectActor()
 	payload := events.SlingPayload(wispRootID, targetAgent)

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/agentaddr"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -60,15 +61,11 @@ func sessionToAgentID(sessionName string) string {
 // buildAgentIdentity: town-level agents (mayor, deacon) get a trailing slash.
 // session.AgentIdentity.Address() returns the bare name for those roles, which
 // causes the read/write mismatch in GH#3699.
+//
+// The trailing-slash rule now lives in agentaddr, which is the one place that
+// decides what an address looks like in storage (gt-cw1).
 func canonicalAssigneeAddress(identity *session.AgentIdentity) string {
-	addr := identity.Address()
-	switch identity.Role {
-	case session.RoleMayor, session.RoleDeacon:
-		if !strings.HasSuffix(addr, "/") {
-			return addr + "/"
-		}
-	}
-	return addr
+	return agentaddr.Canonical(identity.Address())
 }
 
 // resolveSelfTarget determines agent identity, pane, and hook root for slinging to self.


### PR DESCRIPTION
Fixes gt-cw1.

## The defect

Gas Town stored an agent's address as a bare string that each command built its own way, so the same agent ended up under several spellings. `gt sling` wrote `deacon/`; `gt patrol` wrote and matched a bare `deacon`. Exact-match assignee lookups then missed rows that plainly existed.

The damaging symptom is a patrol wisp leak. `gt patrol report` resolves the active patrol by matching `deacon`, so it structurally cannot see anything slung under `deacon/`. It opens a fresh cycle instead of closing the hooked one and strands the old wisp — the mechanism behind a backlog that reached 168 open wisps before manual GC.

This was diagnosed as three separate town beads (hq-5tx, hq-3lu, hq-6yx). They are one defect with three symptoms, so they are fixed together; three point patches at three write sites would leave the fourth to be discovered later.

## The fix

A new `internal/agentaddr` package is the single place that decides what an address looks like, with one parse and one format:

| Function | Role |
| --- | --- |
| `Canonical(s)` | the form writers must store |
| `Variants(s)` | every spelling a reader must accept |
| `Rig(s)` | the rig for an address |

`Rig` replaces ad-hoc `strings.Cut` / `TrimSuffix` parsing that misreads `deacon/` as a rig named `deacon` once the deacon assignee carries its canonical trailing slash.

Write and lookup sites are routed through it: sling (target, dispatch, formula), patrol helpers, deacon, convoy, mail send, session, and molecule assignee resolution.

**Backward compatibility:** readers go through `listAssignedActiveWorkForAgent`, which queries all variants and merges. Canonicalizing reads alone would strand every row written by an older build, so existing rows keep resolving.

Canonicalizing inside `PatrolConfig.assigneeAddress` rather than at each construction site is what stops the two halves of `gt patrol` from drifting apart from `gt sling` again.

## Scope

Canonicalizing the remaining call sites outside `internal/cmd` is tracked separately as gt-3ft.

## Testing

12 new tests: canonical forms, rejection of unaddressable input, unparseable passthrough, town-level detection, variants, equality, rig extraction, normalization, plus tests asserting that patrol and sling agree on the assignee they produce and that legacy spellings are still covered.

```
ok  github.com/steveyegge/gastown/internal/agentaddr   (8 tests)
--- PASS: TestPatrolAssigneeMatchesSlingAssignee
--- PASS: TestPatrolAssigneeVariantsCoverLegacyRows
--- PASS: TestStepsNeedingAssignee
--- PASS: TestStepsNeedingAssigneeIgnoresEquivalentSpellings
```

`go build` and `go vet` are clean on the changed packages.

Full-suite note: `internal/cmd` fails `TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir` and `TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown` both on this branch and on `main` at the merge base — the failing set is identical, so this branch introduces no regressions. Those two, and failures in `internal/{beads,daemon,doctor,doltserver,git,tmux}`, are pre-existing environment failures on this machine (no beads DB / no tmux in the test env), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvYg8ybfEvsTUFrEbissk
