### PR TITLE
fix(polecat): stop an unwritten cleanup_status stranding the whole fleet (gt-ets)

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -118,12 +118,38 @@ var newDoneSessionKiller = func() doneSessionKiller {
 
 var updateAgentStateOnDoneFn = updateAgentStateOnDone
 
-func updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID string, pushFailed, mrFailed bool) error {
+var recordObservedCleanupStatusFn = recordObservedCleanupStatus
+
+func updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID, agentBeadID string, pushFailed, mrFailed bool) error {
 	if !shouldUpdateAgentStateOnDone(pushFailed, mrFailed) {
 		style.PrintWarning("skipping agent cleanup because push or MR submission failed")
+		// The lifecycle update is skipped on purpose so Witness can recover the
+		// still-open work, but cleanup_status is an observation of the worktree,
+		// not a lifecycle decision. Skipping it too leaves the field permanently
+		// absent, and an absent cleanup_status blocks reuse forever — the polecat
+		// is then held out of service by an unwritten field rather than by any
+		// real risk (gt-ets).
+		recordObservedCleanupStatusFn(cwd, agentBeadID)
 		return nil
 	}
 	return updateAgentStateOnDoneFn(cwd, townRoot, exitType, issueID)
+}
+
+// recordObservedCleanupStatus writes the observed git cleanup status to the
+// agent bead without touching hook_bead or agent_state. Best-effort: gt done
+// must finish even when the bead write fails.
+func recordObservedCleanupStatus(cwd, agentBeadID string) {
+	if agentBeadID == "" {
+		return
+	}
+	status := parseCleanupStatus(doneCleanupStatus)
+	if status == polecat.CleanupUnknown {
+		return
+	}
+	// Agent beads live in the town DB despite their rig prefix.
+	if err := beads.New(cwd).ForAgentBead().UpdateAgentCleanupStatus(agentBeadID, string(status)); err != nil {
+		style.PrintWarning("could not record cleanup_status on agent bead %s: %v", agentBeadID, err)
+	}
 }
 
 func resolveDonePolecatWorktree() (donePolecatWorktree, error) {
@@ -1923,7 +1949,7 @@ notifyWitness:
 
 	// Update agent bead state (ZFC: self-report completion). If push/MR failed,
 	// keep the hook intact so Witness can recover the still-open work.
-	if err := updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID, pushFailed, mrFailed); err != nil {
+	if err := updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID, agentBeadID, pushFailed, mrFailed); err != nil {
 		return err
 	}
 

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -943,21 +943,65 @@ func TestUpdateAgentStateAfterSubmissionSkipsFailedSubmissions(t *testing.T) {
 	}
 	t.Cleanup(func() { updateAgentStateOnDoneFn = old })
 
-	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", true, false); err != nil {
+	oldRecord := recordObservedCleanupStatusFn
+	recordObservedCleanupStatusFn = func(cwd, agentBeadID string) {}
+	t.Cleanup(func() { recordObservedCleanupStatusFn = oldRecord })
+
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", true, false); err != nil {
 		t.Fatalf("updateAgentStateAfterSubmission push failure: %v", err)
 	}
-	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", false, true); err != nil {
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", false, true); err != nil {
 		t.Fatalf("updateAgentStateAfterSubmission mr failure: %v", err)
 	}
 	if calls != 0 {
 		t.Fatalf("state update calls after failed submissions = %d, want 0", calls)
 	}
 
-	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", false, false); err != nil {
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", false, false); err != nil {
 		t.Fatalf("updateAgentStateAfterSubmission clean submission: %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("state update calls after clean submission = %d, want 1", calls)
+	}
+}
+
+// A failed push or MR submission must still record the observed cleanup_status.
+// Leaving the field unwritten is what strands a polecat: an absent
+// cleanup_status blocks reuse forever even though the worktree is clean (gt-ets).
+func TestUpdateAgentStateAfterSubmissionRecordsCleanupStatusOnFailure(t *testing.T) {
+	old := updateAgentStateOnDoneFn
+	updateAgentStateOnDoneFn = func(cwd, townRoot, exitType, issueID string) error { return nil }
+	t.Cleanup(func() { updateAgentStateOnDoneFn = old })
+
+	var gotBeadIDs []string
+	oldRecord := recordObservedCleanupStatusFn
+	recordObservedCleanupStatusFn = func(cwd, agentBeadID string) {
+		gotBeadIDs = append(gotBeadIDs, agentBeadID)
+	}
+	t.Cleanup(func() { recordObservedCleanupStatusFn = oldRecord })
+
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", false, true); err != nil {
+		t.Fatalf("mr failure: %v", err)
+	}
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", true, false); err != nil {
+		t.Fatalf("push failure: %v", err)
+	}
+	if len(gotBeadIDs) != 2 {
+		t.Fatalf("cleanup status recordings after failed submissions = %d, want 2", len(gotBeadIDs))
+	}
+	for _, id := range gotBeadIDs {
+		if id != "gt-rig-polecat-p" {
+			t.Fatalf("recorded cleanup status for agent bead %q, want gt-rig-polecat-p", id)
+		}
+	}
+
+	// A clean submission goes through the full lifecycle update, which writes
+	// cleanup_status itself — no extra recording.
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", "gt-rig-polecat-p", false, false); err != nil {
+		t.Fatalf("clean submission: %v", err)
+	}
+	if len(gotBeadIDs) != 2 {
+		t.Fatalf("cleanup status recordings after clean submission = %d, want 2", len(gotBeadIDs))
 	}
 }
 

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -498,7 +498,12 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "warning: failed to list polecats in %s: %v\n", r.Name, err)
 			continue
 		}
-		agents, agentErr := bd.ListAgentBeads()
+		// Agent beads live in the TOWN database even though their IDs carry the
+		// rig prefix. Listing them through the rig-scoped wrapper returns zero
+		// rows, so every polecat renders with empty agent fields and an absent
+		// cleanup_status — town-wide NEEDS_RECOVERY regardless of real state
+		// (gt-ets). ForAgentBead re-roots the query at the town DB.
+		agents, agentErr := bd.ForAgentBead().ListAgentBeads()
 		if agentErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to list agent beads in %s: %v\n", r.Name, agentErr)
 			agents = nil
@@ -1240,7 +1245,14 @@ func applyGitStateToWorkstateInput(input *polecat.WorkstateInput, worktreePath s
 		input.GitCheckFailedReason = recoveryGitStateBlocker(worktreePath, gitState, gitErr)
 		return
 	}
-	if gitState == nil || gitState.Clean {
+	if gitState == nil {
+		return
+	}
+	// Live git facts were gathered for this worktree, so an agent bead that
+	// never had cleanup_status written can be judged on observed state rather
+	// than on the absence of the field (gt-ets).
+	input.GitStateKnown = true
+	if gitState.Clean {
 		return
 	}
 	if gitState.UnpushedCommits > 0 {

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -213,7 +213,10 @@ func polecatCapacitySnapshotForTownNoCleanup(townRoot string) (polecatCapacitySn
 		}
 
 		rigBeads := beads.New(rigPath)
-		agents, err := rigBeads.ListAgentBeads()
+		// Agent beads live in the town DB despite their rig prefix; a
+		// rig-scoped list returns nothing and every slot is counted as
+		// recovery-blocked (gt-ets).
+		agents, err := rigBeads.ForAgentBead().ListAgentBeads()
 		if err != nil {
 			return snapshot, fmt.Errorf("listing agent beads for %s capacity: %w", rigName, err)
 		}

--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -269,8 +269,9 @@ func runPolecatIdentityList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get all agent beads
+	// Agent beads live in the town DB despite their rig prefix (gt-ets).
 	bd := beads.New(r.Path)
-	agentBeads, err := bd.ListAgentBeads()
+	agentBeads, err := bd.ForAgentBead().ListAgentBeads()
 	if err != nil {
 		return fmt.Errorf("listing agent beads: %w", err)
 	}

--- a/internal/cmd/polecat_inventory.go
+++ b/internal/cmd/polecat_inventory.go
@@ -88,6 +88,12 @@ func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *
 	}
 
 	input := polecat.WorkstateInput{State: polecat.StateIdle}
+	// No agent bead means no evidence about this polecat at all. Fail closed,
+	// but say why: reporting the empty cleanup_status instead hid a whole rig's
+	// worth of agent beads being read from the wrong database (gt-ets).
+	if fields == nil {
+		input.AgentBeadMissing = true
+	}
 	if fields != nil {
 		item.CleanupStatus = strings.TrimSpace(fields.CleanupStatus)
 		item.ActiveMR = strings.TrimSpace(fields.ActiveMR)

--- a/internal/cmd/polecat_inventory_test.go
+++ b/internal/cmd/polecat_inventory_test.go
@@ -196,3 +196,71 @@ func TestPolecatNameFromAssignee(t *testing.T) {
 		}
 	}
 }
+
+// gt-ets: when the agent bead can't be read, the inventory must say so rather
+// than report the resulting empty cleanup_status as the defect. Blaming
+// cleanup_status hid every polecat's agent bead being read from the rig
+// database instead of the town database — six polecats rendered identically
+// as "cleanup_status=<missing>" while three of them had it written as clean.
+func TestBuildPolecatInventoryItemMissingAgentBeadNamesItself(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet(nil)
+
+	item := buildPolecatInventoryItem("gastown", "ghost", nil, nil, sessions)
+
+	if item.Disposition.Reusable {
+		t.Fatal("a polecat with no readable agent bead must not be reusable")
+	}
+	if item.Disposition.Reason != "agent-bead-missing" {
+		t.Fatalf("reason = %q, want %q", item.Disposition.Reason, "agent-bead-missing")
+	}
+	for _, blocker := range item.Disposition.Blockers {
+		if strings.Contains(blocker, "cleanup_status") {
+			t.Fatalf("blockers = %v, want no cleanup_status blocker when the bead itself is missing", item.Disposition.Blockers)
+		}
+	}
+}
+
+// A readable agent bead reporting cleanup_status=clean must stay reusable, and
+// must not be dragged down by the missing-bead blocker.
+func TestBuildPolecatInventoryItemCleanAgentBeadIsReusable(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet(nil)
+
+	fields := &beads.AgentFields{
+		RoleType:      "polecat",
+		Rig:           "gastown",
+		AgentState:    "idle",
+		CleanupStatus: "clean",
+		Branch:        "polecat/obsidian/gt-cw1",
+	}
+	item := buildPolecatInventoryItem("gastown", "obsidian", fields, nil, sessions)
+
+	if !item.Disposition.Reusable {
+		t.Fatalf("clean idle polecat not reusable: reason=%q blockers=%v", item.Disposition.Reason, item.Disposition.Blockers)
+	}
+}
+
+// mr_failed on the agent bead is a real blocker and must survive: it is the
+// blocker that a rig-scoped (empty) agent bead read was masking.
+func TestBuildPolecatInventoryItemSurfacesMRFailed(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet(nil)
+
+	fields := &beads.AgentFields{
+		RoleType:      "polecat",
+		Rig:           "gastown",
+		AgentState:    "idle",
+		CleanupStatus: "clean",
+		Branch:        "polecat/jasper/gt-cw1",
+		MRFailed:      true,
+	}
+	item := buildPolecatInventoryItem("gastown", "jasper", fields, nil, sessions)
+
+	if item.Disposition.Reusable {
+		t.Fatal("polecat with mr_failed=true must not be reusable")
+	}
+	if item.Disposition.Reason != "mr-failed" {
+		t.Fatalf("reason = %q, want %q", item.Disposition.Reason, "mr-failed")
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2321,8 +2321,10 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 	_, fields, err := m.agentBeads().GetAgentBead(agentID)
 	hookSafe := true
 	hookTerminal := false
-	if err != nil {
-		input.GitCheckFailed = true
+	if err != nil || fields == nil {
+		// A bead that cannot be read is not a git failure. Labeling it as one
+		// sends recovery after the worktree instead of the bead (gt-ets).
+		input.AgentBeadMissing = true
 	}
 	if err == nil && fields != nil {
 		hookSafe, hookTerminal = m.hookBeadSafeForWorkstate(fields.HookBead)
@@ -2370,13 +2372,12 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 			input.GitCheckFailed = true
 		}
 	}
-	// Legacy/test polecats can lack agent cleanup metadata. If git proves there is
-	// no local work at risk, treat the missing cleanup_status as clean; otherwise
-	// DecideSlotReuse will continue to fail closed on CleanupUnknown.
+	// The git predicates above were actually evaluated here, so DecideWorkstate
+	// may use them to settle a missing/unknown cleanup_status. Reporting the
+	// evidence instead of rewriting CleanupStatus to "clean" keeps the field's
+	// real value visible to callers that surface it (gt-ets).
+	input.GitStateKnown = true
 	gitSafe := !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0
-	if input.CleanupStatus == CleanupUnknown && gitSafe {
-		input.CleanupStatus = CleanupClean
-	}
 	activeMRSafe := true
 	sourceTerminal := sourceHint != "" && m.assignedBeadTerminal(sourceHint)
 	if activeMR != "" {

--- a/internal/polecat/reuse.go
+++ b/internal/polecat/reuse.go
@@ -22,6 +22,7 @@ type SlotReuseInput struct {
 	UnpushedCommits      int
 	GitCheckFailed       bool
 	GitCheckFailedReason string
+	GitStateKnown        bool
 	ActiveMR             string
 	ActiveMRBlocker      string
 	MQCheckRequired      bool
@@ -55,6 +56,7 @@ func DecideSlotReuse(in SlotReuseInput) SlotReuseDecision {
 		UnpushedCommits:      in.UnpushedCommits,
 		GitCheckFailed:       in.GitCheckFailed,
 		GitCheckFailedReason: in.GitCheckFailedReason,
+		GitStateKnown:        in.GitStateKnown,
 		ActiveMR:             in.ActiveMR,
 		ActiveMRBlocker:      in.ActiveMRBlocker,
 		MQCheckRequired:      in.MQCheckRequired,

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -13,10 +13,21 @@ const (
 // WorkstateInput contains the lifecycle, git, and merge-queue facts needed to
 // classify a polecat consistently across list, recovery, witness, and capacity.
 type WorkstateInput struct {
-	State                          State
-	HookBead                       string
-	CleanupStatus                  CleanupStatus
-	IgnoreCleanupStatus            bool
+	State    State
+	HookBead string
+	// AgentBeadMissing records that the polecat's agent bead could not be read
+	// at all. Every other field is then a zero value rather than an
+	// observation, so the classifier must say so instead of blaming whichever
+	// predicate happens to be empty.
+	AgentBeadMissing    bool
+	CleanupStatus       CleanupStatus
+	IgnoreCleanupStatus bool
+	// GitStateKnown records that the caller gathered live git facts for this
+	// polecat, so GitCheckFailed/GitDirty/StashCount/UnpushedCommits carry
+	// evidence rather than zero values. Callers that cannot inspect the
+	// worktree must leave it false: an absent cleanup_status only stops
+	// blocking when a clean tree has been positively observed.
+	GitStateKnown                  bool
 	PartialSpawnWithoutDurableHook bool
 	PushFailed                     bool
 	MRFailed                       bool
@@ -101,6 +112,12 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		capacityBlocked = capacityBlocked || countsTowardCapacity
 	}
 
+	// Checked first so its reason wins: when the agent bead is unreadable the
+	// remaining fields carry no evidence, and reporting a downstream predicate
+	// (an empty cleanup_status, say) sends recovery after the wrong defect.
+	if in.AgentBeadMissing {
+		block("agent-bead-missing", "agent_bead=<not found>", true)
+	}
 	if in.HookBead != "" && !in.PartialSpawnWithoutDurableHook {
 		block("hook-still-set", "has work on hook ("+in.HookBead+")", true)
 	}
@@ -113,7 +130,14 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 	if in.ActiveWorkBlocker != "" {
 		block("active-work", in.ActiveWorkBlocker, in.ActiveWorkCountsTowardCapacity)
 	}
-	if !in.IgnoreCleanupStatus && !in.CleanupStatus.IsSafe() {
+	// An absent or unknown cleanup_status is ambiguous, not dangerous. Failing
+	// closed on it is right only while nothing else proves the worktree safe;
+	// when the caller has actually looked at git and found a clean tree, that
+	// positive evidence settles the ambiguity. Without this, a field that is
+	// simply never written strands a polecat permanently (gt-ets). Absence
+	// plus an unknown or dirty tree still blocks, and a KNOWN-unsafe status
+	// (has_uncommitted/has_stash/has_unpushed) always blocks regardless of git.
+	if !in.IgnoreCleanupStatus && !in.CleanupStatus.IsSafe() && !cleanupAbsenceResolvedByGit(in) {
 		reason := "cleanup-" + string(in.CleanupStatus)
 		blocker := "cleanup_status=" + string(in.CleanupStatus)
 		if in.CleanupStatus == "" {
@@ -198,6 +222,20 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		d.ReuseStatus = "idle-clean"
 	}
 	return d
+}
+
+// cleanupAbsenceResolvedByGit reports whether a missing or unknown
+// cleanup_status is answered by directly observed git state. It deliberately
+// requires GitStateKnown: a caller that never ran the git checks presents the
+// same zero values as a clean worktree, and must keep failing closed.
+func cleanupAbsenceResolvedByGit(in WorkstateInput) bool {
+	if in.CleanupStatus != "" && in.CleanupStatus != CleanupUnknown {
+		return false
+	}
+	if !in.GitStateKnown || in.GitCheckFailed {
+		return false
+	}
+	return !in.GitDirty && in.StashCount == 0 && in.UnpushedCommits == 0
 }
 
 // CanIgnoreStaleCleanupStatus returns true when a dirty persisted

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -144,3 +144,93 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 		})
 	}
 }
+
+// gt-ets: a cleanup_status that was never written must not strand a polecat
+// whose worktree has been directly observed to be clean — but absence with no
+// git evidence, or with evidence of risk, still fails closed.
+func TestDecideWorkstateMissingCleanupStatusNeedsGitEvidence(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           WorkstateInput
+		wantReusable bool
+		wantReason   string
+	}{
+		{
+			name:         "missing cleanup status with observed clean tree is reusable",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true},
+			wantReusable: true,
+			wantReason:   "reusable",
+		},
+		{
+			name:         "unknown cleanup status with observed clean tree is reusable",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: CleanupUnknown, Branch: "polecat/test", GitStateKnown: true},
+			wantReusable: true,
+			wantReason:   "reusable",
+		},
+		{
+			name:         "missing cleanup status without git evidence still blocks",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test"},
+			wantReusable: false,
+			wantReason:   "cleanup-unknown",
+		},
+		{
+			name:         "missing cleanup status with failed git check still blocks",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true, GitCheckFailed: true, GitCheckFailedReason: "git_state=unknown"},
+			wantReusable: false,
+			wantReason:   "cleanup-unknown",
+		},
+		{
+			name:         "missing cleanup status with dirty tree still blocks",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true, GitDirty: true},
+			wantReusable: false,
+			wantReason:   "cleanup-unknown",
+		},
+		{
+			name:         "missing cleanup status with unpushed commits still blocks",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true, UnpushedCommits: 2},
+			wantReusable: false,
+			wantReason:   "cleanup-unknown",
+		},
+		{
+			name:         "missing cleanup status with stash still blocks",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true, StashCount: 1},
+			wantReusable: false,
+			wantReason:   "cleanup-unknown",
+		},
+		{
+			name:         "known-unsafe cleanup status blocks even with a clean tree",
+			in:           WorkstateInput{State: StateIdle, CleanupStatus: CleanupUncommitted, Branch: "polecat/test", GitStateKnown: true},
+			wantReusable: false,
+			wantReason:   "cleanup-has_uncommitted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideWorkstate(tt.in)
+			if got.Reusable != tt.wantReusable {
+				t.Fatalf("DecideWorkstate() reusable = %v, want %v (reason %q, blockers %v)", got.Reusable, tt.wantReusable, got.Reason, got.Blockers)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("DecideWorkstate() reason = %q, want %q", got.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// Other blockers must survive the missing-cleanup_status relaxation: a polecat
+// whose MR submission failed still needs recovery even with a clean worktree.
+func TestDecideWorkstateMissingCleanupStatusKeepsOtherBlockers(t *testing.T) {
+	got := DecideWorkstate(WorkstateInput{State: StateIdle, CleanupStatus: "", Branch: "polecat/test", GitStateKnown: true, MRFailed: true})
+	if got.Reusable {
+		t.Fatalf("DecideWorkstate() reusable = true with mr_failed set, want false")
+	}
+	if got.Reason != "mr-failed" {
+		t.Fatalf("DecideWorkstate() reason = %q, want %q", got.Reason, "mr-failed")
+	}
+	for _, blocker := range got.Blockers {
+		if blocker == "cleanup_status=<missing>" {
+			t.Fatalf("DecideWorkstate() reported a phantom cleanup blocker alongside %v", got.Blockers)
+		}
+	}
+}

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1054,6 +1054,9 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	} else {
 		input.GitCheckFailed = true
 	}
+	// The git predicates above were actually evaluated here (failures recorded
+	// in GitCheckFailed), so a missing cleanup_status can be settled by them.
+	input.GitStateKnown = true
 	gitSafe := !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0
 	activeMRSafe := true
 	sourceTerminal := fields != nil && issueID != "" && witnessIssueTerminal(rigBeads, issueID)


### PR DESCRIPTION
Fixes gt-ets.

Six of seven polecats rendered `NEEDS_RECOVERY` on the single predicate `cleanup_status=<missing>` while every worktree was present and clean. **Three defects produced that, and only the third is the one the bead describes.**

## 1. `gt polecat list` and the capacity snapshot read agent beads from the *rig* database

Agent beads live in the **town** database even though their IDs carry the rig prefix, so the rig-scoped query returns zero rows:

```
$ cd ~/gt/gastown && bd list --label=gt:agent --include-infra --json --flat | jq length
0
$ cd ~/gt        && bd list --label=gt:agent --include-infra --json --flat | jq length
17
```

Every polecat was therefore classified from an all-zero `WorkstateInput`, and the resulting empty `cleanup_status` was reported as the blocker. That is why all six rendered *identically* although obsidian, onyx and quartz have `cleanup_status: clean` written on their beads, and why `mr_failed=true` and topaz's `agent_state=working` / `hook_bead=gt-6sg` never surfaced in the list. `gt polecat check-recovery` goes through the manager and always showed the real blockers — the two commands disagreed and nobody compared them.

Fixed by routing the agent-bead listing through `ForAgentBead()` in `gt polecat list`, the capacity snapshot, and `gt polecat identity list`.

## 2. Absence blocked even with a directly observed clean tree

When the agent bead exists but `cleanup_status` is absent, `check-recovery` skipped the git fallback its no-bead branch already had.

`WorkstateInput.GitStateKnown` now lets an absent or unknown `cleanup_status` stop blocking **only** when the caller actually ran the git checks *and* found the tree clean. Absence plus unknown, dirty or failed git still blocks; a known-unsafe status (`has_uncommitted` / `has_stash` / `has_unpushed`) always blocks. Callers that cannot inspect the worktree leave the flag false and keep failing closed — a zero value must never be mistaken for a clean tree.

This replaces the manager's silent coercion of `CleanupUnknown` → `CleanupClean`, so the field's real value stays visible to callers that surface it.

## 3. `gt done` never wrote the field on the path that mattered

`updateAgentStateAfterSubmission` returned early when push or MR submission failed, skipping the `cleanup_status` write entirely — exactly why jasper, opal and topaz (all `mr_failed: true`) have `cleanup_status: null`. Skipping the *lifecycle* update is deliberate so Witness can recover the still-open work, but `cleanup_status` is an observation of the worktree, not a lifecycle decision. The failure path now records it without touching `hook_bead` or `agent_state`.

## Also: an unreadable agent bead now names itself

`agent-bead-missing` / `agent_bead=<not found>` instead of blaming the empty `cleanup_status` it leaves behind. Same class of misdiagnosis as hq-s0n, where an ENOENT surfaced as "git binary absent". The manager was labelling an unreadable bead as `GitCheckFailed` (`git_state=unknown`). Verdict unchanged, diagnosis honest — and it is the signal that would have made defect 1 visible in hours rather than days.

## Verification against the live town (read-only commands only)

**Before** — all eight polecats: `reason=cleanup-unknown`, `blockers=[cleanup_status=<missing>]`, `reusable=false`, including `sandbox/chrome`.

**After** — `gt polecat list --all`:

| polecat | reason | blockers | cleanup |
|---|---|---|---|
| jasper | mr-failed | `mr_failed=true`, `cleanup_status=<missing>` | – |
| obsidian | mr-failed | `mr_failed=true`, `agent_state=stuck` | clean |
| onyx | active-work | `agent_state=stuck` | clean |
| opal | mr-failed | `mr_failed=true`, `cleanup_status=<missing>` | – |
| quartz | mr-failed | `mr_failed=true`, `agent_state=stuck` | clean |
| topaz | not-idle | `agent_state=working` | – |
| sandbox/chrome | **reusable** | – | clean |

`sandbox/chrome` was held out of service by the phantom blocker alone and is reusable again. `check-recovery`, which has git evidence, drops the cleanup blocker for jasper, topaz and opal entirely. Every remaining blocker is real state rather than a phantom.

**No polecat was nuked, reset or modified.** All six worktrees were verified present and clean throughout.

## The reuse gate's `hook_bead` handling is unchanged and still holds

`ReuseIdlePolecat` blocks unless `hookBeadSafeForWorkstate` proves the hook bead terminal (a lookup failure blocks too), then `resetAgentBeadForReuse` **clears** `hook_bead` before the new one is written. Verified by reading `manager.go`, not assumed. The relaxation here is scoped to `cleanup_status` alone and cannot unblock a set `hook_bead`, so it does not re-arm the hq-8x6 restart loop.

## Not absorbed here — filed as discovered work

`mr_failed` is never cleared, and after this fix it is the **only** remaining blocker on five of six gastown polecats. In this fork-backed rig the Refinery/MQ is disabled by default, so `gt done` attempting an MQ submission and failing is the *expected* path — every polecat that completes work here ends with the flag set and is never reusable again. That is the remaining half of the town-wide capacity loss. It must not be fixed by ignoring the flag: it records a real failed submission and should keep blocking until the work is verified delivered. Details are in a comment on gt-ets.

## Tests

`./internal/polecat` and `./internal/witness` are green. `./internal/cmd` has two failures, both pre-existing and reproduced on the base commit `649b832b` in a pristine worktree: `TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir` and `TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown`, both comparing a `t.TempDir()` path against its `/private`-prefixed resolution on macOS. Neither touches this change.

New coverage: `GitStateKnown` truth table (absence + clean tree reusable; absence without evidence, with failed git, dirty, unpushed or stashed still blocks; known-unsafe always blocks), other blockers surviving the relaxation, the missing-agent-bead diagnosis, and `gt done` recording `cleanup_status` on the push/MR failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FybpzG6bo5hxUMWJyaDebq
