### PR TITLE
fix/refinery spawn deadlock

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -598,7 +598,7 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 			stateStr = style.Info.Render(stateStr)
 		case polecat.StateStuck:
 			stateStr = style.Warning.Render(stateStr)
-		case polecat.StateStalled:
+		case polecat.StateStalled, polecat.StateBlocked:
 			stateStr = style.Error.Render(stateStr)
 		case polecat.StateReviewNeeded:
 			stateStr = style.Warning.Render(stateStr)
@@ -801,7 +801,7 @@ func runPolecatStatus(cmd *cobra.Command, args []string) error {
 		stateStr = style.Info.Render(stateStr)
 	case polecat.StateStuck:
 		stateStr = style.Warning.Render(stateStr)
-	case polecat.StateStalled:
+	case polecat.StateStalled, polecat.StateBlocked:
 		stateStr = style.Error.Render(stateStr)
 	case polecat.StateReviewNeeded:
 		stateStr = style.Warning.Render(stateStr)

--- a/internal/cmd/polecat_inventory.go
+++ b/internal/cmd/polecat_inventory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 const polecatSessionKeySep = "\x00"
@@ -23,7 +24,15 @@ type polecatInventoryItem struct {
 	Branch         string
 	SessionRunning bool
 	SessionName    string
+	BlockedReason  string
 	Disposition    polecat.WorkstateDisposition
+}
+
+// probePolecatBlocked reports why a live polecat session shows no evidence of
+// progress, or "" when it shows some. A package var so tests can drive the
+// verdict without a tmux server; production always probes real tmux.
+var probePolecatBlocked = func(sessionName string) string {
+	return polecat.SessionBlockedReason(tmux.NewTmux(), sessionName)
 }
 
 type polecatActiveWorkEvidence struct {
@@ -107,13 +116,22 @@ func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *
 		activeWorkEvidence = assessPolecatAgentStateWork(beads.AgentState(strings.TrimSpace(fields.AgentState)))
 	}
 
+	blockedReason := ""
 	if activeWorkEvidence.BlocksCleanup {
 		item.Issue = activeWorkEvidence.AssignedIssue
 		if activeWorkEvidence.RequiresRestart || activeWorkEvidence.CountsTowardCapacity {
-			if running {
-				item.State = polecat.StateWorking
-			} else {
+			switch {
+			case !running:
 				item.State = polecat.StateStalled
+			default:
+				// A session that EXISTS is not a session that WORKS. Ask for
+				// evidence of progress before claiming any (hq-3l8r).
+				blockedReason = probePolecatBlocked(sessionName)
+				if blockedReason != "" {
+					item.State = polecat.StateBlocked
+				} else {
+					item.State = polecat.StateWorking
+				}
 			}
 		} else if running && !polecat.CleanupStatus(item.CleanupStatus).IsSafe() {
 			item.State = polecat.StateReviewNeeded
@@ -135,6 +153,11 @@ func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *
 
 	input.State = item.State
 	item.Disposition = polecat.DecideWorkstate(input)
+	if blockedReason != "" {
+		item.BlockedReason = blockedReason
+		item.Disposition.Reason = "agent-blocked"
+		item.Disposition.Blockers = append(item.Disposition.Blockers, "agent_blocked="+blockedReason)
+	}
 	return item
 }
 

--- a/internal/cmd/polecat_inventory_test.go
+++ b/internal/cmd/polecat_inventory_test.go
@@ -196,3 +196,93 @@ func TestPolecatNameFromAssignee(t *testing.T) {
 		}
 	}
 }
+
+// stubPolecatBlockedProbe replaces the tmux probe for the duration of a test.
+func stubPolecatBlockedProbe(t *testing.T, reason string) {
+	t.Helper()
+	prev := probePolecatBlocked
+	probePolecatBlocked = func(string) string { return reason }
+	t.Cleanup(func() { probePolecatBlocked = prev })
+}
+
+// TestBuildPolecatInventoryItemReportsBlockedNotWorking is the regression test
+// for hq-3l8r. Three rho polecats held hooked work with live tmux sessions and a
+// dead Codex token; `gt polecat list` called all three "working" for six hours
+// while 972 commits piled up unpushed across 32 worktrees.
+//
+// The registry derived "working" from `tmux list-sessions` name presence alone
+// (polecat_inventory.go), so the two rows below differ in exactly one input: the
+// evidence-of-progress probe. Everything else — the hooked bead, the assignee,
+// the agent fields, the live session — is identical, which is what makes this a
+// proof rather than a demonstration. Revert the probe call and "blocked" becomes
+// "working" here, exactly as it did in production.
+func TestBuildPolecatInventoryItemReportsBlockedNotWorking(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet([]string{"gt-obsidian"})
+	fields := &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)}
+	work := &beads.Issue{ID: "gt-4di", Status: string(beads.IssueStatusHooked), Assignee: "gastown/polecats/obsidian"}
+
+	// Control: session live, probe sees progress → working (unchanged behaviour).
+	stubPolecatBlockedProbe(t, "")
+	working := buildPolecatInventoryItem("gastown", "obsidian", fields, work, sessions)
+	if working.State != polecat.StateWorking {
+		t.Fatalf("progressing polecat state = %q, want %q", working.State, polecat.StateWorking)
+	}
+	if working.Disposition.Verdict != polecat.WorkstateVerdictWorking {
+		t.Fatalf("progressing polecat verdict = %q, want %q", working.Disposition.Verdict, polecat.WorkstateVerdictWorking)
+	}
+
+	// Same live session, same hooked bead, no evidence of progress → blocked.
+	stubPolecatBlockedProbe(t, "provider error: access token could not be refreshed")
+	blocked := buildPolecatInventoryItem("gastown", "obsidian", fields, work, sessions)
+	if blocked.State == polecat.StateWorking {
+		t.Fatal("polecat with a live session but no evidence of progress reported as working; a session that exists is not a session that works (hq-3l8r)")
+	}
+	if blocked.State != polecat.StateBlocked {
+		t.Fatalf("blocked polecat state = %q, want %q", blocked.State, polecat.StateBlocked)
+	}
+	if blocked.Disposition.Verdict == polecat.WorkstateVerdictWorking {
+		t.Fatalf("blocked polecat verdict = %q, want anything but %q", blocked.Disposition.Verdict, polecat.WorkstateVerdictWorking)
+	}
+	// The operator must be able to read the cause off the row, not just the state.
+	if !strings.Contains(strings.Join(blocked.Disposition.Blockers, " "), "access token could not be refreshed") {
+		t.Fatalf("blockers = %v, want the probe's reason surfaced", blocked.Disposition.Blockers)
+	}
+	// The slot stays occupied: blocked work is not free capacity.
+	if !blocked.Disposition.CountsTowardCapacity {
+		t.Fatal("blocked polecat freed its capacity slot; the work is still on its hook")
+	}
+
+	// And the list layer must not promote it back to working.
+	if got := effectivePolecatState(PolecatListItem{
+		State:                blocked.State,
+		Issue:                blocked.Issue,
+		SessionRunning:       blocked.SessionRunning,
+		CountsTowardCapacity: blocked.Disposition.CountsTowardCapacity,
+	}); got != polecat.StateBlocked {
+		t.Fatalf("effectivePolecatState(blocked) = %q, want %q", got, polecat.StateBlocked)
+	}
+}
+
+// TestBuildPolecatInventoryItemDoesNotProbeDeadSessions keeps "no session" as
+// stalled rather than blocked: the two have different remedies (respawn vs.
+// unblock the agent) and collapsing them loses that.
+func TestBuildPolecatInventoryItemDoesNotProbeDeadSessions(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	probed := false
+	prev := probePolecatBlocked
+	probePolecatBlocked = func(string) string { probed = true; return "should not be consulted" }
+	t.Cleanup(func() { probePolecatBlocked = prev })
+
+	item := buildPolecatInventoryItem("gastown", "gone",
+		&beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+		&beads.Issue{ID: "gt-4di", Status: string(beads.IssueStatusHooked), Assignee: "gastown/polecats/gone"},
+		newPolecatSessionSet(nil))
+
+	if probed {
+		t.Error("probed tmux for a polecat with no session; wasted work")
+	}
+	if item.State != polecat.StateStalled {
+		t.Fatalf("sessionless polecat state = %q, want %q", item.State, polecat.StateStalled)
+	}
+}

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -1588,7 +1588,9 @@ func pathExists(path string) bool {
 }
 
 func isAgentSessionHealthy(t *tmux.Tmux, sessionName string) bool {
-	return t.CheckSessionHealth(sessionName, 0) == tmux.SessionHealthy
+	// Non-zero inactivity bound: a session whose agent process is alive but whose
+	// pane has produced nothing for this long is hung, not healthy (hq-3l8r).
+	return t.CheckSessionHealth(sessionName, polecat.NoProgressTimeout) == tmux.SessionHealthy
 }
 
 func runRigBoot(cmd *cobra.Command, args []string) error {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -439,6 +439,22 @@ var DefaultRateLimitPatterns = []string{
 	`OAuth token has expired`,                        // Token expired — needs fresh auth
 }
 
+// AgentBlockedPatterns are provider messages that end a session's ability to
+// act at all: the agent process is alive and its TUI may still redraw, but
+// every prompt it receives will be refused until a human intervenes.
+//
+// Every string here was copied verbatim from a pane during hq-3l8r, where three
+// rho polecats sat on a dead Codex token for six hours while every status
+// surface reported them "working". Matched with (?i) against the bottom of a
+// pane, and only ever as a SECOND trigger: the primary detector is cause-blind
+// (no pane output at all), so an error not listed here is still caught.
+var AgentBlockedPatterns = []string{
+	`access token could not be refreshed`, // Codex: stale token, or signed in elsewhere
+	`refresh token was revoked`,           // Codex: refresh token revoked
+	`please (log out and )?sign in again`, // Codex/Claude: re-auth required
+	`usage limit reset available`,         // Codex: quota exhausted, manual reset offered
+}
+
 // DefaultNearLimitPatterns are patterns that indicate a session is approaching
 // its rate limit but hasn't hit it yet. These enable proactive rotation before
 // the hard 429. Matched with (?i) for case-insensitive matching.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1745,6 +1745,33 @@ func (d *Daemon) hasPendingEvents(channel string) bool {
 	return false
 }
 
+// hasPendingMergeRequests checks if there are open merge requests in the queue for a rig.
+// Used to detect when refinery must spawn even with no event files present.
+func (d *Daemon) hasPendingMergeRequests(rigName string) bool {
+	r := &rig.Rig{
+		Name: rigName,
+		Path: filepath.Join(d.config.TownRoot, rigName),
+	}
+	b := beads.New(r.BeadsPath())
+
+	// Query for open merge requests. Empty Rig field means all rigs (not filtered).
+	// We pass the rigName to ensure we only count MRs for this specific rig.
+	opts := beads.ListOptions{
+		Label:    "gt:merge-request",
+		Priority: -1, // No priority filter
+		Status:   "open",
+		Rig:      rigName,
+	}
+
+	issues, err := b.ListMergeRequests(opts)
+	if err != nil {
+		// If query fails (beads unavailable, corrupted DB, etc), assume no MRs.
+		// The refinery will pick them up on the next event cycle if they exist.
+		return false
+	}
+	return len(issues) > 0
+}
+
 // ensureWitnessRunning ensures the witness for a specific rig is running.
 // Discover, don't track: uses Manager.Start() which checks tmux directly (gt-zecmc).
 func (d *Daemon) ensureWitnessRunning(rigName string) {
@@ -1842,7 +1869,8 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	// If a refinery session is already running, Start() returns ErrAlreadyRunning (cheap).
 	// But spawning a NEW session with an empty queue burns API credits for nothing.
 	// The refinery formula uses await-event internally, so it will wake when events appear.
-	if !d.hasPendingEvents("refinery") {
+	// Also check merge queue depth: a deep queue with no live session must spawn one.
+	if !d.hasPendingEvents("refinery") && !d.hasPendingMergeRequests(rigName) {
 		// Check if session already exists before skipping — let running sessions continue
 		r := &rig.Rig{
 			Name: rigName,
@@ -1850,7 +1878,7 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 		}
 		mgr := refinery.NewManager(r)
 		if running, _ := mgr.IsRunning(); !running {
-			d.logger.Printf("No pending refinery events and no session running for %s, skipping spawn", rigName)
+			d.logger.Printf("No pending refinery events or merge requests and no session running for %s, skipping spawn", rigName)
 			return
 		}
 	}

--- a/internal/polecat/liveness.go
+++ b/internal/polecat/liveness.go
@@ -1,0 +1,123 @@
+package polecat
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// NoProgressTimeout is how long a live polecat session's pane may produce no
+// output at all before the town reports it blocked instead of working.
+//
+// Agent TUIs redraw an elapsed-time counter roughly every second while they run
+// ("Working (10s)"), so a pane that has not changed for this long is not
+// thinking — it is stopped. The bound is deliberately the town's existing
+// "no progress with hooked work" bound so there is one number, not two.
+//
+// ponytail: a constant, not a config knob. Add the knob only if a real agent is
+// ever observed genuinely working with a completely silent pane for this long.
+var NoProgressTimeout = constants.GUPPViolationTimeout
+
+// SessionLiveness is the subset of tmux needed to judge whether a session is
+// making progress. It exists so the judgement is testable without a tmux
+// server; *tmux.Tmux is the only production implementation.
+type SessionLiveness interface {
+	CheckSessionHealth(session string, maxInactivity time.Duration) tmux.ZombieStatus
+	CapturePane(session string, lines int) (string, error)
+}
+
+// blockedPaneScanLines / blockedPaneCheckLines mirror internal/quota's scan
+// window: capture generously, match only the bottom, so an error that has since
+// scrolled up out of view does not keep firing.
+const (
+	blockedPaneScanLines  = 30
+	blockedPaneCheckLines = 20
+)
+
+// blockedPanePatterns are the provider errors that end a session's ability to
+// act. Rate-limit messages count: an agent that is being refused is not working,
+// whichever way the provider says no.
+var blockedPanePatterns = compileBlockedPatterns()
+
+func compileBlockedPatterns() []*regexp.Regexp {
+	raw := make([]string, 0, len(constants.DefaultRateLimitPatterns)+len(constants.AgentBlockedPatterns))
+	raw = append(raw, constants.DefaultRateLimitPatterns...)
+	raw = append(raw, constants.AgentBlockedPatterns...)
+
+	out := make([]*regexp.Regexp, 0, len(raw))
+	for _, p := range raw {
+		if re, err := regexp.Compile("(?i)" + p); err == nil {
+			out = append(out, re)
+		}
+	}
+	return out
+}
+
+// SessionBlockedReason reports why a live polecat session shows no evidence of
+// progress, or "" when it shows some.
+//
+// The presence of a tmux session is not evidence of progress, and collapsing the
+// two is the bug this closes (hq-3l8r). The primary check here is general and
+// cause-blind — is the agent process still there, and has the pane emitted
+// anything at all recently — so a failure mode nobody has seen yet still trips
+// it. The pane-text check is a second, INDEPENDENT trigger for the case where a
+// provider error stops the agent while its TUI keeps redrawing. It can only add
+// a verdict, never suppress one.
+//
+// A missing session returns "" — that is the caller's "stalled", not this
+// function's "blocked", and the two have different remedies.
+//
+// ponytail: two tmux round-trips per LIVE polecat session (a health probe, plus
+// a pane capture only when the health probe is green). Callers already hold a
+// single ListSessions result, so nothing is paid for polecats with no session.
+// Known ceiling: tmux counts an operator ATTACHING as activity, so a session
+// someone is watching cannot be judged hung while they watch it. The pane-text
+// arm still fires there. Batch via `list-panes -a` if this ever shows up in
+// `gt sling` admission latency.
+func SessionBlockedReason(t SessionLiveness, sessionName string) string {
+	if t == nil {
+		return ""
+	}
+	switch t.CheckSessionHealth(sessionName, NoProgressTimeout) {
+	case tmux.SessionDead:
+		return ""
+	case tmux.AgentDead:
+		return "agent process is gone"
+	case tmux.AgentHung:
+		return "no pane output for " + NoProgressTimeout.String()
+	}
+	if line := blockedPaneLine(t, sessionName); line != "" {
+		return "provider error: " + line
+	}
+	return ""
+}
+
+// blockedPaneLine returns the matched provider-error text from the bottom of the
+// pane, or "" when there is none.
+//
+// The bottom lines are joined before matching, not tested one at a time: tmux
+// hard-wraps a pane at its width, and every message worth matching here is long
+// enough to be split mid-phrase in a narrow pane. Per-line matching would miss
+// exactly the panes this exists to catch.
+func blockedPaneLine(t SessionLiveness, sessionName string) string {
+	content, err := t.CapturePane(sessionName, blockedPaneScanLines)
+	if err != nil {
+		// Cannot see the pane. Unknown is not blocked — the general check above
+		// already had its say.
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	if n := len(lines) - blockedPaneCheckLines; n > 0 {
+		lines = lines[n:]
+	}
+	bottom := strings.Join(strings.Fields(strings.Join(lines, " ")), " ")
+	for _, re := range blockedPanePatterns {
+		if match := re.FindString(bottom); match != "" {
+			return match
+		}
+	}
+	return ""
+}

--- a/internal/polecat/liveness_test.go
+++ b/internal/polecat/liveness_test.go
@@ -1,0 +1,189 @@
+package polecat
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+type fakeLiveness struct {
+	health   tmux.ZombieStatus
+	pane     string
+	paneErr  error
+	gotBound time.Duration
+}
+
+func (f *fakeLiveness) CheckSessionHealth(_ string, maxInactivity time.Duration) tmux.ZombieStatus {
+	f.gotBound = maxInactivity
+	return f.health
+}
+
+func (f *fakeLiveness) CapturePane(_ string, _ int) (string, error) {
+	return f.pane, f.paneErr
+}
+
+// The verbatim pane text measured on rho-obsidian, rho-onyx and rho-quartz
+// during hq-3l8r, hard-wrapped the way tmux wraps a pane. All three polecats
+// reported "working" while showing this.
+//
+// Every wrap deliberately falls MID-PHRASE, so no single line matches any
+// pattern on its own. That is not contrived: tmux wraps at the pane width, which
+// nothing here controls, and a matcher that tests one line at a time silently
+// misses these panes.
+const codexAuthPane = `> go test ./internal/polygon/settlement/...
+ok  	github.com/4rho/4rho/internal/polygon/settlement	10.770s
+
+Your access token could not
+be refreshed because you have since logged out or signed
+in to another account. Please sign
+in again.
+
+  Ask Codex to do anything
+`
+
+func TestSessionBlockedReason(t *testing.T) {
+	t.Parallel()
+
+	healthyPane := `⏺ Running tests…
+  Bash: go test ./internal/scheduler/...
+· Working (10s · esc to interrupt)
+`
+
+	tests := []struct {
+		name       string
+		fake       fakeLiveness
+		wantReason bool
+		wantSubstr string
+	}{{
+		// The exact production condition: process alive, TUI redrawing, agent dead.
+		name:       "auth error in pane while session looks healthy",
+		fake:       fakeLiveness{health: tmux.SessionHealthy, pane: codexAuthPane},
+		wantReason: true,
+		wantSubstr: "access token could not be refreshed",
+	}, {
+		name:       "quota wall in pane",
+		fake:       fakeLiveness{health: tmux.SessionHealthy, pane: "You've hit your usage limit. Visit chatgpt.com to purchase more credits.\n"},
+		wantReason: true,
+		wantSubstr: "hit your usage limit",
+	}, {
+		// The general arm: no pane output at all. Cause unknown and irrelevant.
+		name:       "no pane output",
+		fake:       fakeLiveness{health: tmux.AgentHung, pane: healthyPane},
+		wantReason: true,
+		wantSubstr: "no pane output",
+	}, {
+		name:       "agent process gone",
+		fake:       fakeLiveness{health: tmux.AgentDead, pane: healthyPane},
+		wantReason: true,
+		wantSubstr: "agent process is gone",
+	}, {
+		// No session is the caller's "stalled"; different remedy, not ours to claim.
+		name: "no session at all",
+		fake: fakeLiveness{health: tmux.SessionDead, pane: codexAuthPane},
+	}, {
+		name: "genuinely working",
+		fake: fakeLiveness{health: tmux.SessionHealthy, pane: healthyPane},
+	}, {
+		// An unreadable pane must not manufacture a verdict.
+		name: "pane capture fails",
+		fake: fakeLiveness{health: tmux.SessionHealthy, paneErr: errors.New("no server")},
+	}, {
+		// A resolved error scrolled above the check window must stop firing.
+		name: "auth error scrolled out of the check window",
+		fake: fakeLiveness{health: tmux.SessionHealthy, pane: codexAuthPane + strings.Repeat("recovered and working\n", blockedPaneCheckLines+2)},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := tc.fake
+			got := SessionBlockedReason(&fake, "rho-obsidian")
+			if tc.wantReason {
+				if got == "" {
+					t.Fatalf("SessionBlockedReason() = %q, want a blocked reason", got)
+				}
+				if !strings.Contains(got, tc.wantSubstr) {
+					t.Fatalf("SessionBlockedReason() = %q, want it to contain %q", got, tc.wantSubstr)
+				}
+				return
+			}
+			if got != "" {
+				t.Fatalf("SessionBlockedReason() = %q, want \"\"", got)
+			}
+		})
+	}
+}
+
+// TestSessionBlockedReason_PassesInactivityBound guards the one-character
+// regression that recreates this bug: passing 0 makes tmux skip the activity
+// check entirely, which is what every polecat caller did before hq-3l8r.
+func TestSessionBlockedReason_PassesInactivityBound(t *testing.T) {
+	t.Parallel()
+	fake := fakeLiveness{health: tmux.SessionHealthy}
+	SessionBlockedReason(&fake, "rho-obsidian")
+	if fake.gotBound <= 0 {
+		t.Fatalf("SessionBlockedReason passed maxInactivity=%v to CheckSessionHealth; 0 disables hang detection", fake.gotBound)
+	}
+}
+
+// TestSessionBlockedReason_NilTmux keeps the tmux-less paths (tests, hosts with
+// no tmux) reporting "unknown", never "blocked".
+func TestSessionBlockedReason_NilTmux(t *testing.T) {
+	t.Parallel()
+	if got := SessionBlockedReason(nil, "rho-obsidian"); got != "" {
+		t.Fatalf("SessionBlockedReason(nil) = %q, want \"\"", got)
+	}
+}
+
+// TestSessionBlockedReason_RealTmuxPane runs the pane check against a real tmux
+// server, because the risk this fix carries is not the regex — it is whether
+// capture-pane output still carries the phrase after the terminal has broken it
+// across lines. The message is printed pre-split mid-phrase (deterministic at any
+// pane width), which is precisely the case a per-line matcher would miss.
+func TestSessionBlockedReason_RealTmuxPane(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	tm := tmux.NewTmux()
+	sessionName := fmt.Sprintf("gt-test-blocked-%d", os.Getpid())
+	// Print the measured error split mid-phrase, then exec sleep so
+	// pane_current_command is a process we can declare as the agent (keeping the
+	// general arm green, so only the pane text can produce a verdict).
+	cmd := `printf '%s\n' 'Your access token could not' 'be refreshed because you have since logged out or signed' 'in to another account. Please sign' 'in again.' '' '  Ask Codex to do anything'; exec sleep 60`
+	if err := tm.NewSessionWithCommand(sessionName, "", "sh -c "+shellQuote(cmd)); err != nil {
+		t.Skipf("cannot create tmux session: %v", err)
+	}
+	defer tm.KillSession(sessionName)
+	if err := tm.SetEnvironment(sessionName, "GT_PROCESS_NAMES", "sleep"); err != nil {
+		t.Fatalf("SetEnvironment: %v", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	if !tm.IsAgentAlive(sessionName) {
+		t.Skip("tmux did not report the declared pane process as alive")
+	}
+	// Sanity: the general arm must be green, so the only thing that can produce a
+	// verdict below is the pane text.
+	if status := tm.CheckSessionHealth(sessionName, time.Hour); status != tmux.SessionHealthy {
+		t.Skipf("session not healthy (%v); pane-text arm not exercised", status)
+	}
+
+	got := SessionBlockedReason(tm, sessionName)
+	if got == "" {
+		pane, _ := tm.CapturePane(sessionName, 30)
+		t.Fatalf("SessionBlockedReason() = \"\" for a pane carrying the measured Codex auth error; pane was:\n%s", pane)
+	}
+	if !strings.Contains(got, "provider error:") {
+		t.Fatalf("SessionBlockedReason() = %q, want a provider-error reason", got)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2754,6 +2754,24 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	sessionRunning, sessionStale := m.polecatSessionState(name)
 	sessionDead := m.tmux != nil && (!sessionRunning || sessionStale)
 
+	// A live session is not a working agent. Before reporting "working" below,
+	// ask for evidence of progress: an agent whose pane has gone silent, or whose
+	// pane carries a provider error that refuses every prompt, is blocked (hq-3l8r).
+	blockedReason := ""
+	if m.tmux != nil && !sessionDead {
+		blockedReason = SessionBlockedReason(m.tmux, session.PolecatSessionName(session.PrefixFor(m.rig.Name), name))
+	}
+	workState := func() State {
+		switch {
+		case sessionDead:
+			return StateStalled
+		case blockedReason != "":
+			return StateBlocked
+		default:
+			return StateWorking
+		}
+	}
+
 	// Primary source: the work bead itself (status=hooked + assignee).
 	// This is the direct-tracking model introduced in hq-l6mm5.
 	hookedBeads, hookedErr := m.beads.List(beads.ListOptions{
@@ -2762,14 +2780,10 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		Priority: -1,
 	})
 	if hookedErr == nil && len(hookedBeads) > 0 {
-		state := StateWorking
-		if sessionDead {
-			state = StateStalled
-		}
 		return &Polecat{
 			Name:      name,
 			Rig:       m.rig.Name,
-			State:     state,
+			State:     workState(),
 			ClonePath: clonePath,
 			Branch:    branchName,
 			Issue:     hookedBeads[0].ID,
@@ -2784,14 +2798,10 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	if agentErr == nil && fields != nil && fields.HookBead != "" {
 		if hookIssue, err := m.beads.Show(fields.HookBead); err == nil &&
 			isCurrentHookedIssueForAssignee(hookIssue, assignee) {
-			state := StateWorking
-			if sessionDead {
-				state = StateStalled
-			}
 			return &Polecat{
 				Name:      name,
 				Rig:       m.rig.Name,
-				State:     state,
+				State:     workState(),
 				ClonePath: clonePath,
 				Branch:    branchName,
 				Issue:     fields.HookBead,
@@ -2805,10 +2815,8 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	if beadsErr != nil {
 		// If beads query fails, cross-check tmux session state.
 		// Avoid synthesizing working with no issue when we cannot verify active work.
-		state := StateWorking
-		if sessionDead {
-			state = StateStalled
-		} else if sessionRunning {
+		state := workState()
+		if !sessionDead && sessionRunning {
 			state = StateReviewNeeded
 		}
 		return &Polecat{
@@ -2838,10 +2846,7 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 
 	state := agentState
 	if issueID != "" {
-		state = StateWorking
-		if sessionDead {
-			state = StateStalled
-		}
+		state = workState()
 	} else if agentState == StateIdle && sessionRunning && !sessionStale && !m.getCleanupStatusFromBead(name).IsSafe() {
 		state = StateReviewNeeded
 	}

--- a/internal/polecat/types.go
+++ b/internal/polecat/types.go
@@ -62,6 +62,18 @@ const (
 	// Unlike "stuck" (polecat self-reports), stalled is detected externally.
 	StateStalled State = "stalled"
 
+	// StateBlocked means the polecat holds work and its tmux session is alive,
+	// but the agent inside it cannot act: the agent process is gone, the pane has
+	// produced no output at all for NoProgressTimeout, or the pane carries a
+	// provider error (expired credential, exhausted quota) that will refuse every
+	// prompt. Detected externally, like "stalled", but the remedy differs — the
+	// session does not need respawning, the operator needs to unblock the agent.
+	//
+	// This exists because a session that EXISTS is not a session that WORKS
+	// (hq-3l8r): three rho polecats sat at an idle prompt on a dead Codex token
+	// for six hours while `gt polecat list` reported all of them working.
+	StateBlocked State = "blocked"
+
 	// StateZombie means a tmux session exists but has no corresponding worktree directory.
 	// This is a detected condition: the polecat was incompletely nuked or has a
 	// session naming mismatch, leaving an orphaned tmux session.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2846,10 +2846,46 @@ func TestCheckSessionHealth_ActivityCheck(t *testing.T) {
 		// sleep is not an agent process, so this is expected
 		t.Logf("Status with sleep process: %v (expected AgentDead since sleep != agent)", status)
 	}
+}
 
-	// With a very short maxInactivity, a recently-created session should be healthy
-	// (if the agent were actually running). This tests the activity threshold logic
-	// without needing a real Claude process.
+// TestCheckSessionHealth_HungAgent proves the maxInactivity arm actually fires.
+// The previous version of TestCheckSessionHealth_ActivityCheck ended in a comment
+// where the assertion should have been, so nothing in the tree proved AgentHung
+// was reachable — and every polecat caller passed 0, which skips the check
+// entirely. That gap is what let auth-blocked polecats report "working" (hq-3l8r).
+//
+// Red proof: the agent process is alive and the session is real in both halves,
+// so the ONLY thing separating healthy from hung is the inactivity bound being
+// compared against real tmux session_activity. Drop the comparison, or pass 0,
+// and the first half returns SessionHealthy and this test fails.
+func TestCheckSessionHealth_HungAgent(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := fmt.Sprintf("gt-test-hung-%d", os.Getpid())
+	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer tm.KillSession(sessionName)
+
+	// Declare 'sleep' as this session's agent so the process-liveness arm passes:
+	// the agent is unambiguously ALIVE for the whole test.
+	if err := tm.SetEnvironment(sessionName, "GT_PROCESS_NAMES", "sleep"); err != nil {
+		t.Fatalf("SetEnvironment: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	if !tm.IsAgentAlive(sessionName) {
+		t.Skip("tmux did not report the declared pane process as alive; nothing to prove about hang detection")
+	}
+
+	// Any elapsed time counts as inactivity → hung, despite the live process.
+	if status := tm.CheckSessionHealth(sessionName, time.Nanosecond); status != AgentHung {
+		t.Errorf("CheckSessionHealth(live process, 1ns inactivity bound) = %v, want AgentHung", status)
+	}
+
+	// Same session, same live process, generous bound → healthy.
+	if status := tm.CheckSessionHealth(sessionName, time.Hour); status != SessionHealthy {
+		t.Errorf("CheckSessionHealth(live process, 1h inactivity bound) = %v, want SessionHealthy", status)
+	}
 }
 
 func TestValidateCommandBinary(t *testing.T) {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -342,10 +342,13 @@ func notifyRefineryMergeReady(workDir, rigName string, result *HandlerResult) {
 	townRoot, _ := workspace.Find(workDir)
 	// Emit file-based event so refinery's await-event unblocks instantly.
 	if townRoot != "" {
-		_, _ = channelevents.EmitToTown(townRoot, "refinery", "MERGE_READY", []string{
+		if _, err := channelevents.EmitToTown(townRoot, "refinery", "MERGE_READY", []string{
 			"source=witness",
 			"rig=" + rigName,
-		})
+		}); err != nil {
+			// Log emit failure but continue; witness nudge is the fallback.
+			Logger.Printf("warning: failed to emit MERGE_READY for refinery: %v", err)
+		}
 	}
 	if nudgeErr := nudgeRefinery(townRoot, rigName); nudgeErr != nil {
 		if result.Error == nil {
@@ -2528,8 +2531,17 @@ func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *Po
 			discovery.Error = fmt.Errorf("updating wisp state: %w", err)
 		}
 
-		// Nudge refinery to check merge queue (no permanent mail needed).
+		// Emit MERGE_READY event and nudge refinery to check merge queue (no permanent mail needed).
 		townRoot, _ := workspace.Find(workDir)
+		if townRoot != "" {
+			if _, err := channelevents.EmitToTown(townRoot, "refinery", "MERGE_READY", []string{
+				"source=witness",
+				"rig=" + rigName,
+			}); err != nil {
+				// Log emit failure but continue; witness nudge is the fallback.
+				Logger.Printf("warning: failed to emit MERGE_READY for refinery: %v", err)
+			}
+		}
 		if nudgeErr := nudgeRefinery(townRoot, rigName); nudgeErr != nil {
 			if discovery.Error == nil {
 				discovery.Error = fmt.Errorf("nudging refinery: %w (non-fatal)", nudgeErr)


### PR DESCRIPTION
- **fix(polecat): a session that exists is not a session that works**
- **Fix refinery spawn deadlock: emit events and check queue depth**
