### PR TITLE
fix(doctor): bound git ls-remote with timeout to stop gt doctor hangs

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -128,6 +128,13 @@ func (g *Git) run(args ...string) (string, error) {
 // (e.g. GitLab) is unreachable or slow.
 const pushTimeout = 60 * time.Second
 
+// lsRemoteTimeout is the maximum time any git ls-remote (network query) is
+// allowed to run before being killed. The stalled-polecats and
+// identity-collision doctor checks shell out ls-remote against origin; without
+// a deadline a slow/unreachable remote hangs the whole `gt doctor` run past
+// the deacon health-check plugin's 30s budget. GH/doctor regression hq-wisp-90h0.
+const lsRemoteTimeout = 10 * time.Second
+
 // runWithTimeout executes a git command with a deadline. If the command does
 // not finish within the timeout, the process is killed and an error is returned.
 func (g *Git) runWithTimeout(timeout time.Duration, args ...string) (_ string, _ error) { //nolint:unparam // string return kept for consistency with Run()
@@ -1787,7 +1794,7 @@ type RemoteRef struct {
 // The prefix filters refs (e.g., "refs/heads/polecat/" for all polecat branches).
 // Returns full ref names like "refs/heads/polecat/furiosa-abc123".
 func (g *Git) ListRemoteRefsWithHashes(remote, prefix string) ([]RemoteRef, error) {
-	out, err := g.run("ls-remote", "--refs", remote, prefix+"*")
+	out, err := g.runWithTimeout(lsRemoteTimeout, "ls-remote", "--refs", remote, prefix+"*")
 	if err != nil {
 		return nil, err
 	}
@@ -1826,7 +1833,7 @@ func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
 // includes tags so callers can distinguish a truly empty repo from a non-empty
 // repo with no branch refs or a broken remote HEAD.
 func (g *Git) RemoteHasRefs(remote string) (bool, error) {
-	out, err := g.run("ls-remote", "--refs", remote)
+	out, err := g.runWithTimeout(lsRemoteTimeout, "ls-remote", "--refs", remote)
 	if err != nil {
 		return false, err
 	}
@@ -2033,7 +2040,7 @@ func (g *Git) IsEmpty() (bool, error) {
 // NOTE: For named remotes with a separate pushurl, this checks the fetch URL.
 // Use PushRemoteBranchExists to verify branches that were pushed.
 func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
-	out, err := g.run("ls-remote", "--heads", remote, branch)
+	out, err := g.runWithTimeout(lsRemoteTimeout, "ls-remote", "--heads", remote, branch)
 	if err != nil {
 		return false, err
 	}
@@ -2043,7 +2050,7 @@ func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 // RemoteBranchTip returns the SHA at refs/heads/<branch> on the remote.
 // An empty SHA with nil error means the branch is missing.
 func (g *Git) RemoteBranchTip(remote, branch string) (string, error) {
-	out, err := g.run("ls-remote", "--heads", remote, branch)
+	out, err := g.runWithTimeout(lsRemoteTimeout, "ls-remote", "--heads", remote, branch)
 	if err != nil {
 		return "", err
 	}
@@ -2060,7 +2067,7 @@ func (g *Git) PushRemoteBranchExists(remote, branch string) (bool, error) {
 	if pushTarget == remote {
 		return g.RemoteBranchExists(remote, branch)
 	}
-	out, err := g.run("ls-remote", "--heads", pushTarget, branch)
+	out, err := g.runWithTimeout(lsRemoteTimeout, "ls-remote", "--heads", pushTarget, branch)
 	if err != nil {
 		return false, err
 	}
@@ -3561,11 +3568,14 @@ func submoduleDefaultBranch(submodulePath, remote string) (string, error) {
 		}
 	}
 
-	// Fallback: network query via ls-remote
+	// Fallback: network query via ls-remote (bounded — see lsRemoteTimeout)
 	for _, candidate := range []string{"main", "master"} {
-		check := exec.Command("git", "-C", submodulePath, "ls-remote", "--exit-code", remote, "refs/heads/"+candidate)
+		ctx, cancel := context.WithTimeout(context.Background(), lsRemoteTimeout)
+		check := exec.CommandContext(ctx, "git", "-C", submodulePath, "ls-remote", "--exit-code", remote, "refs/heads/"+candidate)
 		util.SetDetachedProcessGroup(check)
-		if check.Run() == nil {
+		err := check.Run()
+		cancel()
+		if err == nil {
 			return candidate, nil
 		}
 	}


### PR DESCRIPTION
## Problem

The stalled-polecats and identity-collision doctor checks shell out `git ls-remote --heads origin polecat/<rig>/<bead>@<session>` without any deadline. A slow or unreachable remote hangs the whole `gt doctor` run, blowing the deacon health-check plugin's 30s budget.

Reproduced 3x in the wild (escalation hq-wisp-90h0); chronic since July (beads hq-1lzmr, hq-wxwbo).

## Fix

Route all `git ls-remote` (network) calls through the existing `runWithTimeout` helper with a new `lsRemoteTimeout = 10s`:

- `ListRemoteRefsWithHashes`
- `RemoteHasRefs`
- `RemoteBranchExists`
- `RemoteBranchTip`
- `PushRemoteBranchExists`
- submodule default-branch fallback (now uses `exec.CommandContext` with the same deadline)

On timeout the check reports a regular git error (doctor marks it failed) instead of hanging forever.

## Verification

- `go build ./internal/git/` — clean
- `gofmt -l internal/git/git.go` — clean
- Full `go build ./...`/test blocked in this environment by a pre-existing native ICU dependency (`go-icu-regex` needs `unicode/regex.h`), unrelated to this change.