### PR TITLE
fix(health): measure bd's own read latency, as a distribution, not the server's

### DIFF
--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -595,7 +595,7 @@ func runDoltStatus(cmd *cobra.Command, args []string) error {
 		if running {
 			metrics := doltserver.GetHealthMetrics(townRoot)
 			fmt.Printf("\n  %s\n", style.Bold.Render("Resource Metrics:"))
-			fmt.Printf("    Query latency: %v\n", metrics.QueryLatency.Round(time.Millisecond))
+			printLatencyLines(metrics)
 			fmt.Printf("    Connections:   %d / %d (%.0f%%)\n",
 				metrics.Connections, metrics.MaxConnections, metrics.ConnectionPct)
 			if metrics.ReadOnly {
@@ -637,7 +637,7 @@ func runDoltStatus(cmd *cobra.Command, args []string) error {
 		// Resource metrics
 		metrics := doltserver.GetHealthMetrics(townRoot)
 		fmt.Printf("\n  %s\n", style.Bold.Render("Resource Metrics:"))
-		fmt.Printf("    Query latency: %v\n", metrics.QueryLatency.Round(time.Millisecond))
+		printLatencyLines(metrics)
 		fmt.Printf("    Connections:   %d / %d (%.0f%%)\n",
 			metrics.Connections, metrics.MaxConnections, metrics.ConnectionPct)
 		fmt.Printf("    Disk usage:    %s\n", metrics.DiskUsageHuman)
@@ -1840,5 +1840,30 @@ func printMigrateWispsResult(result *doltserver.MigrateWispsResult) {
 	}
 	if result.AgentsCopied == 0 && len(result.AuxTablesCreated) == 0 && !result.WispsTableCreated {
 		fmt.Printf("  %s Already migrated (no changes needed)\n", style.Bold.Render("✓"))
+	}
+}
+
+// printLatencyLines renders the two latency numbers with labels that cannot be
+// confused for one another.
+//
+// There used to be ONE line here reading "Query latency: 0s", and operators
+// read it as "beads is fast". It was measuring the :3307 server, which bd does
+// not use, and it sat at 0s through an outage in which bd swung from 210ms to
+// 6.7s (gt-iw5s, gt-kei9). The label was doing more damage than the missing
+// metric: a health check that reads green through a real outage is worse than
+// no health check, because it actively discourages looking.
+func printLatencyLines(metrics *doltserver.HealthMetrics) {
+	fmt.Printf("    Server latency: %v  (:3307 — bd does NOT use this server)\n",
+		metrics.QueryLatency.Round(time.Millisecond))
+
+	br := metrics.BeadsRead
+	switch {
+	case br.Err != nil:
+		fmt.Printf("    bd read latency: UNMEASURED (%v)\n", br.Err)
+	default:
+		fmt.Printf("    bd read latency: median %v, max %v over %d samples\n",
+			br.Median.Round(time.Millisecond),
+			br.Max.Round(time.Millisecond),
+			br.Samples)
 	}
 }

--- a/internal/cmd/vitals.go
+++ b/internal/cmd/vitals.go
@@ -48,7 +48,7 @@ func printVitalsDoltServers(townRoot string) {
 		fmt.Printf("  %s :%d  production  PID %d  %s  %d/%d conn  %v\n",
 			style.Success.Render("●"), config.Port, pid,
 			m.DiskUsageHuman, m.Connections, m.MaxConnections,
-			m.QueryLatency.Round(time.Millisecond))
+			beadsLatencySummary(m))
 		for _, w := range m.Warnings {
 			fmt.Printf("    %s %s\n", style.Warning.Render("!"), w)
 		}
@@ -260,4 +260,16 @@ func vitalsShortHome(path string) string {
 		return "~" + filepath.ToSlash(path[len(home):])
 	}
 	return path
+}
+
+// beadsLatencySummary renders bd's read latency for the one-line vitals view.
+//
+// It shows the MAX rather than the median on purpose. The median sits on a
+// tight ~200ms floor and barely moves while the town is suffering; the max is
+// the number that corresponds to an agent actually waiting.
+func beadsLatencySummary(m *doltserver.HealthMetrics) string {
+	if m.BeadsRead.Err != nil {
+		return "bd:unmeasured"
+	}
+	return fmt.Sprintf("bd:%v max", m.BeadsRead.Max.Round(time.Millisecond))
 }

--- a/internal/doltserver/beads_read_latency.go
+++ b/internal/doltserver/beads_read_latency.go
@@ -1,0 +1,159 @@
+package doltserver
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"time"
+)
+
+// beadsProbeSamples is how many reads a single latency measurement takes.
+//
+// One sample is not enough, and that is the whole point of this file rather
+// than a detail of it. Measured on this town 2026-09-03, the slow tail is
+// roughly 28% of invocations, so a single-shot probe reads fast about seven
+// times in ten BY CONSTRUCTION -- which is exactly how the pre-existing
+// server probe managed to report "0s" through a real outage. Five samples
+// miss the tail entirely only about 1 time in 5.
+const beadsProbeSamples = 5
+
+// beadsProbeTimeout bounds a single sample. The worst honestly-measured read
+// on this town was 6.7 seconds, so this must sit well above that or the probe
+// would truncate the very tail it exists to report.
+const beadsProbeTimeout = 30 * time.Second
+
+// BeadsReadLatency is a DISTRIBUTION of read latencies against the store bd
+// actually uses, not a single reading.
+//
+// It reports Median and Max because they answer different questions and the
+// Max is the one that matters. Latency here is bimodal, not noisy: a tight
+// floor around 200ms with independent excursions to several seconds. The
+// median tracks the floor and is nearly constant even while the town is
+// suffering; the max tracks the contention that actually costs agents time.
+type BeadsReadLatency struct {
+	// Samples is how many reads completed. Fewer than beadsProbeSamples means
+	// some failed; zero means the probe could not run at all.
+	Samples int `json:"samples"`
+
+	// Median is the typical read: the floor.
+	Median time.Duration `json:"median_ns"`
+
+	// Max is the worst read observed: the symptom.
+	Max time.Duration `json:"max_ns"`
+
+	// Err is non-nil when the probe could not run. A probe that cannot run
+	// must say so rather than report a zero, because a zero here is
+	// indistinguishable from a healthy store and that confusion is the
+	// defect this whole file addresses.
+	Err error `json:"-"`
+}
+
+// MeasureBeadsReadLatency times reads against the store bd ACTUALLY USES.
+//
+// WHY THIS EXISTS ALONGSIDE MeasureQueryLatency. MeasureQueryLatency times
+// SELECT active_branch() against the Dolt server on :3307 and is correct for
+// what it measures. But bd does not use that server. bd runs Dolt EMBEDDED out
+// of .beads/embeddeddolt (see the non-server path in beads' own
+// store_factory.go, which calls embeddeddolt.Open). So no query against :3307,
+// however expensive, can track how slow bd is -- the two are different
+// processes against different files. Making the server query heavier would not
+// have fixed it; only measuring a different thing does.
+//
+// HOW THE PROBE COMMAND WAS CHOSEN, because the obvious candidates are wrong
+// and the next person will otherwise repeat this. Measured against `bd show`
+// on 2026-09-03:
+//
+//	bd stats            FLAT at 117-187ms while bd show swung to 2736ms.
+//	                    Touches the store, never sees the contention. Shipping
+//	                    it would have been a second probe that reads green
+//	                    during the outage it exists to detect.
+//	bd list --limit 1   DOES spike (186ms to 1632ms). Chosen.
+//	bd ready --limit 1  Also spikes; equivalent, arbitrarily not chosen.
+//
+// A NOTE THAT LOOKS LIKE A CONTRADICTION AND IS NOT. `bd list` run from the
+// town root returns a PARTIAL row set -- it can omit a rig bead that `bd show`
+// resolves (gt-irl). That is irrelevant here because this code TIMES the
+// command and never reads a single row of its output. It is used as a
+// stopwatch, not as a query.
+//
+// The returned durations are RAW WALL TIME and include roughly 27ms of bd
+// process startup (measured: `bd --version` is 27ms). That is deliberately not
+// subtracted: it is a real cost every agent pays, it is small against a 200ms
+// floor, and it is irrelevant against a multi-second tail. Subtracting a
+// constant nobody can re-verify later would make the number less honest, not
+// more precise.
+func MeasureBeadsReadLatency(townRoot string) BeadsReadLatency {
+	bd, err := exec.LookPath("bd")
+	if err != nil {
+		return BeadsReadLatency{Err: fmt.Errorf("bd not on PATH: %w", err)}
+	}
+
+	samples := make([]time.Duration, 0, beadsProbeSamples)
+	var lastErr error
+	for i := 0; i < beadsProbeSamples; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), beadsProbeTimeout)
+		cmd := exec.CommandContext(ctx, bd, "list", "--limit", "1")
+		cmd.Dir = townRoot
+		start := time.Now()
+		runErr := cmd.Run()
+		elapsed := time.Since(start)
+		cancel()
+
+		if runErr != nil {
+			lastErr = runErr
+			continue
+		}
+		samples = append(samples, elapsed)
+	}
+
+	if len(samples) == 0 {
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no samples completed")
+		}
+		return BeadsReadLatency{Err: fmt.Errorf("probing bd read latency: %w", lastErr)}
+	}
+
+	return summarizeSamples(samples)
+}
+
+// summarizeSamples reduces raw sample durations to the reported distribution.
+// Split out from MeasureBeadsReadLatency so the reduction can be tested
+// without spawning bd.
+func summarizeSamples(samples []time.Duration) BeadsReadLatency {
+	if len(samples) == 0 {
+		return BeadsReadLatency{Err: fmt.Errorf("no samples completed")}
+	}
+	sorted := make([]time.Duration, len(samples))
+	copy(sorted, samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	return BeadsReadLatency{
+		Samples: len(sorted),
+		Median:  sorted[len(sorted)/2],
+		Max:     sorted[len(sorted)-1],
+	}
+}
+
+// BeadsLatencyWarning returns the warning an operator should see for this
+// reading, or "" when there is nothing to say.
+//
+// It fires on the MAX, never the median. Latency here is bimodal: a tight
+// floor around 200ms with independent excursions to several seconds. The
+// median sits on the floor and barely moves while the town is suffering, so a
+// median threshold is blind to the tail by construction.
+//
+// A probe that could not run returns a warning rather than silence, because a
+// zero reading is indistinguishable from a fast store and that confusion is
+// the entire defect this file exists to correct.
+func BeadsLatencyWarning(br BeadsReadLatency, threshold time.Duration) string {
+	switch {
+	case br.Err != nil:
+		return fmt.Sprintf("bd read latency UNMEASURED (%v) — this is not a healthy reading, it is no reading", br.Err)
+	case br.Max > threshold:
+		return fmt.Sprintf("bd read latency spiked to %v (median %v over %d samples) — agents are waiting on store contention",
+			br.Max.Round(time.Millisecond), br.Median.Round(time.Millisecond), br.Samples)
+	default:
+		return ""
+	}
+}

--- a/internal/doltserver/beads_read_latency_test.go
+++ b/internal/doltserver/beads_read_latency_test.go
@@ -1,0 +1,156 @@
+package doltserver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ms(n int) time.Duration { return time.Duration(n) * time.Millisecond }
+
+func TestSummarizeSamples(t *testing.T) {
+	tests := []struct {
+		name       string
+		samples    []time.Duration
+		wantN      int
+		wantMedian time.Duration
+		wantMax    time.Duration
+		wantErr    bool
+	}{
+		{
+			// The shape this probe exists to catch: a tight floor with one
+			// excursion. The median must stay on the floor and the max must
+			// carry the spike, because that difference is the whole signal.
+			name:       "bimodal, one spike",
+			samples:    []time.Duration{ms(196), ms(190), ms(1939), ms(205), ms(198)},
+			wantN:      5,
+			wantMedian: ms(198),
+			wantMax:    ms(1939),
+		},
+		{
+			name:       "input order does not matter",
+			samples:    []time.Duration{ms(1939), ms(205), ms(198), ms(196), ms(190)},
+			wantN:      5,
+			wantMedian: ms(198),
+			wantMax:    ms(1939),
+		},
+		{
+			name:       "all fast",
+			samples:    []time.Duration{ms(190), ms(196), ms(198)},
+			wantN:      3,
+			wantMedian: ms(196),
+			wantMax:    ms(198),
+		},
+		{
+			name:       "single sample",
+			samples:    []time.Duration{ms(204)},
+			wantN:      1,
+			wantMedian: ms(204),
+			wantMax:    ms(204),
+		},
+		{
+			// Zero samples must be an ERROR, never a zero-valued reading. A
+			// zero here would render as a very fast store, which is the exact
+			// confusion this file exists to remove.
+			name:    "no samples is an error, not a zero",
+			samples: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeSamples(tt.samples)
+			if tt.wantErr {
+				if got.Err == nil {
+					t.Fatalf("summarizeSamples(empty) = %+v, want an error", got)
+				}
+				if got.Median != 0 || got.Max != 0 || got.Samples != 0 {
+					t.Errorf("an errored reading must carry no numbers, got %+v", got)
+				}
+				return
+			}
+			if got.Err != nil {
+				t.Fatalf("unexpected error: %v", got.Err)
+			}
+			if got.Samples != tt.wantN {
+				t.Errorf("Samples = %d, want %d", got.Samples, tt.wantN)
+			}
+			if got.Median != tt.wantMedian {
+				t.Errorf("Median = %v, want %v", got.Median, tt.wantMedian)
+			}
+			if got.Max != tt.wantMax {
+				t.Errorf("Max = %v, want %v", got.Max, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestSummarizeSamplesDoesNotMutateInput guards the caller's slice, since the
+// samples may be reused for other reporting later.
+func TestSummarizeSamplesDoesNotMutateInput(t *testing.T) {
+	in := []time.Duration{ms(1939), ms(190), ms(205)}
+	summarizeSamples(in)
+	if in[0] != ms(1939) || in[1] != ms(190) || in[2] != ms(205) {
+		t.Errorf("input slice was reordered: %v", in)
+	}
+}
+
+func TestBeadsLatencyWarning(t *testing.T) {
+	threshold := time.Second
+
+	t.Run("quiet when the max is under threshold", func(t *testing.T) {
+		got := BeadsLatencyWarning(BeadsReadLatency{Samples: 5, Median: ms(196), Max: ms(662)}, threshold)
+		if got != "" {
+			t.Errorf("want no warning for a 662ms max, got %q", got)
+		}
+	})
+
+	t.Run("fires on the MAX even when the median is on the floor", func(t *testing.T) {
+		// The load-bearing case. A median-based threshold would never fire
+		// here, and this is precisely the reading a suffering town produces.
+		got := BeadsLatencyWarning(BeadsReadLatency{Samples: 5, Median: ms(190), Max: ms(1939)}, threshold)
+		if got == "" {
+			t.Fatal("want a warning when max is 1.939s, got none")
+		}
+		if !strings.Contains(got, "1.939s") {
+			t.Errorf("warning must name the max: %q", got)
+		}
+		if !strings.Contains(got, "190ms") {
+			t.Errorf("warning must also give the median for context: %q", got)
+		}
+	})
+
+	t.Run("an unmeasurable probe warns rather than reading healthy", func(t *testing.T) {
+		got := BeadsLatencyWarning(BeadsReadLatency{Err: errors.New("bd not on PATH")}, threshold)
+		if got == "" {
+			t.Fatal("an errored probe must warn, not stay silent")
+		}
+		if !strings.Contains(got, "UNMEASURED") {
+			t.Errorf("warning must say the reading is absent, not fine: %q", got)
+		}
+	})
+
+	t.Run("a zeroed reading with an error never reads as fast", func(t *testing.T) {
+		// Defence against the regression this whole file addresses: a zero
+		// that renders as a healthy store.
+		got := BeadsLatencyWarning(BeadsReadLatency{Err: errors.New("no samples completed")}, threshold)
+		if strings.Contains(got, "0s") {
+			t.Errorf("an unmeasured probe must not report a duration: %q", got)
+		}
+	})
+}
+
+// TestMeasureBeadsReadLatencyFailsLoudly checks the no-bd path end to end.
+// A probe that cannot run must return an error rather than a zero reading.
+func TestMeasureBeadsReadLatencyFailsLoudly(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	got := MeasureBeadsReadLatency(t.TempDir())
+	if got.Err == nil {
+		t.Fatalf("want an error when bd is not on PATH, got %+v", got)
+	}
+	if got.Samples != 0 || got.Median != 0 || got.Max != 0 {
+		t.Errorf("an errored probe must carry no numbers, got %+v", got)
+	}
+}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3950,10 +3950,24 @@ type HealthMetrics struct {
 	// DiskUsageHuman is a human-readable disk usage string.
 	DiskUsageHuman string `json:"disk_usage_human"`
 
-	// QueryLatency is the time taken for a SELECT active_branch() round-trip.
+	// QueryLatency is the time taken for a SELECT active_branch() round-trip
+	// AGAINST THE :3307 SERVER.
+	//
+	// READ THE NEXT SENTENCE BEFORE USING THIS FOR ANYTHING. bd does NOT use
+	// that server -- it runs Dolt embedded out of .beads/embeddeddolt -- so
+	// this number is a fact about the server and says NOTHING about how slow
+	// bd is. It read a steady "0s" through a real outage in which bd swung
+	// from 210ms to 6.7s. For bd's latency use BeadsRead below.
+	//
 	// Note: json.Marshal emits nanoseconds for time.Duration. Consumers should use
 	// ServerHealth.LatencyMs (int64 milliseconds) for JSON output instead.
 	QueryLatency time.Duration `json:"query_latency_ns"`
+
+	// BeadsRead is the latency DISTRIBUTION of reads against the store bd
+	// actually uses. This is the number an operator means when they ask
+	// whether beads is slow. See MeasureBeadsReadLatency for why it is a
+	// distribution rather than a single sample.
+	BeadsRead BeadsReadLatency `json:"beads_read"`
 
 	// ReadOnly indicates whether the server is in read-only mode.
 	// When true, the server accepts reads but rejects all writes.
@@ -3987,14 +4001,28 @@ func GetHealthMetrics(townRoot string) *HealthMetrics {
 		metrics.MaxConnections = 1000 // Dolt default
 	}
 
-	// 1. Query latency: time a SELECT active_branch()
+	// 1. Server query latency: time a SELECT active_branch() against :3307.
+	// A fact about the SERVER only. bd does not use it; see BeadsRead below.
 	latency, err := MeasureQueryLatency(townRoot)
 	if err == nil {
 		metrics.QueryLatency = latency
 		if latency > 1*time.Second {
 			metrics.Warnings = append(metrics.Warnings,
-				fmt.Sprintf("query latency %v exceeds 1s threshold — server may be under stress", latency.Round(time.Millisecond)))
+				fmt.Sprintf("server query latency %v exceeds 1s threshold — server may be under stress", latency.Round(time.Millisecond)))
 		}
+	}
+
+	// 1b. bd read latency: the store bd ACTUALLY uses.
+	//
+	// The warning fires on the MAX, not the median, and that is deliberate.
+	// Latency here is bimodal: a tight ~200ms floor with independent
+	// excursions to several seconds. The median sits on the floor and barely
+	// moves while the town is suffering, so a median-based threshold is blind
+	// to the tail BY CONSTRUCTION -- which is the same shape of mistake as
+	// probing the wrong server, arriving by a different route.
+	metrics.BeadsRead = MeasureBeadsReadLatency(townRoot)
+	if w := BeadsLatencyWarning(metrics.BeadsRead, 1*time.Second); w != "" {
+		metrics.Warnings = append(metrics.Warnings, w)
 	}
 
 	// 2. Connection count


### PR DESCRIPTION
## The bug

`gt dolt status` reported **`Query latency: 0s`** while `bd` swung from 210ms to **6.7 seconds**.

The probe was not broken. `MeasureQueryLatency` times `SELECT active_branch()` against the Dolt server on `:3307`, accurately. **bd does not use that server** — it runs Dolt embedded out of `.beads/embeddeddolt` (beads' own `store_factory.go` takes `embeddeddolt.Open` on the non-server path). Different processes, different files. No query against `:3307`, however expensive, can track how slow bd is; making the server query heavier would not have helped.

A health check that reads green through a real outage is worse than no health check, because it actively discourages looking.

## Why a distribution, not just a second number

**This is the part worth reviewing.** Pointing a one-shot probe at the correct store would *still* have been a false green.

Measured on a live town, the spikes **do not correlate across commands**:

| sample | `bd show` | `bd list --limit 1` | `bd ready --limit 1` |
|---|---|---|---|
| 4 | 3383ms | 1091ms | 186ms |
| 7 | 215ms | 188ms | 1538ms |
| **11** | **6688ms** | **251ms** | **194ms** |

Each invocation independently draws a fast or slow outcome. There is no "the store is slow right now" period for a single sample to land in — which is exactly what a one-shot probe assumes.

The tail is ~28% of invocations, so **one sample reads fast about seven times in ten by construction**. Five samples miss it about one time in five.

Hence median *and* max — and **the warning fires on the max**. The median sits on a tight ~200ms floor and barely moves while the town is suffering, so a median threshold is blind to the tail: the same shape of mistake as probing the wrong server, arriving by a different route.

## How the probe command was chosen

The bead this fixes warns: *do not resurrect a probe without evidence it tracks the symptom.* So I validated candidates **before** writing code.

| candidate | result |
|---|---|
| `bd stats` | **FLAT** at 117–187ms while `bd show` swung to 2736ms. My first choice — would have shipped a second probe that reads green during the outage it exists to detect. |
| `bd list --limit 1` | **spikes** (186ms → 1632ms). Chosen. |
| `bd ready --limit 1` | also spikes; equivalent, arbitrarily not chosen. |

**Looks like a contradiction and is not:** `bd list` from the town root returns a partial row set and can omit a bead `bd show` resolves. Irrelevant here — this code *times* the command and never reads a row. A stopwatch, not a query. The code comment says so, because otherwise the next reader will correctly flag it.

## Verified end to end on the live town

```
Server latency: 0s  (:3307 — bd does NOT use this server)
bd read latency: median 190ms, max 1.939s over 5 samples
! bd read latency spiked to 1.939s (median 190ms over 5 samples)
```

The old output for that same moment was `Query latency: 0s` and nothing else.

An unmeasurable probe **warns** rather than reporting zero — a zero is indistinguishable from a fast store, which is the confusion being fixed.

**Cost:** the daemon calls `GetHealthMetrics` on its 10-minutely tick (`internal/daemon/daemon.go:1052`), so ~1s of sampling every 10 minutes.

## Known gap, deliberately not fixed here

The OTel gauge at `daemon/metrics.go:151` still receives `QueryLatency`, so the exported dolt-latency metric remains the server's. Adding a bd gauge means touching observable-gauge registration I have not read, and half-plumbed observability I cannot verify end to end is worse than a gap I name.

## Tests

New unit tests cover the reduction and the warning decision, including the load-bearing case (fires on max when the median is on the floor) and that an errored probe never renders as fast.

**Pre-existing failures, baselined honestly.** `internal/doltserver` (`TestWaitForCatalog_NoServer`, `TestFindBrokenWorkspaces_*`) and `internal/cmd` (8 `TestFindActivePatrol*` / `TestBurnPreviousPatrolWisps*` / `TestIsRigParked_*`) fail on clean `origin/main`. Stashed this change and re-ran: the failing **set** is identical before and after. `internal/daemon` passes.

Refs: gt-iw5s, gt-5hf1, gt-kei9, gt-k14m

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxzPCaz7gDX8d9BmDdFrG5