### PR TITLE
fix: relax disk usage guard to 97.5%

### DIFF
--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -64,7 +64,7 @@ const (
 	DiskSpaceMinimumMB uint64 = 500
 
 	// DiskSpaceWarningMB is the threshold (in MB) at which warnings are emitted.
-	// At 1 GB free, the system is at risk and should shed load.
+	// Below 1 GB free, the system is at risk and should shed load.
 	DiskSpaceWarningMB uint64 = 1024
 
 	// DiskSpaceCriticalPercent is the usage percentage at or above which

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -67,9 +67,9 @@ const (
 	// At 1 GB free, the system is at risk and should shed load.
 	DiskSpaceWarningMB uint64 = 1024
 
-	// DiskSpaceCriticalPercent is the usage percentage above which operations
-	// should be blocked regardless of absolute free space.
-	DiskSpaceCriticalPercent float64 = 95.0
+	// DiskSpaceCriticalPercent is the usage percentage at or above which
+	// operations should be blocked regardless of absolute free space.
+	DiskSpaceCriticalPercent float64 = 97.5
 )
 
 // DiskSpaceLevel represents the severity of disk space status.
@@ -106,21 +106,24 @@ func CheckDiskSpace(path string) (DiskSpaceLevel, string, error) {
 		return DiskSpaceOK, "", err
 	}
 
+	level, message := evaluateDiskSpace(info)
+	return level, message, nil
+}
+
+func evaluateDiskSpace(info *DiskSpaceInfo) (DiskSpaceLevel, string) {
 	availMB := info.AvailableMB()
 
 	if availMB < DiskSpaceMinimumMB || info.UsedPercent >= DiskSpaceCriticalPercent {
 		return DiskSpaceCritical,
 			fmt.Sprintf("CRITICAL: only %s free (%.1f%% used) — disk space exhausted, operations blocked",
-				info.AvailableHuman(), info.UsedPercent),
-			nil
+				info.AvailableHuman(), info.UsedPercent)
 	}
 
 	if availMB < DiskSpaceWarningMB {
 		return DiskSpaceWarning,
 			fmt.Sprintf("WARNING: only %s free (%.1f%% used) — disk space low, reduce workload",
-				info.AvailableHuman(), info.UsedPercent),
-			nil
+				info.AvailableHuman(), info.UsedPercent)
 	}
 
-	return DiskSpaceOK, "", nil
+	return DiskSpaceOK, ""
 }

--- a/internal/util/diskspace_darwin_test.go
+++ b/internal/util/diskspace_darwin_test.go
@@ -124,11 +124,13 @@ func TestAPFSPurgeablePreventsBlock(t *testing.T) {
 			float64(info.AvailableBytes)/float64(GB), float64(containerFree)/float64(GB))
 	}
 
-	// Old code would have used statfs Bavail (~41 GB) → 95.6% → CRITICAL block.
+	// Old code used a 95% threshold with statfs Bavail (~41 GB), so 95.6%
+	// produced a false-positive CRITICAL block.
+	const historicalCriticalPercent = 95.0
 	oldUsed := containerTotal - statfsFree
 	oldPct := float64(oldUsed) / float64(containerTotal) * 100
-	if oldPct < DiskSpaceCriticalPercent {
-		t.Errorf("test setup broken: old code would show %.1f%% (expected >= %.1f%%)", oldPct, DiskSpaceCriticalPercent)
+	if oldPct < historicalCriticalPercent {
+		t.Errorf("test setup broken: old code would show %.1f%% (expected >= %.1f%%)", oldPct, historicalCriticalPercent)
 	}
 
 	// New code must be below the critical threshold.

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -119,6 +119,35 @@ func TestCheckDiskSpace_InvalidPath(t *testing.T) {
 	}
 }
 
+func TestEvaluateDiskSpaceThresholds(t *testing.T) {
+	const MB = uint64(1024 * 1024)
+	tests := []struct {
+		name        string
+		availableMB uint64
+		usedPercent float64
+		want        DiskSpaceLevel
+	}{
+		{name: "below percentage limit", availableMB: 1024, usedPercent: 97.49, want: DiskSpaceOK},
+		{name: "at percentage limit", availableMB: 1024, usedPercent: 97.5, want: DiskSpaceCritical},
+		{name: "below absolute floor", availableMB: 499, usedPercent: 10, want: DiskSpaceCritical},
+		{name: "below warning floor", availableMB: 900, usedPercent: 10, want: DiskSpaceWarning},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &DiskSpaceInfo{
+				AvailableBytes: tt.availableMB * MB,
+				TotalBytes:     100 * 1024 * MB,
+				UsedPercent:    tt.usedPercent,
+			}
+			got, _ := evaluateDiskSpace(info)
+			if got != tt.want {
+				t.Fatalf("evaluateDiskSpace() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDiskSpaceLevel_String(t *testing.T) {
 	tests := []struct {
 		level DiskSpaceLevel

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -105,6 +105,12 @@ func TestCheckDiskSpace_CurrentDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckDiskSpace(\".\") failed: %v", err)
 	}
+	info, err := GetDiskSpace(".")
+	if err != nil {
+		t.Fatalf("GetDiskSpace(\".\") failed: %v", err)
+	}
+	t.Logf("current filesystem: %s free, %.2f%% used => level=%s message=%q",
+		info.AvailableHuman(), info.UsedPercent, level, msg)
 
 	// In a normal test environment, disk should be OK
 	if level == DiskSpaceCritical {
@@ -129,8 +135,11 @@ func TestEvaluateDiskSpaceThresholds(t *testing.T) {
 	}{
 		{name: "below percentage limit", availableMB: 1024, usedPercent: 97.49, want: DiskSpaceOK},
 		{name: "at percentage limit", availableMB: 1024, usedPercent: 97.5, want: DiskSpaceCritical},
+		{name: "above percentage limit", availableMB: 1024, usedPercent: 97.51, want: DiskSpaceCritical},
 		{name: "below absolute floor", availableMB: 499, usedPercent: 10, want: DiskSpaceCritical},
-		{name: "below warning floor", availableMB: 900, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "at absolute floor", availableMB: 500, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "below warning floor", availableMB: 1023, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "at warning floor", availableMB: 1024, usedPercent: 10, want: DiskSpaceOK},
 	}
 
 	for _, tt := range tests {
@@ -140,10 +149,12 @@ func TestEvaluateDiskSpaceThresholds(t *testing.T) {
 				TotalBytes:     100 * 1024 * MB,
 				UsedPercent:    tt.usedPercent,
 			}
-			got, _ := evaluateDiskSpace(info)
+			got, message := evaluateDiskSpace(info)
 			if got != tt.want {
 				t.Fatalf("evaluateDiskSpace() = %s, want %s", got, tt.want)
 			}
+			t.Logf("available=%d MB used=%.2f%% => level=%s message=%q",
+				tt.availableMB, tt.usedPercent, got, message)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- raise the disk-usage critical threshold from 95% to 97.5%
- retain the existing 500 MB critical floor and 1 GB warning floor
- cover exact percentage and absolute-space boundaries with behavioral tests
- keep the historical APFS purgeable-space regression tied to the former 95% behavior

## Validation

- `go test ./internal/util -count=1`
- focused doctor tests with the live `GT_DOLT_PORT` override removed
- no-mistakes source review, behavioral test, documentation, and lint stages
- production `make build`

The broad polecat suite also ran; its failures were pre-existing environment failures from the locally installed Beads 1.2.2 first-run metrics banner, unrelated to this change.
