### PR TITLE
fix(web): coalesce dashboard Dolt polling

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -62,11 +62,18 @@ type APIHandler struct {
 	optionsCacheMu   sync.RWMutex
 	// cmdSem limits concurrent command executions to prevent resource exhaustion.
 	cmdSem chan struct{}
+	// Dashboard hash cache coalesces the identical polling work performed by
+	// every connected SSE client. Only one client refreshes it per interval.
+	dashboardHashMu    sync.RWMutex
+	dashboardHash      string
+	dashboardHashTime  time.Time
+	dashboardHashInUse sync.Mutex
 	// csrfToken is validated on POST requests to prevent cross-site request forgery.
 	csrfToken string
 }
 
 const optionsCacheTTL = 30 * time.Second
+const dashboardHashCacheTTL = 2 * time.Second
 
 // maxConcurrentCommands limits how many gt subprocesses can run at once.
 // handleOptions alone spawns 7; allow headroom for other concurrent handlers.
@@ -242,6 +249,7 @@ func (h *APIHandler) runGtCommand(ctx context.Context, timeout time.Duration, ar
 	}
 
 	cmd := exec.CommandContext(ctx, h.gtPath, args...)
+	configureWebCommand(cmd)
 	if h.workDir != "" {
 		cmd.Dir = h.workDir
 	}
@@ -1388,6 +1396,7 @@ func (h *APIHandler) runBdCommand(ctx context.Context, timeout time.Duration, ar
 	}
 
 	cmd := exec.CommandContext(ctx, "bd", args...)
+	configureWebCommand(cmd)
 	if h.workDir != "" {
 		cmd.Dir = h.workDir
 	}
@@ -1666,6 +1675,7 @@ func (h *APIHandler) runGhCommand(ctx context.Context, timeout time.Duration, ar
 	}
 
 	cmd := exec.CommandContext(ctx, "gh", args...)
+	configureWebCommand(cmd)
 	if h.workDir != "" {
 		cmd.Dir = h.workDir
 	}
@@ -2228,6 +2238,36 @@ func (h *APIHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 // computeDashboardHash generates a lightweight hash of key dashboard state.
 // It runs quick commands in parallel and hashes their output to detect changes.
 func (h *APIHandler) computeDashboardHash(ctx context.Context) string {
+	if hash := h.cachedDashboardHash(); hash != "" {
+		return hash
+	}
+
+	h.dashboardHashInUse.Lock()
+	defer h.dashboardHashInUse.Unlock()
+	if hash := h.cachedDashboardHash(); hash != "" {
+		return hash
+	}
+
+	hash := h.computeDashboardHashFresh(ctx)
+	if hash != "" {
+		h.dashboardHashMu.Lock()
+		h.dashboardHash = hash
+		h.dashboardHashTime = time.Now()
+		h.dashboardHashMu.Unlock()
+	}
+	return hash
+}
+
+func (h *APIHandler) cachedDashboardHash() string {
+	h.dashboardHashMu.RLock()
+	defer h.dashboardHashMu.RUnlock()
+	if h.dashboardHash == "" || time.Since(h.dashboardHashTime) >= dashboardHashCacheTTL {
+		return ""
+	}
+	return h.dashboardHash
+}
+
+func (h *APIHandler) computeDashboardHashFresh(ctx context.Context) string {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
@@ -2273,7 +2313,13 @@ func (h *APIHandler) computeDashboardHash(ctx context.Context) string {
 		return ""
 	}
 
-	h256 := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hashDashboardParts(parts)
+}
+
+func hashDashboardParts(parts []string) string {
+	canonical := append([]string(nil), parts...)
+	sort.Strings(canonical)
+	h256 := sha256.Sum256([]byte(strings.Join(canonical, "|")))
 	return fmt.Sprintf("%x", h256[:8])
 }
 

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -877,6 +879,62 @@ func TestAPIHandler_SSE_ContentType(t *testing.T) {
 	body := w.Body.String()
 	if !strings.Contains(body, "event: connected") {
 		t.Error("SSE response should contain initial 'connected' event")
+	}
+}
+
+func TestHashDashboardPartsIsIndependentOfCompletionOrder(t *testing.T) {
+	first := hashDashboardParts([]string{"status:stable", "hooks:stable", "mail:stable"})
+	second := hashDashboardParts([]string{"mail:stable", "status:stable", "hooks:stable"})
+
+	if first != second {
+		t.Fatalf("dashboard hash changed with command completion order: %q != %q", first, second)
+	}
+}
+
+func TestComputeDashboardHashCoalescesConcurrentClients(t *testing.T) {
+	dir := t.TempDir()
+	commandLog := filepath.Join(dir, "commands.log")
+	gtStub := filepath.Join(dir, "gt-stub")
+	if err := os.WriteFile(gtStub, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$GT_WEB_COMMAND_LOG\"\nprintf '%s\\n' \"$*\"\n"), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("GT_WEB_COMMAND_LOG", commandLog)
+
+	h := NewAPIHandler(30*time.Second, 60*time.Second, "test-token")
+	h.gtPath = gtStub
+	h.workDir = dir
+
+	const clients = 10
+	var wg sync.WaitGroup
+	wg.Add(clients)
+	for range clients {
+		go func() {
+			defer wg.Done()
+			if got := h.computeDashboardHash(context.Background()); got == "" {
+				t.Error("computeDashboardHash returned an empty hash")
+			}
+		}()
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	if got := len(strings.Split(strings.TrimSpace(string(data)), "\n")); got != 3 {
+		t.Fatalf("concurrent clients launched %d hash commands, want 3 total; log: %q", got, data)
+	}
+}
+
+func TestConfigureWebCommandInstallsProcessTreeCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group cancellation is Unix-specific")
+	}
+
+	cmd := exec.Command("true")
+	configureWebCommand(cmd)
+	if cmd.Cancel == nil {
+		t.Fatal("web subprocess has no process-group cancellation hook")
 	}
 }
 

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -33,6 +33,7 @@ func runCmd(timeout time.Duration, name string, args ...string) (*bytes.Buffer, 
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, name, args...)
+	configureWebCommand(cmd)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 
@@ -74,6 +75,7 @@ func (f *LiveConvoyFetcher) runBdCmd(beadsDir string, args ...string) (*bytes.Bu
 		bin = "bd"
 	}
 	cmd := exec.CommandContext(ctx, bin, args...)
+	configureWebCommand(cmd)
 	cmd.Dir = beadsDir
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/web/process.go
+++ b/internal/web/process.go
@@ -1,0 +1,14 @@
+package web
+
+import (
+	"os/exec"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+// configureWebCommand is the common process-lifecycle seam for dashboard
+// subprocesses. Dashboard commands often launch bd descendants, so killing
+// only the immediate child on timeout leaks work and connections into Dolt.
+func configureWebCommand(cmd *exec.Cmd) {
+	util.SetProcessGroup(cmd)
+}

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -346,6 +346,7 @@ func (h *SetupAPIHandler) handleCheckWorkspace(w http.ResponseWriter, r *http.Re
 	// Try to get rig list from this workspace
 	var rigs []string
 	cmd := exec.CommandContext(r.Context(), "gt", "rig", "list", "--json")
+	configureWebCommand(cmd)
 	cmd.Dir = path
 	if output, err := cmd.Output(); err == nil {
 		// Parse JSON output for rig names
@@ -395,6 +396,7 @@ func (h *SetupAPIHandler) runGtCommand(ctx context.Context, timeout time.Duratio
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "gt", args...)
+	configureWebCommand(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary

Reduce dashboard-driven Dolt connection amplification by coalescing identical SSE polling work across clients, making change detection deterministic, and cancelling complete subprocess trees on timeout.

Each connected dashboard client previously ran `gt status --json`, `gt hooks list`, and `gt mail inbox` every two seconds. Because parallel outputs were hashed in completion order, unchanged state could generate a different hash and trigger another full refresh. Timed-out commands also killed only their immediate process, leaving descendant `bd sql` work alive.

## Related Issue

Beads: `gt-3qw`

## Changes

- Cache the dashboard hash for the two-second polling interval and coalesce concurrent cache misses.
- Sort command outputs before hashing so completion order cannot create false changes.
- Apply the existing process-group cancellation helper to dashboard, fetcher, and setup subprocesses.
- Add regressions for deterministic hashing, ten-client request coalescing, and process-tree cancellation.

## Testing

- [x] `go test ./internal/web -count=1`
- [x] `go vet ./internal/web`
- [x] Targeted `go test -race` for all three new regressions
- [ ] `go test ./...` (the changed package passes; the repository-wide run reports unrelated existing/environment-sensitive failures in Beads/Dolt routing, macOS `/var` path canonicalization, and the unsigned test-binary guard)
- [ ] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (not applicable; internal behavior only)
- [x] No breaking changes
