### PR TITLE
feat(tap): refuse the repo-root search that freezes polecats on the .env prompt

### DIFF
--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -23,6 +23,7 @@ Available guards:
   bd-init            - Block bd init in wrong directories
   mol-patrol         - Block mol patrol from agent contexts
   dangerous-command  - Block rm -rf, force push, hard reset, git clean
+  broad-search       - Block a repo-root recursive search that stalls on .env
 
 External guards (standalone scripts, not compiled into gt):
   context-budget   - scripts/guards/context-budget-guard.sh

--- a/internal/cmd/tap_guard_broad_search.go
+++ b/internal/cmd/tap_guard_broad_search.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var tapGuardBroadSearchCmd = &cobra.Command{
+	Use:   "broad-search",
+	Short: "Block a repo-root recursive search that would read a denied .env",
+	Long: `Block unbounded repo-root searches that walk into a denied .env file.
+
+WHY THIS EXISTS. A polecat doing a "find all consumers" sweep writes a
+recursive grep rooted at the repo root. The sweep reaches .env, the deny rule
+in the repo's .claude/settings.json correctly stops it, and Claude Code raises
+an owner-only permission prompt. The agent then blocks INDEFINITELY on a
+question only the human can answer, holding a capacity slot, while every
+status surface still reports it as working.
+
+Measured on liveop, 2026-09-02/03: nuka held 7 hours, brahmin held 2.5 hours
+with 8 files of uncommitted work, on the identical prompt. Two of the last
+three polecats to attempt a repo-wide search hit the same wall.
+
+The deny rule is RIGHT and this guard does not weaken it. The search is too
+broad. Failing closed here converts an indefinite silent block into a clean
+refusal the agent can read and adapt to, which is the whole difference between
+a lost afternoon and a retried command.
+
+WHEN IT BLOCKS. All of these must hold, so ordinary searches are unaffected:
+  1. the command is a recursive grep/find-exec-grep, or an rg that has been
+     told to ignore .gitignore or to include hidden files
+  2. its search root is the repository root ("." or omitted), not a subtree
+  3. a .env file actually exists at that root -- no .env, no block
+  4. the command does not already exclude .env
+
+Exit codes:
+  0 - Search allowed
+  2 - Search BLOCKED (with a scoped rewrite suggested on stderr)`,
+	// The refusal text IS the product here -- it is the only thing the blocked
+	// agent reads before deciding what to do next. Cobra's usage dump and its
+	// "Error: exit 2" line would bury it, so silence both. The other guards
+	// print them; matching that is not worth a worse message.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runTapGuardBroadSearch,
+}
+
+func init() {
+	tapGuardCmd.AddCommand(tapGuardBroadSearchCmd)
+}
+
+// hookInputCwd extracts the working directory Claude Code reports for the
+// tool call, falling back to the guard's own cwd. The .env existence check
+// has to run against the AGENT's directory, not the guard process's, or the
+// guard answers a question about the wrong repository.
+func hookInputCwd(input []byte) string {
+	var hookInput struct {
+		Cwd string `json:"cwd"`
+	}
+	if err := json.Unmarshal(input, &hookInput); err == nil && hookInput.Cwd != "" {
+		return hookInput.Cwd
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return wd
+}
+
+// rootHasEnvFile reports whether a dotenv file the deny rules cover exists at
+// dir. The guard blocks ONLY when the prompt it prevents could actually fire,
+// so a repository with no .env is never slowed down by this rule.
+func rootHasEnvFile(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if e.Name() == ".env" || strings.HasPrefix(e.Name(), ".env.") {
+			return true
+		}
+	}
+	return false
+}
+
+// splitCommand tokenises a shell command for the matchers below. Word
+// splitting is enough here: every predicate either looks for a whole token or
+// trims the quotes itself, and a real shell parser would buy nothing a guard
+// that fails open can use.
+func splitCommand(command string) []string {
+	return strings.Fields(command)
+}
+
+// excludesEnv reports whether the command already keeps the sweep away from
+// .env, by any of the spellings the tools accept.
+func excludesEnv(command string) bool {
+	markers := []string{
+		"--exclude=.env",
+		"--exclude='.env",
+		"--exclude=\".env",
+		"--exclude-dir=.env",
+		"!.env",
+		"--exclude=*.env",
+	}
+	for _, m := range markers {
+		if strings.Contains(command, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// searchRootIsRepoRoot reports whether the recursive search starts at the
+// current directory rather than a subtree. A sweep of "src/" cannot reach a
+// root .env, so it is none of this guard's business.
+//
+// A bare "." must appear, and no other argument may name a directory that
+// actually exists under dir. Testing for existence rather than for a "/" is
+// what keeps `grep -rn 'foo/bar' .` blocked: the pattern looks like a path
+// but is not one, and treating it as a scope would let the exact command
+// this guard exists to stop through unexamined.
+func searchRootIsRepoRoot(fields []string, dir string) bool {
+	sawDotRoot := false
+	for i, f := range fields {
+		if i == 0 || strings.HasPrefix(f, "-") {
+			continue
+		}
+		f = strings.Trim(f, "\"'")
+		if f == "." || f == "./" {
+			sawDotRoot = true
+			continue
+		}
+		if dir == "" {
+			continue
+		}
+		candidate := f
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(dir, f)
+		}
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return false
+		}
+	}
+	return sawDotRoot
+}
+
+// isRecursiveGrep reports whether the command is a grep walking a tree.
+func isRecursiveGrep(fields []string) bool {
+	sawGrep := false
+	recursive := false
+	for _, f := range fields {
+		base := filepath.Base(f)
+		if base == "grep" || base == "egrep" || base == "fgrep" {
+			sawGrep = true
+			continue
+		}
+		if strings.HasPrefix(f, "-") && !strings.HasPrefix(f, "--") &&
+			(strings.Contains(f, "r") || strings.Contains(f, "R")) {
+			recursive = true
+		}
+		if f == "--recursive" || f == "--dereference-recursive" {
+			recursive = true
+		}
+	}
+	return sawGrep && recursive
+}
+
+// isUnrestrictedRipgrep reports whether an rg invocation has been told to
+// look at files it would otherwise skip. Plain rg honours .gitignore and
+// skips hidden files, so it never reaches .env on its own -- only the
+// overrides do.
+func isUnrestrictedRipgrep(fields []string) bool {
+	sawRg := false
+	unrestricted := false
+	for _, f := range fields {
+		if filepath.Base(f) == "rg" {
+			sawRg = true
+			continue
+		}
+		switch f {
+		case "--no-ignore", "--no-ignore-vcs", "--hidden", "-.", "--unrestricted":
+			unrestricted = true
+		}
+		// -u, -uu, -uuu and combined short flags such as -ul are the short
+		// spellings of --unrestricted.
+		if strings.HasPrefix(f, "-") && !strings.HasPrefix(f, "--") && strings.Contains(f, "u") {
+			unrestricted = true
+		}
+	}
+	return sawRg && unrestricted
+}
+
+// isFindExecGrep reports whether the command is the find-pipes-into-grep
+// spelling of the same sweep.
+func isFindExecGrep(fields []string) bool {
+	sawFind := false
+	sawGrep := false
+	for _, f := range fields {
+		switch filepath.Base(f) {
+		case "find":
+			sawFind = true
+		case "grep", "egrep", "fgrep", "xargs":
+			sawGrep = true
+		}
+	}
+	return sawFind && sawGrep
+}
+
+func runTapGuardBroadSearch(cmd *cobra.Command, args []string) error {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil // fail open
+	}
+
+	command := extractCommand(input)
+	if command == "" {
+		return nil
+	}
+
+	if excludesEnv(command) {
+		return nil
+	}
+
+	fields := splitCommand(command)
+	if !isRecursiveGrep(fields) && !isUnrestrictedRipgrep(fields) && !isFindExecGrep(fields) {
+		return nil
+	}
+	cwd := hookInputCwd(input)
+	if !searchRootIsRepoRoot(fields, cwd) {
+		return nil
+	}
+	if !rootHasEnvFile(cwd) {
+		return nil
+	}
+
+	printBroadSearchBlock(command)
+	return NewSilentExit(2)
+}
+
+func printBroadSearchBlock(originalCommand string) {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
+	fmt.Fprintln(os.Stderr, "║  ❌ REPO-ROOT SEARCH BLOCKED — it would stall on a .env prompt    ║")
+	fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════╣")
+	fmt.Fprintf(os.Stderr, "║  Command: %-53s ║\n", truncateStr(originalCommand, 53))
+	fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "This search walks the repository root, so it reaches .env, which the")
+	fmt.Fprintln(os.Stderr, "deny rule in .claude/settings.json covers. That raises a permission")
+	fmt.Fprintln(os.Stderr, "prompt only the human owner can answer, and you would block on it")
+	fmt.Fprintln(os.Stderr, "indefinitely — two polecats lost 9.5 hours between them this way.")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Do not ask for the search to be approved. Narrow it instead:")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  name the subtrees you actually mean")
+	fmt.Fprintln(os.Stderr, "    grep -rn 'pattern' src/ components/ services/")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  or exclude the files you never wanted")
+	fmt.Fprintln(os.Stderr, "    grep -rn 'pattern' . --exclude='.env*' --exclude-dir=node_modules")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "  or use the Grep tool, which honours the deny rules without prompting")
+	fmt.Fprintln(os.Stderr, "")
+}

--- a/internal/cmd/tap_guard_broad_search_test.go
+++ b/internal/cmd/tap_guard_broad_search_test.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// repoWithEnv builds a throwaway repository root holding a .env plus the
+// subdirectories the scoped-search cases name, so the existence checks in
+// searchRootIsRepoRoot and rootHasEnvFile run against real inodes rather
+// than against a guess about what a path looks like.
+func repoWithEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("SECRET=1\n"), 0600); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+	for _, sub := range []string{"src", "components", "services"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0755); err != nil {
+			t.Fatalf("creating %s: %v", sub, err)
+		}
+	}
+	return dir
+}
+
+func TestRootHasEnvFile(t *testing.T) {
+	withEnv := repoWithEnv(t)
+	withoutEnv := t.TempDir()
+
+	dotEnvLocal := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dotEnvLocal, ".env.local"), []byte("X=1\n"), 0600); err != nil {
+		t.Fatalf("writing .env.local: %v", err)
+	}
+
+	envDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(envDir, ".env"), 0755); err != nil {
+		t.Fatalf("creating .env dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		dir  string
+		want bool
+	}{
+		{"repo holding .env", withEnv, true},
+		{"repo holding .env.local", dotEnvLocal, true},
+		{"repo with no dotenv", withoutEnv, false},
+		{"a DIRECTORY named .env is not a dotenv file", envDir, false},
+		{"empty path", "", false},
+		{"missing path", filepath.Join(withoutEnv, "nope"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rootHasEnvFile(tt.dir); got != tt.want {
+				t.Errorf("rootHasEnvFile(%q) = %v, want %v", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExcludesEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"grep --exclude", "grep -rn foo . --exclude=.env", true},
+		{"grep --exclude quoted", "grep -rn foo . --exclude='.env*'", true},
+		{"grep --exclude double quoted", `grep -rn foo . --exclude=".env*"`, true},
+		{"grep --exclude glob", "grep -rn foo . --exclude=*.env", true},
+		{"exclude-dir", "grep -rn foo . --exclude-dir=.env.d", true},
+		{"ripgrep negated glob", "rg -u foo . -g '!.env'", true},
+		{"no exclusion", "grep -rn foo .", false},
+		{"excludes something else", "grep -rn foo . --exclude-dir=node_modules", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludesEnv(tt.command); got != tt.want {
+				t.Errorf("excludesEnv(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRecursiveGrep(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"grep -r", "grep -r foo .", true},
+		{"grep -rn combined", "grep -rn foo .", true},
+		{"grep -R", "grep -R foo .", true},
+		{"grep --recursive", "grep --recursive foo .", true},
+		{"absolute path to grep", "/usr/bin/grep -rn foo .", true},
+		{"egrep -r", "egrep -r foo .", true},
+		{"non-recursive grep", "grep -n foo file.txt", false},
+		{"not grep at all", "cat file.txt", false},
+		{"long flag that merely contains r", "grep --color foo file.txt", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRecursiveGrep(splitCommand(tt.command)); got != tt.want {
+				t.Errorf("isRecursiveGrep(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUnrestrictedRipgrep(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"rg -u", "rg -u foo .", true},
+		{"rg -uu", "rg -uu foo .", true},
+		{"rg --no-ignore", "rg --no-ignore foo .", true},
+		{"rg --hidden", "rg --hidden foo .", true},
+		// Plain rg honours .gitignore and skips hidden files, so it never
+		// reaches .env and must not be blocked.
+		{"plain rg", "rg foo .", false},
+		{"rg with harmless flags", "rg -n --color never foo .", false},
+		{"not rg", "grep -r foo .", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnrestrictedRipgrep(splitCommand(tt.command)); got != tt.want {
+				t.Errorf("isUnrestrictedRipgrep(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchRootIsRepoRoot(t *testing.T) {
+	dir := repoWithEnv(t)
+
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"bare dot", "grep -rn foo .", true},
+		{"dot slash", "grep -rn foo ./", true},
+		// The pattern LOOKS like a path and is not one. Treating it as a
+		// scope would let the exact command this guard exists to stop
+		// through, so existence is what decides, not the slash.
+		{"pattern containing a slash, root search", "grep -rn foo/bar .", true},
+		{"scoped to one real subtree", "grep -rn foo src/", false},
+		{"scoped to several real subtrees", "grep -rn foo src/ components/ services/", false},
+		{"dot plus a real subtree", "grep -rn foo . src/", false},
+		{"no path argument at all", "grep -rn foo", false},
+		{"quoted dot", `grep -rn foo "."`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := searchRootIsRepoRoot(splitCommand(tt.command), dir); got != tt.want {
+				t.Errorf("searchRootIsRepoRoot(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFindExecGrep(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"find exec grep", "find . -type f -exec grep -l foo {} ;", true},
+		{"find piped to xargs grep", "find . -type f | xargs grep foo", true},
+		{"find alone", "find . -name *.ts", false},
+		{"grep alone", "grep -rn foo .", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFindExecGrep(splitCommand(tt.command)); got != tt.want {
+				t.Errorf("isFindExecGrep(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHookInputCwd(t *testing.T) {
+	// The .env check has to run against the AGENT's directory. If the guard
+	// read its own cwd instead, it would answer a question about the wrong
+	// repository -- allowing the sweep in a repo that has a .env, or
+	// blocking one in a repo that does not.
+	got := hookInputCwd([]byte(`{"tool_input":{"command":"grep -rn foo ."},"cwd":"/some/polecat/worktree"}`))
+	if got != "/some/polecat/worktree" {
+		t.Errorf("hookInputCwd() = %q, want the cwd from the hook payload", got)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if got := hookInputCwd([]byte(`{"tool_input":{"command":"grep -rn foo ."}}`)); got != wd {
+		t.Errorf("hookInputCwd() with no cwd field = %q, want the process cwd %q", got, wd)
+	}
+}
+
+// TestBroadSearchGuardDecision exercises the whole predicate chain the way
+// runTapGuardBroadSearch composes it, because the individual matchers being
+// right is not the same claim as the guard blocking the right commands.
+func TestBroadSearchGuardDecision(t *testing.T) {
+	withEnv := repoWithEnv(t)
+	withoutEnv := t.TempDir()
+	for _, sub := range []string{"src"} {
+		if err := os.MkdirAll(filepath.Join(withoutEnv, sub), 0755); err != nil {
+			t.Fatalf("creating %s: %v", sub, err)
+		}
+	}
+
+	blocks := func(command, dir string) bool {
+		if excludesEnv(command) {
+			return false
+		}
+		fields := splitCommand(command)
+		if !isRecursiveGrep(fields) && !isUnrestrictedRipgrep(fields) && !isFindExecGrep(fields) {
+			return false
+		}
+		if !searchRootIsRepoRoot(fields, dir) {
+			return false
+		}
+		return rootHasEnvFile(dir)
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		dir     string
+		want    bool
+	}{
+		// The command that actually froze nuka and brahmin.
+		{"repo-root recursive grep in a repo holding .env", "grep -rn 'ResearchHub' .", withEnv, true},
+		{"find piped to xargs grep at the root", "find . -type f | xargs grep ResearchHub", withEnv, true},
+		{"unrestricted rg at the root", "rg -u ResearchHub .", withEnv, true},
+
+		// Everything a polecat legitimately needs stays allowed.
+		{"scoped search", "grep -rn 'ResearchHub' src/", withEnv, false},
+		{"root search that excludes .env", "grep -rn 'ResearchHub' . --exclude='.env*'", withEnv, false},
+		{"plain rg, which skips hidden files anyway", "rg ResearchHub .", withEnv, false},
+		{"non-recursive grep", "grep -n ResearchHub package.json", withEnv, false},
+		{"not a search", "npm test", withEnv, false},
+
+		// No .env means no prompt to prevent, so the guard must stay out of
+		// the way entirely.
+		{"repo-root recursive grep where no .env exists", "grep -rn 'ResearchHub' .", withoutEnv, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := blocks(tt.command, tt.dir); got != tt.want {
+				t.Errorf("blocks(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/tap_list.go
+++ b/internal/cmd/tap_list.go
@@ -61,6 +61,14 @@ func runTapList(cmd *cobra.Command, args []string) error {
 			matchers:    []string{"Bash(sudo *)", "Bash(apt install*)", "Bash(dnf install*)", "Bash(brew install*)", "Bash(rm -rf /*)", "Bash(git push --force*)", "Bash(git push -f*)"},
 			implemented: true,
 		},
+		{
+			name:        "broad-search",
+			kind:        "guard",
+			description: "Block a repo-root recursive search that would stall on the .env permission prompt",
+			event:       "PreToolUse",
+			matchers:    []string{"Bash(grep*)", "Bash(rg*)", "Bash(find*)"},
+			implemented: true,
+		},
 	}
 
 	// Try to load registry for additional handlers

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1059,6 +1059,33 @@ func DefaultBase() *HooksConfig {
 					Command: gtCommand("gt tap guard dangerous-command"),
 				}},
 			},
+			// A repo-root recursive search walks into .env, which the repo's
+			// own deny rule covers, and the resulting permission prompt is
+			// owner-only -- so the agent blocks on it indefinitely while every
+			// status surface still reports it working. Two polecats lost 9.5
+			// hours to exactly this on 2026-09-02/03. The guard refuses the
+			// unbounded sweep so the agent can narrow it and carry on.
+			{
+				Matcher: "Bash(grep*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: gtCommand("gt tap guard broad-search"),
+				}},
+			},
+			{
+				Matcher: "Bash(rg*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: gtCommand("gt tap guard broad-search"),
+				}},
+			},
+			{
+				Matcher: "Bash(find*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: gtCommand("gt tap guard broad-search"),
+				}},
+			},
 		},
 		SessionStart: []HookEntry{
 			{

--- a/internal/hooks/templates/claude/settings-autonomous.json
+++ b/internal/hooks/templates/claude/settings-autonomous.json
@@ -102,6 +102,33 @@
             "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
+      },
+      {
+        "matcher": "Bash(grep*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} tap guard broad-search"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(rg*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} tap guard broad-search"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(find*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} tap guard broad-search"
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## What this fixes

A polecat doing a "find all consumers" sweep writes a recursive grep rooted at the repo root. The sweep reaches `.env`, the deny rule in the repo's own `.claude/settings.json` correctly stops it, and Claude Code raises a permission prompt **only the human owner can answer**. The agent then blocks indefinitely, holding a capacity slot, while `gt polecat list` still reports it working.

Measured on liveop over 2026-09-02/03:

| polecat | held | work at risk |
|---|---|---|
| nuka | 7h | none |
| brahmin | 2h32m | commit `fabf8dd1`, 8+ files, unpushed |

Two of the last three polecats that attempted a repo-wide search hit the identical wall. That makes it a dispatch-level defect, not two incidents.

## The approach

**The deny rule is right and this does not weaken it. The search is too broad.** Failing closed converts an indefinite silent block into a refusal the agent can read and act on.

New `gt tap guard broad-search`, wired into the autonomous PreToolUse scaffold on `Bash(grep*)`, `Bash(rg*)`, `Bash(find*)`. It blocks only when **all** of these hold, so ordinary searches are untouched:

1. recursive grep, find-into-grep, or an `rg` told to ignore `.gitignore` or include hidden files — plain `rg` skips `.env` on its own and is left alone
2. the search root is the repository root, not a subtree
3. a `.env` file actually exists at that root — no `.env`, no block
4. the command does not already exclude `.env`

The refusal names the three ways to narrow the search.

## Two decisions worth reviewing

**Scope is decided by statting the argument, not by looking for a slash.** That is what keeps `grep -rn 'foo/bar' .` blocked: the pattern looks like a path and is not one, and reading it as a scope would let the exact command this exists to stop through unexamined.

**This guard sets `SilenceUsage`/`SilenceErrors` where the other guards do not.** The refusal text is the only thing the blocked agent reads before deciding what to do next, and cobra's usage dump buried it. The same wart affects `dangerous-command`; fixing it there changes shared behaviour for every guard, so it is left for its own change.

## Verification

End to end against the built binary:

| case | exit |
|---|---|
| repo-root grep, repo has `.env` | 2 (blocked) |
| scoped to `src/` | 0 |
| root search with `--exclude='.env*'` | 0 |
| `rg -u` at root | 2 (blocked) |
| plain `rg` at root | 0 |
| repo-root grep, repo has **no** `.env` | 0 |

Unit tests exercise the predicate chain as `runTapGuardBroadSearch` composes it, not just the individual matchers, and include every negative case above.

**Pre-existing failures, baselined honestly:** `internal/cmd` carries 8 failures on clean `origin/main` (`TestFindActivePatrol*`, `TestBurnPreviousPatrolWisps*`, `TestIsRigParked_WhenOnlyBeadLabelPresent`). I stashed this change and re-ran: the failing **set** is identical before and after, and the new tests pass.

Refs: gt-0x4a, gt-ti8k

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxzPCaz7gDX8d9BmDdFrG5