### PR TITLE
fix(done): fail loudly when the MR bead never reaches the rig's queue (gt-6sg)

### DIFF
--- a/internal/beads/beads_mr.go
+++ b/internal/beads/beads_mr.go
@@ -2,6 +2,8 @@
 package beads
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -115,4 +117,52 @@ func (b *Beads) FindOpenMRsForIssue(issueID string) ([]*Issue, error) {
 func MatchesMRSourceIssue(description, issueID string) bool {
 	needle := "source_issue: " + issueID + "\n"
 	return strings.Contains(description, needle)
+}
+
+// ErrMRNotInRigQueue reports that a merge-request bead was created and is
+// readable, but is not present in the rig's own merge-queue view.
+var ErrMRNotInRigQueue = errors.New("merge request is not visible in the rig's merge queue")
+
+// VerifyMRInRigQueue confirms that mrID is visible in the rig's own merge-queue
+// view — the same query the Refinery runs to pick up work (see runMQList).
+//
+// This exists because neither of the older guards can detect a misfiled MR:
+//
+//   - ValidateRigPrefix compares only the bead's ID prefix. A town whose rig
+//     store and contributor store share a prefix (gastown: both "gt-") passes
+//     that check no matter which store the bead landed in.
+//   - A plain Show read-back succeeds too, because bd resolves reads across
+//     repos.additional and happily finds the bead in the contributor store.
+//
+// So an MR can be created, be readable, pass both guards, and still be invisible
+// to the Refinery — which on a merge-queue rig is silent work loss: the branch is
+// pushed, the polecat reports COMPLETED, and nothing is ever queued to merge it
+// (gt-6sg). Presence in the queue view is the only check that reflects what the
+// Refinery will actually see, so it is the one worth gating completion on.
+func (b *Beads) VerifyMRInRigQueue(rigName, mrID string) error {
+	if mrID == "" {
+		return fmt.Errorf("%w: empty merge request ID", ErrMRNotInRigQueue)
+	}
+
+	issues, err := b.ListMergeRequests(ListOptions{
+		Status:   "all",
+		Label:    "gt:merge-request",
+		Priority: -1,
+		Rig:      rigName,
+	})
+	if err != nil {
+		// An unreadable queue is not proof the MR is missing. Report the failure
+		// so callers can surface it rather than silently treating it as absent.
+		return fmt.Errorf("querying rig %q merge queue: %w", rigName, err)
+	}
+
+	for _, issue := range issues {
+		if issue != nil && issue.ID == mrID {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: %s was created and is readable, but rig %q's queue does not contain it — "+
+		"the bead most likely landed in a different store than the one the Refinery reads",
+		ErrMRNotInRigQueue, mrID, rigName)
 }

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -431,6 +432,145 @@ case "${1:-}" in
       *gt-other*) echo 'other rig should not be hydrated' >&2; exit 7 ;;
     esac
     printf '%s\n' '[{"id":"gt-current","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","ephemeral":true,"labels":["gt:merge-request"]}]'
+    exit 0
+    ;;
+  *)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestVerifyMRInRigQueueDetectsMisfiledMR reproduces the gt-6sg failure in the
+// shape it actually occurs in: the MR bead is created for real (not --dry-run,
+// which short-circuits before the DB-init path and therefore succeeds exactly
+// where the real call fails), the create returns an ID, a Show read-back finds
+// the bead — and the rig's own queue is still empty, because the bead landed in
+// a different store than the one the Refinery reads.
+//
+// Both pre-existing guards pass on this input: the ID carries the rig's own
+// "gt-" prefix, and the read-back resolves. Only the queue check catches it.
+func TestVerifyMRInRigQueueDetectsMisfiledMR(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installMisfiledMRBDStub(t, false)
+
+	b := New(t.TempDir())
+
+	// The real create path: bd create returns a genuine MR bead with an ID.
+	mr, err := b.Create(CreateOptions{
+		Title:     "Merge: gt-source",
+		Labels:    []string{"gt:merge-request"},
+		Priority:  1,
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v, want a successful create", err)
+	}
+	if mr.ID != "gt-wisp-misfiled" {
+		t.Fatalf("Create() ID = %q, want gt-wisp-misfiled", mr.ID)
+	}
+
+	// The old guards are satisfied, which is precisely the problem.
+	if got, err := b.Show(mr.ID); err != nil || got == nil {
+		t.Fatalf("Show(%q) = %v, %v; the read-back guard is expected to PASS here", mr.ID, got, err)
+	}
+
+	err = b.VerifyMRInRigQueue("gastown", mr.ID)
+	if err == nil {
+		t.Fatal("VerifyMRInRigQueue() = nil, want an error: the MR is absent from the rig's queue")
+	}
+	if !errors.Is(err, ErrMRNotInRigQueue) {
+		t.Fatalf("VerifyMRInRigQueue() error = %v, want ErrMRNotInRigQueue", err)
+	}
+	if !strings.Contains(err.Error(), mr.ID) {
+		t.Errorf("VerifyMRInRigQueue() error = %q, want it to name the MR %q", err, mr.ID)
+	}
+}
+
+// TestVerifyMRInRigQueueAcceptsQueuedMR is the positive control: the same real
+// create path, but the rig's queue does contain the MR.
+func TestVerifyMRInRigQueueAcceptsQueuedMR(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installMisfiledMRBDStub(t, true)
+
+	b := New(t.TempDir())
+	mr, err := b.Create(CreateOptions{
+		Title:     "Merge: gt-source",
+		Labels:    []string{"gt:merge-request"},
+		Priority:  1,
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := b.VerifyMRInRigQueue("gastown", mr.ID); err != nil {
+		t.Fatalf("VerifyMRInRigQueue() error = %v, want nil for a queued MR", err)
+	}
+}
+
+// TestVerifyMRInRigQueueRejectsEmptyID guards the degenerate input: an empty ID
+// must not be treated as "found".
+func TestVerifyMRInRigQueueRejectsEmptyID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installMisfiledMRBDStub(t, true)
+
+	b := New(t.TempDir())
+	if err := b.VerifyMRInRigQueue("gastown", ""); !errors.Is(err, ErrMRNotInRigQueue) {
+		t.Fatalf("VerifyMRInRigQueue(\"\") error = %v, want ErrMRNotInRigQueue", err)
+	}
+}
+
+// installMisfiledMRBDStub installs a bd stub whose create genuinely succeeds and
+// whose show resolves the created bead. When queued is false the rig's queue
+// query comes back empty — the gastown store-split behaviour observed on gt-6sg,
+// where every create landed in the embedded contributor store while the Refinery
+// read the rig's server database.
+func installMisfiledMRBDStub(t *testing.T, queued bool) {
+	t.Helper()
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+
+	mrJSON := `{"id":"gt-wisp-misfiled","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"assignee":"","created_at":"2026-09-04T00:00:00Z","updated_at":"2026-09-04T00:00:00Z","created_by":"tester","labels_csv":"gt:merge-request"}`
+	sqlRows := `[]`
+	if queued {
+		sqlRows = `[` + mrJSON + `]`
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+if [ "${1:-}" = "--allow-stale" ]; then
+  if [ "${2:-}" = "version" ]; then
+    echo "Error: unknown flag: --allow-stale" >&2
+    exit 0
+  fi
+  shift
+fi
+case "${1:-}" in
+  create)
+    printf '%s\n' '{"id":"gt-wisp-misfiled","title":"Merge: gt-source","status":"open","priority":1,"ephemeral":true,"labels":["gt:merge-request"]}'
+    exit 0
+    ;;
+  show)
+    printf '%s\n' '[{"id":"gt-wisp-misfiled","title":"Merge: gt-source","status":"open","priority":1,"labels":["gt:merge-request"]}]'
+    exit 0
+    ;;
+  list)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '` + sqlRows + `'
     exit 0
     ;;
   *)

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -75,6 +75,10 @@ const (
 	ExitCompleted = "COMPLETED"
 	ExitEscalated = "ESCALATED"
 	ExitDeferred  = "DEFERRED"
+	// ExitIncomplete is reported instead of COMPLETED when the push or the MR
+	// submission failed. The work is not merge-queued, so calling it COMPLETED
+	// tells the Witness the opposite of what happened (gt-6sg).
+	ExitIncomplete = "INCOMPLETE"
 )
 
 func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
@@ -951,6 +955,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	var pushFailed bool
 	var mrFailed bool
 	var doneErrors []string
+	// Declared here rather than at the notifyWitness label: several failure paths
+	// goto that label, and Go forbids jumping over a variable declaration.
+	var reportedExit string
 	var convoyInfo *ConvoyInfo // Populated if issue is tracked by a convoy
 	var sourceIssueForNoMerge *beads.Issue
 	var sourceBD *beads.Beads
@@ -1804,6 +1811,24 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				style.PrintWarning("MR bead prefix mismatch: %v\nThe refinery may not find this MR — check 'gt mq list %s'", prefixErr, rigName)
 			}
 
+			// gt-6sg: Confirm the MR is visible in the rig's own merge queue.
+			// The two guards above are both satisfied by a misfiled MR: the
+			// prefix check compares only the ID prefix, which is identical when
+			// a town's rig store and contributor store share one, and the Show
+			// read-back resolves across repos.additional and finds the bead in
+			// whichever store it landed in. So an MR can be created, readable,
+			// and still invisible to the Refinery — the branch is pushed, the
+			// polecat reports COMPLETED, and nothing is ever queued to merge it.
+			// That is silent work loss, so this guard sets mrFailed rather than
+			// warning: an unqueued MR is a failed submission, not a cosmetic one.
+			if queueErr := bd.VerifyMRInRigQueue(rigName, mrID); queueErr != nil {
+				mrFailed = true
+				errMsg := fmt.Sprintf("MR bead created but not queued: %v", queueErr)
+				doneErrors = append(doneErrors, errMsg)
+				style.PrintWarning("%s\nBranch is pushed but the Refinery will not see this MR. Preserving worktree.\nCheck 'gt mq list %s'.", errMsg, rigName)
+				goto notifyWitness
+			}
+
 			// GH#3032: Supersede older open MRs for the same source issue.
 			// When a polecat re-submits after fixing a gate failure, the old MR
 			// (same branch, different SHA) is stale. Close it so the refinery
@@ -1879,8 +1904,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 notifyWitness:
+	// gt-6sg: what we tell the Witness and the feed must reflect whether the work
+	// actually reached the merge queue, not merely that gt done ran to the end.
+	reportedExit = reportedExitType(exitType, pushFailed, mrFailed)
+
 	// Nudge refinery — MR bead is already on main (transaction-based shared main).
-	if shouldNudgeRefinery(exitType, mrID) {
+	if shouldNudgeRefinery(exitType, mrID, mrFailed) {
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 
@@ -1930,8 +1959,8 @@ notifyWitness:
 	// Nudge witness only after hook/cleanup state is updated. Otherwise witness can
 	// evaluate slot availability against stale hook_bead or cleanup_status and emit
 	// false SLOT_BLOCKED/SLOT_OPEN signals.
-	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
-	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
+	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, reportedExit))
+	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), reportedExit)
 
 	// Clean successful polecats are retired after durable handoff. Preserve the
 	// feature branch and metadata; Witness/refinery cleanup owns the sandbox.
@@ -1941,7 +1970,11 @@ notifyWitness:
 		isPolecat = true
 
 		if pushFailed || mrFailed {
+			// gt-6sg: say why the sandbox survives. A sandbox preserved here holds
+			// work that never reached the queue and genuinely needs recovery — as
+			// opposed to one left behind by a cleanup step that simply did not run.
 			fmt.Printf("%s Work needs recovery (push or MR failed) — session preserved\n", style.Bold.Render("⚠"))
+			fmt.Printf("  This sandbox is preserved because the work is NOT queued, not merely uncleaned.\n")
 		}
 		if exitType == ExitCompleted && issueID != "" && convoyInfo == nil {
 			convoyInfo = getConvoyInfoFromSourceIssue(sourceIssueForNoMerge)
@@ -1974,6 +2007,14 @@ notifyWitness:
 		if err := retirePolecatSessionAfterDone(rigName, polecatName, os.Getpid()); err != nil {
 			style.PrintWarning("could not terminate polecat session: %v", err)
 		}
+	}
+
+	// gt-6sg: exit non-zero when the work never reached the merge queue. Every
+	// notification above has already been written, so this only changes the exit
+	// status — but a zero exit is what let callers and formula steps treat a
+	// failed submission as a successful one.
+	if reportedExit == ExitIncomplete {
+		return fmt.Errorf("work not submitted to the merge queue: %s", strings.Join(doneErrors, "; "))
 	}
 
 	return nil
@@ -2102,8 +2143,25 @@ func verifyPushedCommitWithBareFallback(g *git.Git, townRoot, rigName, branch, c
 // never emit MQ_SUBMIT, or the refinery wakes from backoff to find an empty
 // merge queue (gh#3885). The exitType check is defensive: it holds the
 // invariant even if a future code path populates mrID outside COMPLETED.
-func shouldNudgeRefinery(exitType, mrID string) bool {
+func shouldNudgeRefinery(exitType, mrID string, mrFailed bool) bool {
+	// A created-but-unqueued MR still yields a non-empty mrID (gt-6sg). Nudging
+	// the Refinery for one sends it hunting for work its queue cannot see.
+	if mrFailed {
+		return false
+	}
 	return exitType == ExitCompleted && mrID != ""
+}
+
+// reportedExitType degrades COMPLETED to INCOMPLETE when the push or the MR
+// submission failed. The branch may be pushed and the MR bead may even exist,
+// but nothing is queued to merge it, so reporting COMPLETED is what turns this
+// failure into silent work loss (gt-6sg). ESCALATED and DEFERRED pass through:
+// they already describe a non-completion and carry their own meaning.
+func reportedExitType(exitType string, pushFailed, mrFailed bool) string {
+	if exitType == ExitCompleted && (pushFailed || mrFailed) {
+		return ExitIncomplete
+	}
+	return exitType
 }
 
 // setDoneIntentLabel writes a done-intent:<type>:<unix-ts> label on the agent bead

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -891,21 +891,26 @@ func TestShouldNudgeRefinery(t *testing.T) {
 		name     string
 		exitType string
 		mrID     string
+		mrFailed bool
 		want     bool
 	}{
-		{"completed with MR nudges", ExitCompleted, "gt-abc123", true},
-		{"completed without MR does not nudge", ExitCompleted, "", false},
-		{"deferred without MR does not nudge", ExitDeferred, "", false},
-		{"deferred with stray MR does not nudge", ExitDeferred, "gt-abc123", false},
-		{"escalated without MR does not nudge", ExitEscalated, "", false},
-		{"escalated with stray MR does not nudge", ExitEscalated, "gt-abc123", false},
+		{"completed with MR nudges", ExitCompleted, "gt-abc123", false, true},
+		{"completed without MR does not nudge", ExitCompleted, "", false, false},
+		{"deferred without MR does not nudge", ExitDeferred, "", false, false},
+		{"deferred with stray MR does not nudge", ExitDeferred, "gt-abc123", false, false},
+		{"escalated without MR does not nudge", ExitEscalated, "", false, false},
+		{"escalated with stray MR does not nudge", ExitEscalated, "gt-abc123", false, false},
+		// gt-6sg: an MR that was created but never landed in the rig's queue
+		// leaves mrID populated. Waking the refinery for it sends it looking
+		// for work its queue cannot see.
+		{"completed with unqueued MR does not nudge", ExitCompleted, "gt-abc123", true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldNudgeRefinery(tt.exitType, tt.mrID); got != tt.want {
-				t.Errorf("shouldNudgeRefinery(%q, %q) = %v, want %v",
-					tt.exitType, tt.mrID, got, tt.want)
+			if got := shouldNudgeRefinery(tt.exitType, tt.mrID, tt.mrFailed); got != tt.want {
+				t.Errorf("shouldNudgeRefinery(%q, %q, %v) = %v, want %v",
+					tt.exitType, tt.mrID, tt.mrFailed, got, tt.want)
 			}
 		})
 	}
@@ -2232,5 +2237,39 @@ func testRunGit(t *testing.T, dir string, args ...string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+// TestReportedExitType locks in the gt-6sg invariant: gt done must not report
+// COMPLETED when the work never reached the merge queue. On a merge-queue rig
+// that report is what turns a failed MR submission into silent work loss — the
+// branch is pushed, the Witness is told the polecat completed, and nothing is
+// queued to merge it. ESCALATED and DEFERRED already describe a non-completion
+// and must pass through untouched.
+func TestReportedExitType(t *testing.T) {
+	tests := []struct {
+		name       string
+		exitType   string
+		pushFailed bool
+		mrFailed   bool
+		want       string
+	}{
+		{"clean completion stays COMPLETED", ExitCompleted, false, false, ExitCompleted},
+		{"failed MR degrades to INCOMPLETE", ExitCompleted, false, true, ExitIncomplete},
+		{"failed push degrades to INCOMPLETE", ExitCompleted, true, false, ExitIncomplete},
+		{"both failed degrades to INCOMPLETE", ExitCompleted, true, true, ExitIncomplete},
+		{"escalated passes through", ExitEscalated, false, false, ExitEscalated},
+		{"escalated with failed MR passes through", ExitEscalated, false, true, ExitEscalated},
+		{"deferred passes through", ExitDeferred, false, false, ExitDeferred},
+		{"deferred with failed push passes through", ExitDeferred, true, false, ExitDeferred},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reportedExitType(tt.exitType, tt.pushFailed, tt.mrFailed); got != tt.want {
+				t.Errorf("reportedExitType(%q, %v, %v) = %q, want %q",
+					tt.exitType, tt.pushFailed, tt.mrFailed, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -271,6 +271,15 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 			style.PrintWarning("MR bead prefix mismatch: %v\nThe refinery may not find this MR — check 'gt mq list %s'", prefixErr, rigName)
 		}
 
+		// gt-6sg: the prefix check above passes whenever the rig store and the
+		// contributor store share a prefix, so it cannot tell a queued MR from a
+		// misfiled one. Confirm the Refinery can actually see this MR before
+		// reporting a successful submission — an unqueued MR here is the same
+		// silent work loss gt done guards against, reached by a different command.
+		if queueErr := bd.VerifyMRInRigQueue(rigName, mrIssue.ID); queueErr != nil {
+			return fmt.Errorf("submitting to merge queue: %w", queueErr)
+		}
+
 		// Nudge refinery to pick up the new MR
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -302,6 +302,7 @@ func installSubmitSourceBDRecorder(t *testing.T, currentBeadsDir, ownerBeadsDir 
 	t.Helper()
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "bd.log")
+	createdMarker := filepath.Join(t.TempDir(), "mr-created")
 	script := fmt.Sprintf(`#!/bin/sh
 if [ "$1" = "--allow-stale" ]; then
   shift
@@ -323,19 +324,33 @@ if [ "$1" = "show" ] && [ "$2" = "bd-source" ]; then
   echo "Issue not found in $BEADS_DIR" >&2
   exit 1
 fi
-if [ "$1" = "show" ] && [ "$2" = "gt-mr" ]; then
-  echo '[{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"],"description":"branch: feature/routed-submit\\ntarget: main\\nsource_issue: bd-source\\nrig: gastown"}]'
-  exit 0
+if [ "$1" = "show" ]; then
+  # Tolerate flag position: dependency hydration issues "show --json gt-mr",
+  # while the direct read-back issues "show gt-mr --json".
+  case " $* " in
+    *" gt-mr "*)
+      echo '[{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"],"description":"branch: feature/routed-submit\\ntarget: main\\nsource_issue: bd-source\\nrig: gastown"}]'
+      exit 0
+      ;;
+  esac
 fi
 if [ "$1" = "list" ]; then
   echo '[]'
   exit 0
 fi
 if [ "$1" = "sql" ]; then
-  echo '[]'
+  # The rig queue is empty until the MR is actually created, and contains it
+  # afterwards. Modelling that ordering keeps the dedup lookup (which runs
+  # before create) distinct from the queue-visibility check (which runs after).
+  if [ -f %q ]; then
+    echo '[{"id":"gt-mr","title":"Merge: bd-source","description":"branch: feature/routed-submit\\ntarget: main\\nsource_issue: bd-source\\nrig: gastown\\n","status":"open","priority":1,"assignee":"","created_at":"2026-09-04T00:00:00Z","updated_at":"2026-09-04T00:00:00Z","created_by":"tester","labels_csv":"gt:merge-request"}]'
+  else
+    echo '[]'
+  fi
   exit 0
 fi
 if [ "$1" = "create" ]; then
+  : > %q
   echo '{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"]}'
   exit 0
 fi
@@ -347,7 +362,7 @@ if [ "$1" = "close" ]; then
 fi
 echo "unexpected bd command: $*" >&2
 exit 1
-`, logPath, currentBeadsDir, ownerBeadsDir)
+`, logPath, currentBeadsDir, ownerBeadsDir, createdMarker, createdMarker)
 	path := filepath.Join(binDir, "bd")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write bd recorder: %v", err)


### PR DESCRIPTION
## The bug

`gt done` pushed the branch, reported **COMPLETED**, and left nothing in the merge queue. On a merge-queue rig that is **silent work loss** — the polecat is retired, the Witness is told the work completed, and no MR exists to merge it. Two confirmed instances a day apart (jasper 2026-09-03, opal 2026-09-04). gastown itself escapes harm only because it is fork-backed and delivers by PR; sandbox is the other operational rig and it *does* use the merge queue.

## Root cause — proven, not inferred

**The MR bead is created in the wrong database.**

On gastown, every `bd create` issued from the rig — ephemeral or not, `BEADS_DIR` pinned to the rig's canonical `.beads` or not — lands in the embedded contributor store `~/.beads-planning` (`dolt_database: gt`, embedded) rather than the rig's server database `gastown`. Verified by direct Dolt query:

| bead | created via | in `gastown` server DB? |
|---|---|---|
| `gt-6sg` (the assigned bead) | normal | ✅ yes |
| `gt-wisp-fn6` | `bd create --ephemeral`, no `BEADS_DIR` | ❌ no |
| `gt-wisp-wfg` | `bd create --ephemeral`, `BEADS_DIR` pinned to rig | ❌ no |
| `gt-hnm` | `bd create` **non**-ephemeral, `BEADS_DIR` pinned | ❌ no |

All three landed in `~/.beads-planning/.beads/embeddeddolt/gt`. `--ephemeral` is **not** the discriminator. `gt mq list gastown` reports an empty queue while all three beads are perfectly readable via `bd show`.

The reported error text — `database not initialized: issue_prefix config is missing` — is explained by the same fact: **the contributor store has no `config.yaml` at all**. The rig's own `config.yaml` is correct (`prefix: gt`, `issue-prefix: gt`) and simply is not the file being read. That is why chasing the `issue_prefix` vs `issue-prefix` spelling led nowhere.

`bd context` reports `role: contributor`, which is the mechanism: writes resolve to the contributor store.

### Two failure modes, one cause — and the quiet one is worse

1. The create **errors** with `issue_prefix config is missing`. Loud-ish, but `gt done` still reported COMPLETED.
2. The create **succeeds** into the contributor store (reproduced 3× here). The MR exists, is readable, and is invisible to the Refinery. This is the more common mode and nobody had seen it.

### Why the existing guards did not catch mode 2

- `beads.ValidateRigPrefix` compares only the **ID prefix**. Both stores are `gt-` prefixed, so it passes on a misfiled MR.
- The GH#1945 `bd.Show(mrID)` read-back passes too, because bd resolves reads across `repos.additional` and finds the bead in whichever store it landed in.

So `done.go` believed the MR was confirmed and proceeded to report COMPLETED.

## The fix

Add `beads.VerifyMRInRigQueue`, which asks the only question that matters — *is this MR in the rig's queue, the same view the Refinery reads* — and gate completion on it.

- `done.go` treats an unqueued MR as a **failed submission** (`mrFailed`), not a warning, and preserves the sandbox.
- New `reportedExitType` degrades `COMPLETED` → `INCOMPLETE` whenever the push or the MR failed, so the Witness nudge stops asserting the opposite of what happened. `ESCALATED`/`DEFERRED` pass through untouched.
- `shouldNudgeRefinery` no longer wakes the Refinery for a created-but-unqueued MR (`mrID` is non-empty in that case), which would send it hunting for work its queue cannot see.
- `gt done` **exits non-zero** in that case. Every notification is still written first; only the status changes. A zero exit is what let callers and formula steps treat a failed submission as a successful one.
- The preserved-sandbox message now says *why* it survived.

The same guard is applied to `gt mq submit`, which creates MR beads through a parallel implementation and had the identical silent hole. That is adjacent to the assigned scope and called out deliberately rather than slipped in.

### Scope

`routing.contributor` / `repos.additional` configuration is **deliberately untouched** — `gastown/witness` holds that half (hq-2xnnx8) and it affects every agent's bead access. This change makes the failure impossible to miss; it does not attempt to re-route the store. The underlying store split is hq-m4vgy0.

## What a preserved sandbox means after this — please read

The bead asked for this explicitly. Previously, `gt done` cleanup was gated behind the failed MR submission, so **a preserved polecat sandbox was frequently just a side effect of this bug, not a signal of outstanding work**. Every agent in town has been reading preserved sandboxes as "work needs recovery", and that reading was wrong whenever this fired.

After this change, a sandbox preserved by `gt done` means the work **genuinely did not reach the queue**, and both the exit status and the Witness notification say so. `INCOMPLETE` is now the signal to act on, not the presence of a sandbox.

## Tests

Cover the **real create path**, not `--dry-run` — which short-circuits before the DB-init path and succeeds exactly where the real call fails, so it is not a valid control:

- `TestVerifyMRInRigQueueDetectsMisfiledMR` — a real create succeeds and returns an ID, the old read-back guard **still passes** (asserted, because that is the trap), and the queue check is the one that catches it.
- `TestVerifyMRInRigQueueAcceptsQueuedMR` / `...RejectsEmptyID` — positive control and degenerate input.
- `TestReportedExitType` — COMPLETED degrades only on failure; ESCALATED/DEFERRED pass through.
- `TestShouldNudgeRefinery` — new case for the created-but-unqueued MR.
- The mq-submit bd stub is now **stateful**: the queue is empty before the create and populated after, which keeps the dedup lookup distinct from the queue check and exercises dependency hydration for the first time.

`make build` green; `go vet` clean; the `done_*` suite and `internal/beads` MR tests pass; changed files are gofmt-clean.

**Pre-existing failures, filed separately, verified failing at HEAD in a pristine worktree** — not regressions from this change: `TestRunEnv_StripsPollutedDoltEnvAndUsesRigMetadata`, `TestGetRigDirForName`, `TestRunDoneWithRoutedIssueIgnoresCurrentRigMirror`, and `TestPersistentPreRunDoneRejectsBeforeRegistryFallback` (this one `os.Exit`s and silently invalidates the whole `internal/cmd` run — worth fixing first).

Closes gt-6sg. The routing half of hq-92n remains with `gastown/witness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTnBpgNYqTKkwT9DANowDU
