### PR TITLE
feat: add grok CLI as a built-in agent preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`grok agent --always-approve stdio`), and Gas Town hooks in `.grok/hooks/`.
   This is not `groq-compound` (Claude CLI proxied to Groq).
 
+### Fixed
+
+- **Grok polecats no longer stall at an empty composer after finishing work.**
+  Autonomous Grok Stop hooks now run `gt tap polecat-stop-check` (the same
+  idle-polecat safety net Claude polecats already had). Idle detection uses
+  the boxed composer prefix `│ ❯` plus Grok's `Esc:cancel` busy marker, so
+  `gt nudge --mode=wait-idle` no longer falls back to queue mode or false-idles
+  on scrollback `❯ [GAS TOWN]…` lines. `GetSessionActivity` prefers
+  `window_activity` when `session_activity` is frozen at session creation.
+
 ## [1.2.1] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Grok Build CLI preset** (`grok`) — first-class runtime for the `grok` binary
+  (`--always-approve --trust --no-leader`), session resume/continue, ACP
+  (`grok agent --always-approve stdio`), and Gas Town hooks in `.grok/hooks/`.
+  This is not `groq-compound` (Claude CLI proxied to Groq).
+
 ## [1.2.1] - 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -504,11 +504,15 @@ gt feed                     # Real-time activity feed (TUI)
 gt feed --problems          # Start in problems view (stuck agent detection)
 ```
 
-**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`
+**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`, `grok`
 
 The `kiro` preset launches `kiro-cli chat --trust-all-tools`, supports Kiro's
 documented `--resume` / `--resume-id` session flags, and does not install Kiro
 hooks or `.kiro` project files.
+
+The `grok` preset launches the Grok Build CLI (`grok --always-approve --trust --no-leader`),
+installs hooks in `.grok/hooks/gastown.json`, and is not the `groq-compound` preset
+(Claude CLI proxied to Groq's API).
 
 ### Convoy (Work Tracking)
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -29,6 +29,7 @@ Native source installs require these host tools. Homebrew and Docker installs pr
 | **Codex CLI** (optional) | latest | `codex --version` | See [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli) |
 | **OpenCode CLI** (optional) | latest | `opencode --version` | See [opencode.ai](https://opencode.ai) |
 | **GitHub Copilot CLI** (optional) | latest | `copilot --version` | See [cli.github.com](https://cli.github.com) (requires Copilot seat) |
+| **Grok Build CLI** (optional) | latest | `grok --version` | See [x.ai/cli](https://x.ai/cli) |
 
 ## Installing Prerequisites
 
@@ -195,7 +196,7 @@ gt status              # Show workspace status
 
 ### Step 5: Configure Agents (Optional)
 
-Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`) plus custom agent aliases.
+Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `grok`) plus custom agent aliases.
 
 ```bash
 # List available agents

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -533,6 +533,9 @@ Current agent capabilities at a glance:
 | Auggie | No | `--resume` (flag) | No | No | arg | auggie |
 | AMP | No | `threads continue` (subcmd) | No | No | arg | amp |
 | OpenCode | Yes (plugin JS) | No | `run` subcmd | No | none | opencode, node, bun |
+| Grok | Yes (`.grok/hooks/gastown.json`) | `--resume` / `--continue` (flag) | `-p` / `--output-format json` | No* | arg | grok |
+
+\*Grok CLI supports `--fork-session`, but the builtin preset leaves it off because `gt seance --talk` currently picks the first fork-capable preset (Claude).
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -470,7 +470,10 @@ Kiro hooks or `.kiro` project files for this preset.
 The `grok` preset launches Grok Build CLI (`grok --always-approve --trust --no-leader`)
 with hooks in `.grok/hooks/gastown.json`. It is not `groq-compound` (Claude CLI
 proxied to Groq). Session restore uses `--continue`; `gt seance --talk` stays
-Claude-only (`SupportsForkSession` is false).
+Claude-only (`SupportsForkSession` is false). Idle detection uses the boxed
+composer prefix `│ ❯` and the `Esc:cancel` busy marker; autonomous Stop hooks
+run `gt tap polecat-stop-check` so a finished polecat cannot sit at an empty
+prompt.
 
 > **Note on GitHub Copilot**: The `copilot` preset uses executable lifecycle hooks in
 > `.github/hooks/gastown.json` (`sessionStart`, `userPromptSubmitted`, `preToolUse`,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -461,11 +461,16 @@ gt config agent remove <name>     # Remove custom agent (built-ins protected)
 gt config default-agent [name]    # Get or set town default agent
 ```
 
-**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `grok`
 
 The `kiro` preset launches `kiro-cli chat --trust-all-tools` and uses Kiro's
 documented `--resume` / `--resume-id` session flags. Gas Town does not install
 Kiro hooks or `.kiro` project files for this preset.
+
+The `grok` preset launches Grok Build CLI (`grok --always-approve --trust --no-leader`)
+with hooks in `.grok/hooks/gastown.json`. It is not `groq-compound` (Claude CLI
+proxied to Groq). Session restore uses `--continue`; `gt seance --talk` stays
+Claude-only (`SupportsForkSession` is false).
 
 > **Note on GitHub Copilot**: The `copilot` preset uses executable lifecycle hooks in
 > `.github/hooks/gastown.json` (`sessionStart`, `userPromptSubmitted`, `preToolUse`,

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -742,7 +742,7 @@ func verifyShutdown(t *tmux.Tmux, townRoot string) []string {
 	return respawned
 }
 
-// findOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot/node)
+// findOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot/grok/node)
 // that are running in the town directory but aren't associated with any active tmux session.
 // This can happen when tmux sessions are killed but child processes don't terminate.
 //
@@ -778,7 +778,7 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 		// Only consider known Gas Town process names
 		comm := strings.ToLower(fields[1])
 		switch comm {
-		case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot", "node":
+		case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot", "grok", "node":
 			// Potential Gas Town process
 		default:
 			continue

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -488,11 +488,16 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			PromptFlag: "-p",
 			OutputFlag: "--output-format json",
 		},
-		PromptMode:           "arg",
-		ConfigDir:            ".grok",
-		HooksProvider:        "grok",
-		HooksDir:             ".grok/hooks",
-		HooksSettingsFile:    "gastown.json",
+		PromptMode:        "arg",
+		ConfigDir:         ".grok",
+		HooksProvider:     "grok",
+		HooksDir:          ".grok/hooks",
+		HooksSettingsFile: "gastown.json",
+		// Boxed composer ("│ ❯ … │"), not Claude's bare "❯ ". Grok scrollback
+		// user lines are "❯ [GAS TOWN]…" and the composer stays visible while
+		// busy, so idle detection must use this prefix plus the Esc:cancel
+		// busy marker. Empty prefix made wait-idle fall back to queue mode.
+		ReadyPromptPrefix:    "│ ❯",
 		ReadyDelayMs:         5000,
 		InstructionsFile:     "AGENTS.md",
 		HasTurnBoundaryDrain: true,

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -44,6 +44,9 @@ const (
 	// AgentOmp is Oh My Pi (OMP) — Pi fork with hook-based lifecycle.
 	// Inspired by github.com/ProbabilityEngineer/pi-mono gastown integration.
 	AgentOmp AgentPreset = "omp"
+	// AgentGrok is the Grok Build CLI (binary "grok"). This is not groq-compound,
+	// which proxies the Claude CLI to Groq's API.
+	AgentGrok AgentPreset = "grok"
 	// AgentMistral is Mistral Vibe CLI.
 	AgentMistral AgentPreset = "vibe"
 	// AgentGroqCompound routes the Claude CLI to Groq's compound-beta model via
@@ -465,6 +468,39 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		SupportsForkSession: false,
 		NonInteractive: &NonInteractiveConfig{
 			PromptFlag: "--prompt",
+		},
+	},
+	AgentGrok: {
+		Name:    AgentGrok,
+		Command: "grok",
+		// --always-approve: skip tool permission prompts (documented; --yolo is a hidden alias).
+		// --trust: project hooks in .grok/hooks require folder trust.
+		// --no-leader: do not share a Grok leader process across Gas Town roles.
+		Args:                []string{"--always-approve", "--trust", "--no-leader"},
+		ProcessNames:        []string{"grok"},
+		SessionIDEnv:        "", // GROK_SESSION_ID is process/hook env, not tmux session env
+		ResumeFlag:          "--resume",
+		ContinueFlag:        "--continue",
+		ResumeStyle:         "flag",
+		SupportsHooks:       true,
+		SupportsForkSession: false, // CLI has --fork-session; seance is Claude-only
+		NonInteractive: &NonInteractiveConfig{
+			PromptFlag: "-p",
+			OutputFlag: "--output-format json",
+		},
+		PromptMode:           "arg",
+		ConfigDir:            ".grok",
+		HooksProvider:        "grok",
+		HooksDir:             ".grok/hooks",
+		HooksSettingsFile:    "gastown.json",
+		ReadyDelayMs:         5000,
+		InstructionsFile:     "AGENTS.md",
+		HasTurnBoundaryDrain: true,
+		EscapeCancelsRequest: true,
+		ACP: &ACPConfig{
+			Mode:    ACPModeSubcommand,
+			Command: "agent",
+			Args:    []string{"--always-approve", "stdio"},
 		},
 	},
 	AgentMistral: {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1008,6 +1008,11 @@ func TestGrokAgentPreset(t *testing.T) {
 	if info.HooksSettingsFile != "gastown.json" {
 		t.Errorf("grok HooksSettingsFile = %q, want gastown.json", info.HooksSettingsFile)
 	}
+	// Grok's composer is a boxed "│ ❯ … │". Using Claude's bare "❯ " false-idles
+	// on scrollback user lines ("❯ [GAS TOWN]…") while the session is working.
+	if info.ReadyPromptPrefix != "│ ❯" {
+		t.Errorf("grok ReadyPromptPrefix = %q, want %q (boxed composer)", info.ReadyPromptPrefix, "│ ❯")
+	}
 	if info.ReadyDelayMs != 5000 {
 		t.Errorf("grok ReadyDelayMs = %d, want 5000", info.ReadyDelayMs)
 	}

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -32,7 +32,7 @@ func TestBuiltInAgentPresetSummary(t *testing.T) {
 func TestBuiltinPresets(t *testing.T) {
 	t.Parallel()
 	// Ensure all built-in presets are accessible
-	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp, AgentGrok}
 
 	for _, preset := range presets {
 		info := GetAgentPreset(preset)
@@ -71,6 +71,7 @@ func TestGetAgentPresetByName(t *testing.T) {
 		{"copilot", AgentCopilot, false},   // Built-in GitHub Copilot CLI agent
 		{"pi", AgentPi, false},             // Pi Coding Agent
 		{"omp", AgentOmp, false},           // Oh My Pi
+		{"grok", AgentGrok, false},         // Grok Build CLI (not groq-compound)
 		{"unknown", "", true},
 	}
 
@@ -101,6 +102,7 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 		{AgentCodex, "codex"},
 		{AgentKiro, "kiro-cli"},
 		{AgentCursor, "cursor-agent"},
+		{AgentGrok, "grok"},
 		{AgentAuggie, "auggie"},
 		{AgentAmp, "amp"},
 		{AgentCopilot, "copilot"},
@@ -657,6 +659,13 @@ func TestBuildResumeCommand(t *testing.T) {
 			contains:  []string{"copilot", "--yolo", "--resume", "cea0d5f0-662a-4a98-9585-060b9d2a7a19"},
 		},
 		{
+			name:      "grok flag style",
+			agentName: "grok",
+			sessionID: "0193a1c2-0000-7000-8000-000000000001",
+			wantEmpty: false,
+			contains:  []string{"grok", "--always-approve", "--trust", "--no-leader", "--resume", "0193a1c2-0000-7000-8000-000000000001"},
+		},
+		{
 			name:      "unknown agent",
 			agentName: "unknown-agent",
 			sessionID: "session-123",
@@ -751,6 +760,7 @@ func TestGetProcessNames(t *testing.T) {
 		{"opencode", []string{"opencode", "node", "bun"}},
 		{"copilot", []string{"copilot"}},
 		{"pi", []string{"pi", "node", "bun"}},
+		{"grok", []string{"grok"}},
 		{"unknown", []string{"node", "claude"}}, // Falls back to Claude's process
 	}
 
@@ -773,7 +783,7 @@ func TestGetProcessNames(t *testing.T) {
 func TestListAgentPresetsMatchesConstants(t *testing.T) {
 	t.Parallel()
 	// Ensure all AgentPreset constants are returned by ListAgentPresets
-	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp, AgentGrok}
 	presets := ListAgentPresets()
 
 	// Convert to map for quick lookup
@@ -839,6 +849,11 @@ func TestAgentCommandGeneration(t *testing.T) {
 			preset:       AgentCopilot,
 			wantCommand:  "copilot",
 			wantContains: []string{"--yolo"},
+		},
+		{
+			preset:       AgentGrok,
+			wantCommand:  "grok",
+			wantContains: []string{"--always-approve", "--trust", "--no-leader"},
 		},
 	}
 
@@ -921,6 +936,101 @@ func TestCursorAgentPreset(t *testing.T) {
 	}
 	if info.ReadyDelayMs != 5000 {
 		t.Errorf("cursor ReadyDelayMs = %d, want 5000 (nudge poller + WaitForRuntimeReady)", info.ReadyDelayMs)
+	}
+}
+
+func TestGrokAgentPreset(t *testing.T) {
+	t.Parallel()
+	info := GetAgentPreset(AgentGrok)
+	if info == nil {
+		t.Fatal("grok preset not found")
+	}
+	if info.Name != AgentGrok {
+		t.Errorf("grok Name = %q, want grok", info.Name)
+	}
+	if info.Command != "grok" {
+		t.Errorf("grok command = %q, want grok", info.Command)
+	}
+	wantArgs := []string{"--always-approve", "--trust", "--no-leader"}
+	if len(info.Args) != len(wantArgs) {
+		t.Fatalf("grok args = %v, want %v", info.Args, wantArgs)
+	}
+	for i, arg := range wantArgs {
+		if info.Args[i] != arg {
+			t.Errorf("grok args[%d] = %q, want %q", i, info.Args[i], arg)
+		}
+	}
+	if len(info.ProcessNames) != 1 || info.ProcessNames[0] != "grok" {
+		t.Errorf("grok ProcessNames = %v, want [grok]", info.ProcessNames)
+	}
+	if info.SessionIDEnv != "" {
+		t.Errorf("grok SessionIDEnv = %q, want empty (restore uses --continue)", info.SessionIDEnv)
+	}
+	if info.ResumeFlag != "--resume" {
+		t.Errorf("grok ResumeFlag = %q, want --resume", info.ResumeFlag)
+	}
+	if info.ContinueFlag != "--continue" {
+		t.Errorf("grok ContinueFlag = %q, want --continue", info.ContinueFlag)
+	}
+	if info.ResumeStyle != "flag" {
+		t.Errorf("grok ResumeStyle = %q, want flag", info.ResumeStyle)
+	}
+	if !info.SupportsHooks {
+		t.Error("grok SupportsHooks = false, want true")
+	}
+	if info.SupportsForkSession {
+		t.Error("grok SupportsForkSession = true, want false (seance is Claude-only)")
+	}
+	if info.NonInteractive == nil {
+		t.Fatal("grok NonInteractive is nil")
+	}
+	if info.NonInteractive.PromptFlag != "-p" {
+		t.Errorf("grok PromptFlag = %q, want -p", info.NonInteractive.PromptFlag)
+	}
+	if info.NonInteractive.OutputFlag != "--output-format json" {
+		t.Errorf("grok OutputFlag = %q, want --output-format json", info.NonInteractive.OutputFlag)
+	}
+	if info.PromptMode != "arg" {
+		t.Errorf("grok PromptMode = %q, want arg", info.PromptMode)
+	}
+	if info.ConfigDir != ".grok" {
+		t.Errorf("grok ConfigDir = %q, want .grok", info.ConfigDir)
+	}
+	if info.ConfigDirEnv != "" {
+		t.Errorf("grok ConfigDirEnv = %q, want empty (auth lives in ~/.grok)", info.ConfigDirEnv)
+	}
+	if info.HooksProvider != "grok" {
+		t.Errorf("grok HooksProvider = %q, want grok", info.HooksProvider)
+	}
+	if info.HooksDir != ".grok/hooks" {
+		t.Errorf("grok HooksDir = %q, want .grok/hooks", info.HooksDir)
+	}
+	if info.HooksSettingsFile != "gastown.json" {
+		t.Errorf("grok HooksSettingsFile = %q, want gastown.json", info.HooksSettingsFile)
+	}
+	if info.ReadyDelayMs != 5000 {
+		t.Errorf("grok ReadyDelayMs = %d, want 5000", info.ReadyDelayMs)
+	}
+	if info.InstructionsFile != "AGENTS.md" {
+		t.Errorf("grok InstructionsFile = %q, want AGENTS.md", info.InstructionsFile)
+	}
+	if !info.HasTurnBoundaryDrain {
+		t.Error("grok HasTurnBoundaryDrain = false, want true (UserPromptSubmit hook)")
+	}
+	if !info.EscapeCancelsRequest {
+		t.Error("grok EscapeCancelsRequest = false, want true")
+	}
+	if info.ACP == nil {
+		t.Fatal("grok ACP is nil")
+	}
+	if info.ACP.Mode != "" && info.ACP.Mode != ACPModeSubcommand {
+		t.Errorf("grok ACP.Mode = %q, want subcommand or empty", info.ACP.Mode)
+	}
+	if info.ACP.Command != "agent" {
+		t.Errorf("grok ACP.Command = %q, want agent", info.ACP.Command)
+	}
+	if len(info.ACP.Args) != 2 || info.ACP.Args[0] != "--always-approve" || info.ACP.Args[1] != "stdio" {
+		t.Errorf("grok ACP.Args = %v, want [--always-approve stdio]", info.ACP.Args)
 	}
 }
 

--- a/internal/config/grok_agent_cli_test.go
+++ b/internal/config/grok_agent_cli_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveGrokForCLIPTest returns a real grok binary path. test_main_test.go prepends
+// tiny PATH stubs that shadow the real CLI; we skip those dirs and prefer GT_GROK_BIN when set.
+func resolveGrokForCLIPTest(t *testing.T) (string, []byte) {
+	t.Helper()
+	if p := os.Getenv("GT_GROK_BIN"); p != "" {
+		out, err := exec.Command(p, "--help").CombinedOutput()
+		if err != nil {
+			t.Fatalf("GT_GROK_BIN --help: %v\n%s", err, out)
+		}
+		return p, out
+	}
+	stubDir := os.Getenv("GT_AGENT_STUB_BIN_DIR")
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		if stubDir != "" && dir == stubDir {
+			continue
+		}
+		p := filepath.Join(dir, "grok")
+		info, err := os.Stat(p)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		out, err := exec.Command(p, "--help").CombinedOutput()
+		if err != nil {
+			continue
+		}
+		if len(out) >= 200 && strings.Contains(string(out), "Usage:") {
+			return p, out
+		}
+	}
+	return "", nil
+}
+
+// TestGrokAgentCLIPresetMatchesHelp verifies the built-in AgentGrok preset stays aligned with
+// the Grok Build CLI when `grok` is installed (curl -fsSL https://x.ai/cli/install.sh | bash).
+func TestGrokAgentCLIPresetMatchesHelp(t *testing.T) {
+	path, out := resolveGrokForCLIPTest(t)
+	if path == "" {
+		t.Skip("real grok not found outside test stubs; install Grok CLI or set GT_GROK_BIN")
+	}
+
+	t.Logf("grok CLI contract using %s", path)
+	help := strings.ToLower(string(out))
+
+	info := GetAgentPreset(AgentGrok)
+	if info == nil {
+		t.Fatal("grok preset not found")
+	}
+
+	for _, needle := range []string{
+		"--always-approve",
+		"--resume",
+		"--continue",
+		"--output-format",
+		"--single",
+	} {
+		if !strings.Contains(help, strings.ToLower(needle)) {
+			t.Errorf("grok --help missing %q (preset may be stale vs CLI)", needle)
+		}
+	}
+	// --trust and --no-leader are accepted by the CLI but omitted from --help.
+	for _, flag := range []string{"--trust", "--no-leader"} {
+		if err := exec.Command(path, flag, "--version").Run(); err != nil {
+			t.Errorf("grok %s --version failed (preset arg %s may be stale): %v", flag, flag, err)
+		}
+	}
+	if !strings.Contains(help, "output-format") || !strings.Contains(help, "json") {
+		t.Errorf("grok --help should document --output-format with json")
+	}
+
+	if info.ResumeFlag != "--resume" {
+		t.Errorf("preset ResumeFlag = %q, want --resume", info.ResumeFlag)
+	}
+	if info.ContinueFlag != "--continue" {
+		t.Errorf("preset ContinueFlag = %q, want --continue", info.ContinueFlag)
+	}
+	if info.NonInteractive == nil {
+		t.Fatal("preset NonInteractive is nil")
+	}
+	if info.NonInteractive.PromptFlag != "-p" {
+		t.Errorf("preset PromptFlag %q should match CLI -p/--single for headless use", info.NonInteractive.PromptFlag)
+	}
+	of := strings.Fields(info.NonInteractive.OutputFlag)
+	if len(of) < 2 || of[0] != "--output-format" {
+		t.Fatalf("preset OutputFlag = %q, want '--output-format …'", info.NonInteractive.OutputFlag)
+	}
+	if !strings.Contains(help, strings.TrimPrefix(of[0], "-")) {
+		t.Errorf("grok --help should document %s", of[0])
+	}
+
+	if info.HooksDir != ".grok/hooks" || info.HooksSettingsFile != "gastown.json" {
+		t.Errorf("hooks path parts = %q + %q, want .grok/hooks + gastown.json", info.HooksDir, info.HooksSettingsFile)
+	}
+
+	agentHelp, err := exec.Command(path, "agent", "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("grok agent --help: %v\n%s", err, agentHelp)
+	}
+	agentHelpLower := strings.ToLower(string(agentHelp))
+	if !strings.Contains(agentHelpLower, "stdio") {
+		t.Error("grok agent --help should document stdio transport")
+	}
+	if info.ACP == nil || info.ACP.Command != "agent" {
+		t.Errorf("preset ACP.Command = %v, want agent", info.ACP)
+	}
+}

--- a/internal/config/test_main_test.go
+++ b/internal/config/test_main_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 		"auggie",
 		"amp",
 		"opencode",
+		"grok",
 	}
 	for _, name := range binaries {
 		path := filepath.Join(stubDir, name)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -50,7 +50,7 @@ type TownSettings struct {
 	CLITheme string `json:"cli_theme,omitempty"`
 
 	// DefaultAgent is the name of the agent preset to use by default.
-	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp", "opencode", "copilot")
+	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp", "opencode", "copilot", "grok")
 	// or a custom agent name defined in settings/agents.json.
 	// Default: "claude"
 	DefaultAgent string `json:"default_agent,omitempty"`
@@ -678,7 +678,7 @@ type RigSettings struct {
 	Runtime    *RuntimeConfig    `json:"runtime,omitempty"`     // LLM runtime settings (deprecated: use Agent)
 
 	// Agent selects which agent preset to use for this rig.
-	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp", "opencode", "copilot")
+	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp", "opencode", "copilot", "grok")
 	// or a custom agent defined in settings/agents.json.
 	// If empty, uses the town's default_agent setting.
 	// Takes precedence over Runtime if both are set.

--- a/internal/doctor/orphan_check.go
+++ b/internal/doctor/orphan_check.go
@@ -434,6 +434,8 @@ func gasTownRuntimeYOLO(cmdName, args string) bool {
 			(strings.Contains(args, "--resume") || argvHasFlag(args, "-p") || strings.Contains(args, "--print"))
 	case "copilot":
 		return strings.Contains(args, "--yolo")
+	case "grok":
+		return strings.Contains(args, "--always-approve") || argvHasFlag(args, "--yolo")
 	default:
 		return false
 	}
@@ -441,7 +443,7 @@ func gasTownRuntimeYOLO(cmdName, args string) bool {
 
 // findRuntimeProcesses finds Gas Town agent processes by per-provider YOLO / launch signatures
 // in argv (not comm name alone): claude/codex --dangerously-skip-permissions, cursor-agent -f,
-// copilot --yolo, etc.
+// copilot --yolo, grok --always-approve, etc.
 func (c *OrphanProcessCheck) findRuntimeProcesses() ([]processInfo, error) {
 	var procs []processInfo
 

--- a/internal/doctor/orphan_check_test.go
+++ b/internal/doctor/orphan_check_test.go
@@ -475,6 +475,8 @@ func TestGasTownRuntimeYOLO(t *testing.T) {
 		{"agent_f_only", "agent", "agent -f", false},
 		{"copilot_yolo", "copilot", "copilot --yolo", true},
 		{"copilot_plain", "copilot", "copilot", false},
+		{"grok_always_approve", "grok", "grok --always-approve --trust", true},
+		{"grok_plain", "grok", "grok", false},
 		{"unknown", "vim", "vim foo", false},
 	}
 	for _, tt := range tests {

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -86,6 +86,16 @@ func needsUpgrade(content []byte) bool {
 			bytes.Contains(content, []byte("$`gt prime`")) ||
 			!bytes.Contains(content, []byte(`prime --hook`))
 	}
+	// Autonomous Grok (and Copilot-style) polecat hooks originally only
+	// recorded costs on Stop. Without polecat-stop-check, a Grok polecat
+	// that finishes a turn sits at an empty composer instead of running
+	// gt done. The *witness* mail-check skip is unique to the autonomous
+	// template, so interactive/crew hooks are left alone.
+	if bytes.Contains(content, []byte(`*witness*`)) &&
+		bytes.Contains(content, []byte(`costs record`)) &&
+		!bytes.Contains(content, []byte(`polecat-stop-check`)) {
+		return true
+	}
 	return false
 }
 

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -693,6 +693,53 @@ func TestInstallForRole_CodexRoleAware(t *testing.T) {
 	}
 }
 
+func TestInstallForRole_GrokRoleAware(t *testing.T) {
+	dir := t.TempDir()
+	err := InstallForRole("grok", dir, dir, "polecat", ".grok/hooks", "gastown.json", false)
+	if err != nil {
+		t.Fatalf("InstallForRole(grok, polecat): %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, ".grok/hooks", "gastown.json"))
+	want, err := resolveAndSubstitute("grok", "hooks-autonomous.json", "polecat")
+	if err != nil {
+		t.Fatalf("resolveAndSubstitute: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Error("grok autonomous: content mismatch")
+	}
+	content := string(got)
+	for _, needle := range []string{
+		"prime --hook",
+		"mail check --inject",
+		"tap guard pr-workflow",
+		"run_terminal_command|Bash",
+		"*witness*",
+	} {
+		if !strings.Contains(content, needle) {
+			t.Errorf("grok autonomous template missing %q", needle)
+		}
+	}
+
+	dir2 := t.TempDir()
+	err = InstallForRole("grok", dir2, dir2, "crew", ".grok/hooks", "gastown.json", false)
+	if err != nil {
+		t.Fatalf("InstallForRole(grok, crew): %v", err)
+	}
+
+	got, _ = os.ReadFile(filepath.Join(dir2, ".grok/hooks", "gastown.json"))
+	want, err = resolveAndSubstitute("grok", "hooks-interactive.json", "crew")
+	if err != nil {
+		t.Fatalf("resolveAndSubstitute: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Error("grok interactive: content mismatch")
+	}
+	if strings.Contains(string(got), "*witness*") {
+		t.Error("grok interactive: UserPromptSubmit should not skip witness/refinery roles")
+	}
+}
+
 func TestInstallForRole_CopilotRoleAware(t *testing.T) {
 	// Copilot uses gastown-autonomous.json / gastown-interactive.json naming
 	dir := t.TempDir()

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -715,6 +715,8 @@ func TestInstallForRole_GrokRoleAware(t *testing.T) {
 		"tap guard pr-workflow",
 		"run_terminal_command|Bash",
 		"*witness*",
+		"polecat-stop-check",
+		"costs record",
 	} {
 		if !strings.Contains(content, needle) {
 			t.Errorf("grok autonomous template missing %q", needle)
@@ -737,6 +739,68 @@ func TestInstallForRole_GrokRoleAware(t *testing.T) {
 	}
 	if strings.Contains(string(got), "*witness*") {
 		t.Error("grok interactive: UserPromptSubmit should not skip witness/refinery roles")
+	}
+	if strings.Contains(string(got), "polecat-stop-check") {
+		t.Error("grok interactive: crew Stop hook should not auto-run polecat-stop-check")
+	}
+}
+
+func TestNeedsUpgrade_GrokAutonomousMissingPolecatStopCheck(t *testing.T) {
+	stale := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) gt mail check --inject ;; esac"}]}],
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gt costs record &"}]}]
+  }
+}`)
+	if !needsUpgrade(stale) {
+		t.Fatal("autonomous grok hooks with costs record but no polecat-stop-check should upgrade")
+	}
+
+	fresh := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "case \"${GT_ROLE:-}\" in *witness*) exit 0 ;; *) gt mail check --inject ;; esac"}]}],
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gt tap polecat-stop-check"}]}]
+  }
+}`)
+	if needsUpgrade(fresh) {
+		t.Fatal("autonomous grok hooks that already include polecat-stop-check should not upgrade")
+	}
+
+	interactive := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "gt mail check --inject"}]}],
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gt costs record &"}]}]
+  }
+}`)
+	if needsUpgrade(interactive) {
+		t.Fatal("interactive grok hooks must not be treated as stale autonomous polecat hooks")
+	}
+}
+
+func TestInstallForRole_GrokAutonomousUpgradesStopCheck(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".grok/hooks", "gastown.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	stale := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) gt mail check --inject ;; esac"}]}],
+    "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gt costs record &"}]}]
+  }
+}`)
+	if err := os.WriteFile(path, stale, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InstallForRole("grok", dir, dir, "polecat", ".grok/hooks", "gastown.json", false); err != nil {
+		t.Fatalf("InstallForRole: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "polecat-stop-check") {
+		t.Fatalf("upgraded grok autonomous hooks missing polecat-stop-check:\n%s", got)
 	}
 }
 

--- a/internal/hooks/templates/grok/hooks-autonomous.json
+++ b/internal/hooks/templates/grok/hooks-autonomous.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "run_terminal_command|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.toolInput.command // empty'); if echo \"$CMD\" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create|git[[:space:]]+checkout[[:space:]]+-b|git[[:space:]]+switch[[:space:]]+-c'; then {{GT_BIN}} tap guard pr-workflow; fi"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} prime --hook"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} prime --hook"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) {{GT_BIN}} mail check --inject ;; esac"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} costs record &"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/hooks/templates/grok/hooks-autonomous.json
+++ b/internal/hooks/templates/grok/hooks-autonomous.json
@@ -51,6 +51,11 @@
           {
             "type": "command",
             "command": "{{GT_BIN}} costs record &"
+          },
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} tap polecat-stop-check",
+            "timeout": 600
           }
         ]
       }

--- a/internal/hooks/templates/grok/hooks-interactive.json
+++ b/internal/hooks/templates/grok/hooks-interactive.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "run_terminal_command|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.toolInput.command // empty'); if echo \"$CMD\" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create|git[[:space:]]+checkout[[:space:]]+-b|git[[:space:]]+switch[[:space:]]+-c'; then {{GT_BIN}} tap guard pr-workflow; fi"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} prime --hook"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} prime --hook"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} mail check --inject"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{GT_BIN}} costs record &"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/tmux/submit_verify.go
+++ b/internal/tmux/submit_verify.go
@@ -204,7 +204,16 @@ func composerContent(line []rune, dim []bool, promptPrefix string) ([]rune, []bo
 	}
 	after := line[idx+len(prefix):]
 	afterDim := dim[idx+len(prefix):]
-	return trimRunesAndDim(after, afterDim)
+	after, afterDim = trimRunesAndDim(after, afterDim)
+	// Grok draws the composer inside a box ("│ ❯ … │"). The trailing
+	// border is not typed content; leaving it in makes an empty composer
+	// look dirty and a stranded nudge look like unrelated text.
+	if len(after) > 0 && after[len(after)-1] == '│' {
+		after = after[:len(after)-1]
+		afterDim = afterDim[:len(afterDim)-1]
+		after, afterDim = trimRunesAndDim(after, afterDim)
+	}
+	return after, afterDim
 }
 
 func analyzeComposerLine(line []rune, dim []bool, needle, promptPrefix string) submitProbe {

--- a/internal/tmux/submit_verify_test.go
+++ b/internal/tmux/submit_verify_test.go
@@ -139,6 +139,41 @@ func TestAnalyzeSubmission(t *testing.T) {
 	}
 }
 
+func TestAnalyzeSubmissionGrokComposer(t *testing.T) {
+	t.Parallel()
+	const needle = "resume the patrol"
+	const grokPrefix = "│ ❯"
+
+	tests := []struct {
+		name    string
+		content string
+		want    submitProbe
+	}{
+		{
+			name:    "empty boxed composer is cleared",
+			content: "transcript\n│ ❯                                                                        │\nShift+Tab:mode  │  Ctrl+x:shortcuts\n",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "nudge text still in boxed composer is stranded",
+			content: "transcript\n│ ❯ resume the patrol                                                     │\n",
+			want:    probeStranded,
+		},
+		{
+			name:    "grok busy footer is turn-started when composer line is absent",
+			content: "agent output\nShift+Tab:mode  │  Esc:cancel  │  Ctrl+b:send to bg  │  Ctrl+x:shortcuts\n",
+			want:    probeTurnStarted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := analyzeSubmission(tt.content, needle, grokPrefix); got != tt.want {
+				t.Errorf("analyzeSubmission() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestErrSubmitNotVerifiedWrapping(t *testing.T) {
 	t.Parallel()
 	wrapped := fmt.Errorf("nudge to session: %w", fmt.Errorf("submit: %w", ErrSubmitNotVerified))

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2357,17 +2357,52 @@ func (t *Tmux) GetPanePID(target string) (string, error) {
 
 // GetSessionActivity returns the last activity time for a session.
 // This is updated whenever there's any activity in the session (input/output).
+//
+// Grok Build CLI (and some other TUIs) can leave #{session_activity} frozen at
+// session creation while #{window_activity} still advances. Witness stall
+// detection and `gt polecat status` both read this value, so a frozen
+// session_activity looks like "zero activity since creation" even after the
+// agent has been working. Prefer the latest of session_activity and every
+// window_activity.
 func (t *Tmux) GetSessionActivity(session string) (time.Time, error) {
 	out, err := t.run("display-message", "-t", session, "-p", "#{session_activity}")
 	if err != nil {
 		return time.Time{}, err
 	}
-
-	timestamp, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("parsing session activity: %w", err)
+	values := []string{strings.TrimSpace(out)}
+	if windows, werr := t.run("list-windows", "-t", session, "-F", "#{window_activity}"); werr == nil {
+		for _, line := range strings.Split(windows, "\n") {
+			if s := strings.TrimSpace(line); s != "" {
+				values = append(values, s)
+			}
+		}
 	}
-	return time.Unix(timestamp, 0), nil
+	return latestUnixActivity(values...)
+}
+
+// latestUnixActivity returns the newest Unix timestamp among the given
+// decimal strings. Empty or unparsable values are skipped.
+func latestUnixActivity(values ...string) (time.Time, error) {
+	var max int64
+	found := false
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			continue
+		}
+		if !found || n > max {
+			max = n
+			found = true
+		}
+	}
+	if !found {
+		return time.Time{}, fmt.Errorf("parsing session activity: no timestamps")
+	}
+	return time.Unix(max, 0), nil
 }
 
 // ZombieStatus describes the liveness state of a tmux agent session.
@@ -3278,8 +3313,8 @@ func matchesPromptPrefix(line, readyPromptPrefix string) bool {
 // agent working?" scrapes the pane for any of these (see hasBusyIndicator), and
 // that signal underpins IsIdle, WaitForIdle, and the nudge Escape-suppression in
 // shouldSendEscape. Claude Code, Codex, and Gemini all surface "esc to
-// interrupt"; if an agent uses different wording, add it here — that is the only
-// place that needs to change.
+// interrupt"; Grok Build CLI surfaces "Esc:cancel". If an agent uses different
+// wording, add it here — that is the only place that needs to change.
 //
 // FRAGILITY (gastownhall/gastown#4240): this couples to upstream TUI status
 // text. Scraping the status bar cannot detect a silent upstream rename on its
@@ -3289,7 +3324,7 @@ func matchesPromptPrefix(line, readyPromptPrefix string) bool {
 // change is intentional rather than accidental. The idle side is already
 // centralized via the agent presets' ReadyPromptPrefix; this is its busy-side
 // counterpart.
-var busyIndicators = []string{"esc to interrupt"}
+var busyIndicators = []string{"esc to interrupt", "Esc:cancel"}
 
 func hasBusyIndicator(line string) bool {
 	trimmed := strings.TrimSpace(line)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2233,6 +2233,14 @@ func TestMatchesPromptPrefix(t *testing.T) {
 
 		// Bare prompt character without any space
 		{"bare prompt no space", "❯", regularPrefix, true},
+
+		// Grok Build CLI composer is a boxed "│ ❯ … │". The grok preset uses
+		// that boxed prefix so scrollback user lines ("❯ [GAS TOWN]…") are not
+		// false-idles. Captured from a stalled Grok polecat pane.
+		{"grok boxed composer", "  │ ❯                                                                        │", "│ ❯", true},
+		{"grok boxed composer with draft", "│ ❯ gt prime                                                                 │", "│ ❯", true},
+		{"grok scrollback user line is not the composer", "     ❯ [GAS TOWN] polecat dinki (rig: tl) <- witness", "│ ❯", false},
+		{"claude prefix must not be used for grok scrollback", "     ❯ [GAS TOWN] polecat dinki (rig: tl) <- witness", regularPrefix, true},
 	}
 
 	for _, tt := range tests {
@@ -2411,14 +2419,20 @@ func TestBusyIndicators(t *testing.T) {
 	// "esc to interrupt" is the marker Claude Code / Codex / Gemini render while
 	// generating. If this assertion fails, the change must be deliberate.
 	found := false
+	grokCancel := false
 	for _, m := range busyIndicators {
 		if m == "esc to interrupt" {
 			found = true
-			break
+		}
+		if m == "Esc:cancel" {
+			grokCancel = true
 		}
 	}
 	if !found {
 		t.Errorf("busyIndicators = %q, want it to contain the known \"esc to interrupt\" marker", busyIndicators)
+	}
+	if !grokCancel {
+		t.Errorf("busyIndicators = %q, want it to contain Grok's \"Esc:cancel\" footer marker", busyIndicators)
 	}
 
 	// Every marker must be matched by hasBusyIndicator (guards against an empty
@@ -2441,6 +2455,52 @@ func TestDefaultReadyPromptPrefix(t *testing.T) {
 	}
 	if !strings.Contains(DefaultReadyPromptPrefix, "❯") {
 		t.Errorf("DefaultReadyPromptPrefix = %q, want to contain ❯", DefaultReadyPromptPrefix)
+	}
+}
+
+func TestLatestUnixActivity(t *testing.T) {
+	t.Parallel()
+
+	got, err := latestUnixActivity("100", "200")
+	if err != nil {
+		t.Fatalf("latestUnixActivity: %v", err)
+	}
+	if got.Unix() != 200 {
+		t.Errorf("latestUnixActivity(100, 200) = %d, want 200", got.Unix())
+	}
+
+	got, err = latestUnixActivity("1788677276", "")
+	if err != nil {
+		t.Fatalf("latestUnixActivity missing window: %v", err)
+	}
+	if got.Unix() != 1788677276 {
+		t.Errorf("latestUnixActivity fell back to session_activity = %d, want 1788677276", got.Unix())
+	}
+
+	// Grok polecat dinki: session_activity frozen at create, window_activity
+	// advanced through the 12m29s of actual work.
+	got, err = latestUnixActivity("1788677276", "1788678029")
+	if err != nil {
+		t.Fatalf("latestUnixActivity grok stall: %v", err)
+	}
+	if got.Unix() != 1788678029 {
+		t.Errorf("latestUnixActivity preferred session_activity %d, want window_activity 1788678029", got.Unix())
+	}
+
+	if _, err := latestUnixActivity("", ""); err == nil {
+		t.Fatal("latestUnixActivity empty values should error")
+	}
+}
+
+func TestGrokBusyFooter(t *testing.T) {
+	t.Parallel()
+	idle := "  Shift+Tab:mode  │  Ctrl+x:shortcuts"
+	busy := "  Shift+Tab:mode  │  Esc:cancel  │  Ctrl+b:send to bg  │  Ctrl+x:shortcuts"
+	if hasBusyIndicator(idle) {
+		t.Error("idle Grok footer must not look busy")
+	}
+	if !hasBusyIndicator(busy) {
+		t.Error("busy Grok footer with Esc:cancel must be detected")
 	}
 }
 

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -409,7 +409,7 @@ func parseEtime(etime string) (int, error) {
 // TTY-less orphan / zombie cleanup (matches internal/config agent presets).
 func isAgentOrphanCommName(cmdLower string) bool {
 	switch cmdLower {
-	case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot":
+	case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot", "grok":
 		return true
 	default:
 		return false
@@ -424,7 +424,7 @@ type OrphanedProcess struct {
 	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
-// FindOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot, etc.)
+// FindOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot/grok, etc.)
 // without a controlling terminal.
 // These are typically subagent processes spawned by Claude Code's Task tool that didn't
 // clean up properly after completion.

--- a/internal/util/orphan_grok_test.go
+++ b/internal/util/orphan_grok_test.go
@@ -1,0 +1,10 @@
+package util
+
+import "testing"
+
+func TestIsAgentOrphanCommNameIncludesGrok(t *testing.T) {
+	t.Parallel()
+	if !isAgentOrphanCommName("grok") {
+		t.Error("isAgentOrphanCommName(\"grok\") = false, want true so gt down / zombie cleanup tracks Grok CLI")
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1935,7 +1935,7 @@ func (h *APIHandler) isClaudeRunningInSession(ctx context.Context, sessionName s
 }
 
 // paneCurrentCommandIsAgent returns true if tmux #{pane_current_command} names a known
-// Gas Town agent (claude/codex/opencode/cursor-agent/copilot/node, or cursor-agent as "agent").
+// Gas Town agent (claude/codex/opencode/cursor-agent/copilot/grok/node, or cursor-agent as "agent").
 func paneCurrentCommandIsAgent(output string) bool {
 	output = strings.ToLower(strings.TrimSpace(output))
 	if output == "" {
@@ -1948,6 +1948,7 @@ func paneCurrentCommandIsAgent(output string) bool {
 		strings.Contains(output, "opencode") ||
 		strings.Contains(output, "cursor-agent") ||
 		strings.Contains(output, "copilot") ||
+		strings.Contains(output, "grok") ||
 		output == "agent"
 }
 

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1446,6 +1446,7 @@ func TestPaneCurrentCommandIsAgent(t *testing.T) {
 		{"opencode", true},
 		{"cursor-agent", true},
 		{"copilot", true},
+		{"grok", true},
 		{"agent", true},
 		{"bash", false},
 		{"", false},


### PR DESCRIPTION
## Summary

Add a first-class **Grok Build CLI** runtime (`grok`) so Gas Town can spawn Grok the same way it spawns Claude, Cursor, or Copilot.

This is **not** `groq-compound` (Claude CLI proxied to Groq's API).

## Related Issue

No existing upstream issue.

## Changes

- Builtin preset `grok`: `grok --always-approve --trust --no-leader`
- Resume/continue via `--resume` / `--continue` (flag style)
- Headless: `-p` + `--output-format json`
- ACP: `grok agent --always-approve stdio`
- Hooks in `.grok/hooks/gastown.json` (SessionStart, UserPromptSubmit, PreCompact, Stop, PreToolUse)
- Process-name coverage for `gt down`, orphan/zombie cleanup, doctor YOLO detection, and web pane liveness
- `SupportsForkSession` left **false** so `gt seance --talk` stays Claude-only (seance currently picks the first fork-capable preset from an unordered map)

## Testing

- [x] Unit tests pass (`go test ./internal/config/ ./internal/hooks/ ./internal/util/ ./internal/doctor/ ./internal/web/`)
- [x] `TestGrokAgentCLIPresetMatchesHelp` ran against real `grok` 1.0.13 (`/home/iru/.grok/bin/grok`)
- [x] Manual `gt start --agent grok` in a town (not run in this PR)

## Checklist

- [x] Code follows project style
- [x] Documentation updated (README, INSTALLING, reference, agent-provider-integration, CHANGELOG)
- [x] No breaking changes (default agent unchanged)

## Notes

Project hooks require `--trust`. Auth stays in `~/.grok` (`GROK_HOME` is not overridden per role). Restore without a stored session id uses `--continue`.