### PR TITLE
fix(tmux): press Down before Enter when trust dialog pre-selects "No, exit"

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2014,7 +2014,12 @@ func (t *Tmux) AcceptWorkspaceTrustDialog(session string) error {
 		// Codex trust screens include a leading ">" banner line, so prompt
 		// detection alone would exit too early.
 		if containsWorkspaceTrustDialog(content) {
-			// Dialog found — accept it (option 1 is pre-selected, just press Enter)
+			// Claude Code >= 2.1.25x pre-selects "No, exit"; move to the trust option first.
+			if trustDialogSelectsExit(content) {
+				_, _ = t.run("send-keys", "-t", session, "Down")
+				time.Sleep(150 * time.Millisecond)
+			}
+			// Accept the (now) selected trust option.
 			if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
 				return err
 			}
@@ -2035,6 +2040,13 @@ func (t *Tmux) AcceptWorkspaceTrustDialog(session string) error {
 
 	// Timeout — no dialog detected, safe to proceed
 	return nil
+}
+
+// trustDialogSelectsExit reports whether the Claude Code trust dialog has
+// "No, exit" as the highlighted option. Claude Code 2.1.25x pre-selects it,
+// so Enter alone would quit the agent; callers press Down first.
+func trustDialogSelectsExit(content string) bool {
+	return strings.Contains(content, "❯ No, exit") || strings.Contains(content, "> No, exit")
 }
 
 func containsWorkspaceTrustDialog(content string) bool {

--- a/internal/tmux/trust_dialog_test.go
+++ b/internal/tmux/trust_dialog_test.go
@@ -1,0 +1,21 @@
+package tmux
+
+import "testing"
+
+func TestTrustDialogSelectsExit(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"claude 2.1.252 default", "Quick safety check: ...\n ❯ No, exit\n   Yes, I trust this folder\n", true},
+		{"ascii caret", "> No, exit\n  Yes, I trust this folder", true},
+		{"trust option highlighted", "   No, exit\n ❯ Yes, I trust this folder", false},
+		{"no dialog", "❯ ", false},
+	}
+	for _, c := range cases {
+		if got := trustDialogSelectsExit(c.content); got != c.want {
+			t.Errorf("%s: got %v want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4818.

Claude Code 2.1.252 renders the workspace trust dialog with **"No, exit"** pre-selected:

```
 ❯ No, exit
   Yes, I trust this folder
 Enter to confirm · Esc to cancel
```

`AcceptWorkspaceTrustDialog` assumed option 1 was the trust option and sent `Enter`, so the agent quit and `gt sling` reported `session likely died during startup`. Polecats whose directory already had `hasTrustDialogAccepted` in `~/.claude.json` were unaffected, which made it look intermittent (reused names worked, fresh ones died).

Change: detect the highlighted `No, exit` line and send `Down` before `Enter`. Codex and older Claude dialogs are unchanged. Unit test for the detector added; the existing `*_NoDialog` tests in this package need a live tmux server and were failing before this change too.

Running on a production town since 2026-09-05 03:00 EDT; polecats spawn cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)