### PR TITLE
fix(doltserver): honor durable listener timeout overrides

### DIFF
--- a/docs/design/dolt-storage.md
+++ b/docs/design/dolt-storage.md
@@ -53,6 +53,39 @@ connects to localhost and fails.
 Per-workspace override: set `dolt.host` in a rig's `.beads/config.yaml`.
 This takes priority over the env var for that specific workspace.
 
+### Listener Timeouts
+
+`GT_DOLT_READ_TIMEOUT_MS` and `GT_DOLT_WRITE_TIMEOUT_MS` control the generated
+Dolt listener's `read_timeout_millis` and `write_timeout_millis`, respectively.
+They apply when Gas Town starts a local Dolt server; they do not reconfigure a
+running or remote server. Do not hand-edit `config.yaml`: Gas Town regenerates
+it at server startup.
+
+Each setting independently uses the first nonempty value from the process
+environment, then `<townRoot>/daemon/daemon.env`. Surrounding whitespace is
+ignored; empty values quietly fall through to the next source or the startup
+path's default. To persist overrides when the launching process does not inherit
+your shell environment, put plain, unquoted `KEY=value` lines in `daemon.env`
+(without `export` or inline comments), for example:
+
+```dotenv
+GT_DOLT_READ_TIMEOUT_MS=28800000
+GT_DOLT_WRITE_TIMEOUT_MS=28800000
+```
+
+Values must be nonnegative decimal integers in milliseconds that fit both the
+platform's Go `int` and Dolt's `time.Duration` after conversion. Zero omits the
+corresponding YAML field, selecting Dolt's own default; it does not disable
+timeouts. A negative, malformed, or overflowing value emits a warning and uses
+the startup path's safe default. An invalid process value does **not** fall back
+to the durable file.
+
+`gt dolt start` retains five-minute read/write defaults. The daemon's direct
+launcher retains its thirty-second defaults. Longer limits can accommodate
+long-running queries or migrations, but delay cleanup of abandoned connections.
+These listener settings are separate from the idle-session `GT_DOLT_WAIT_TIMEOUT`
+setting, which is measured in seconds.
+
 ## Commands
 
 ```bash

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -845,8 +845,8 @@ func IsDoltUnhealthy(townRoot string) bool {
 
 // writeDaemonDoltConfig writes a Dolt config.yaml to configPath using the
 // daemon's DoltServerConfig. Unlike CLI flags, config.yaml can set
-// read_timeout_millis and write_timeout_millis, which prevents CLOSE_WAIT
-// accumulation when clients disconnect without completing their SQL sessions.
+// listener timeouts. Their defaults guard against CLOSE_WAIT accumulation;
+// operator overrides are resolved by doltserver.ResolveListenerTimeouts.
 func writeDaemonDoltConfig(townRoot string, cfg *DoltServerConfig, configPath string) error {
 	timeouts := doltserver.ResolveListenerTimeouts(townRoot, 30000, 30000)
 	hostLine := ""
@@ -937,8 +937,7 @@ func (m *DoltServerManager) startLocked() error {
 
 	// Write config.yaml with timeouts before starting. CLI flags like --port
 	// silently override the config file but cannot set timeout fields, so we
-	// use --config instead. This prevents CLOSE_WAIT accumulation that occurs
-	// when Dolt uses its 8-hour default read/write timeouts. (gt-ch5)
+	// use --config instead. See writeDaemonDoltConfig for the timeout policy.
 	configPath := filepath.Join(m.config.DataDir, "config.yaml")
 	if err := writeDaemonDoltConfig(m.townRoot, m.config, configPath); err != nil {
 		m.logger("Warning: failed to write Dolt config.yaml: %v", err)

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -847,7 +847,8 @@ func IsDoltUnhealthy(townRoot string) bool {
 // daemon's DoltServerConfig. Unlike CLI flags, config.yaml can set
 // read_timeout_millis and write_timeout_millis, which prevents CLOSE_WAIT
 // accumulation when clients disconnect without completing their SQL sessions.
-func writeDaemonDoltConfig(cfg *DoltServerConfig, configPath string) error {
+func writeDaemonDoltConfig(townRoot string, cfg *DoltServerConfig, configPath string) error {
+	timeouts := doltserver.ResolveListenerTimeouts(townRoot, 30000, 30000)
 	hostLine := ""
 	if cfg.Host != "" {
 		hostLine = fmt.Sprintf("\n  host: %s", cfg.Host)
@@ -883,9 +884,7 @@ func writeDaemonDoltConfig(cfg *DoltServerConfig, configPath string) error {
 log_level: info
 
 listener:
-  port: %d%s
-  read_timeout_millis: 30000
-  write_timeout_millis: 30000
+  port: %d%s%s
   max_connections: 1000
 
 data_dir: %q
@@ -895,6 +894,7 @@ behavior:
 %s%s%s`,
 		cfg.Port,
 		hostLine,
+		timeouts.YAML(),
 		cfg.DataDir,
 		eventSchedulerLine,
 		autoGcBlock,
@@ -940,7 +940,7 @@ func (m *DoltServerManager) startLocked() error {
 	// use --config instead. This prevents CLOSE_WAIT accumulation that occurs
 	// when Dolt uses its 8-hour default read/write timeouts. (gt-ch5)
 	configPath := filepath.Join(m.config.DataDir, "config.yaml")
-	if err := writeDaemonDoltConfig(m.config, configPath); err != nil {
+	if err := writeDaemonDoltConfig(m.townRoot, m.config, configPath); err != nil {
 		m.logger("Warning: failed to write Dolt config.yaml: %v", err)
 	}
 

--- a/internal/daemon/dolt_endpoint_config_test.go
+++ b/internal/daemon/dolt_endpoint_config_test.go
@@ -169,7 +169,7 @@ func writeAndReadDaemonAutoGC(t *testing.T) struct {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")
 	cfg := &DoltServerConfig{Port: 3307, DataDir: dir}
-	if err := writeDaemonDoltConfig(cfg, configPath); err != nil {
+	if err := writeDaemonDoltConfig(dir, cfg, configPath); err != nil {
 		t.Fatalf("writeDaemonDoltConfig: %v", err)
 	}
 	data, err := os.ReadFile(configPath)

--- a/internal/daemon/dolt_listener_timeout_test.go
+++ b/internal/daemon/dolt_listener_timeout_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWriteDaemonDoltConfigListenerTimeouts(t *testing.T) {
+	type testCase struct {
+		name        string
+		process     []string
+		durable     string
+		read, write int
+		warnings    bool
+	}
+	tests := []testCase{
+		{name: "defaults", read: 30000, write: 30000},
+		{name: "durable", durable: "28800000", read: 28800000, write: 28800000},
+		{name: "process precedence", process: []string{"123456", "654321"}, durable: "28800000", read: 123456, write: 654321},
+		{name: "empty process fallback", process: []string{"", "  "}, durable: "28800000", read: 28800000, write: 28800000},
+		{name: "empty values quiet", process: []string{"", " "}, durable: " ", read: 30000, write: 30000},
+		{name: "zero process", process: []string{"0", "0"}, durable: "28800000"},
+		{name: "zero durable", durable: "0"},
+		{name: "omit read only", process: []string{"0", "900000"}, write: 900000},
+		{name: "omit write only", process: []string{"900000", "0"}, read: 900000},
+	}
+	for _, value := range []string{"-1", "invalid", "999999999999999999999999", "9223372036855"} {
+		tests = append(tests,
+			testCase{name: "invalid process " + value, process: []string{value, value}, durable: "28800000", read: 30000, write: 30000, warnings: true},
+			testCase{name: "invalid durable " + value, durable: value, read: 30000, write: 30000, warnings: true},
+		)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			keys := []string{"GT_DOLT_READ_TIMEOUT_MS", "GT_DOLT_WRITE_TIMEOUT_MS"}
+			for i, key := range keys {
+				unsetEnv(t, key)
+				if tt.process != nil {
+					t.Setenv(key, tt.process[i])
+				}
+			}
+			if err := os.MkdirAll(filepath.Join(townRoot, "daemon"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			durablePath := filepath.Join(townRoot, "daemon", "daemon.env")
+			if err := os.WriteFile(durablePath, []byte(keys[0]+"="+tt.durable+"\n"+keys[1]+"="+tt.durable+"\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg := &DoltServerConfig{Host: "127.0.0.2", Port: 5507, DataDir: filepath.Join(townRoot, "custom-data")}
+			configPath := filepath.Join(townRoot, "config.yaml")
+			for attempt := 0; attempt < 2; attempt++ {
+				diagnostic := captureListenerTimeoutStderr(t, func() {
+					if err := writeDaemonDoltConfig(townRoot, cfg, configPath); err != nil {
+						t.Fatal(err)
+					}
+				})
+				for _, key := range keys {
+					if tt.warnings && !strings.Contains(diagnostic, key) {
+						t.Errorf("diagnostic %q does not mention %s", diagnostic, key)
+					}
+				}
+				if !tt.warnings && diagnostic != "" {
+					t.Errorf("unexpected diagnostic: %s", diagnostic)
+				}
+				data, err := os.ReadFile(configPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var parsed struct {
+					Listener struct {
+						Host           string `yaml:"host"`
+						Port           int    `yaml:"port"`
+						MaxConnections int    `yaml:"max_connections"`
+						Read           *int   `yaml:"read_timeout_millis"`
+						Write          *int   `yaml:"write_timeout_millis"`
+					} `yaml:"listener"`
+					DataDir string `yaml:"data_dir"`
+				}
+				if err := yaml.Unmarshal(data, &parsed); err != nil {
+					t.Fatal(err)
+				}
+				if parsed.Listener.Host != cfg.Host || parsed.Listener.Port != cfg.Port || parsed.DataDir != cfg.DataDir || parsed.Listener.MaxConnections != 1000 {
+					t.Fatalf("daemon settings changed: %+v", parsed)
+				}
+				for i, got := range []*int{parsed.Listener.Read, parsed.Listener.Write} {
+					want := []int{tt.read, tt.write}[i]
+					if want == 0 {
+						if got != nil {
+							t.Errorf("%s should be omitted, got %d", keys[i], *got)
+						}
+					} else if got == nil || *got != want {
+						t.Errorf("%s = %v, want %d", keys[i], got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func captureListenerTimeoutStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	old := os.Stderr
+	os.Stderr = f
+	defer func() { os.Stderr = old }()
+	fn()
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -225,8 +225,7 @@ type Config struct {
 	PidFile string
 
 	// MaxConnections is the maximum number of simultaneous connections the server will accept.
-	// Set to 0 to use the Dolt default (1000). Gas Town defaults to 50 to prevent
-	// connection storms during mass polecat slings.
+	// Set to 0 to use the Dolt default. See DefaultMaxConnections for Gas Town's default.
 	MaxConnections int
 
 	// ReadTimeoutMs is the server-side read timeout in milliseconds.
@@ -1928,8 +1927,8 @@ func Start(townRoot string) error {
 	}
 
 	// Always write a managed config.yaml from the Config struct before starting.
-	// This ensures critical settings (especially read/write timeouts) are always
-	// present, preventing CLOSE_WAIT accumulation from abandoned connections.
+	// This reapplies listener overrides on every start, including omission for zero
+	// values. The default limits guard against abandoned CLOSE_WAIT connections.
 	// The config file uses --config so all settings come from this file; CLI flags
 	// are ignored by dolt when --config is used.
 	configPath := filepath.Join(config.DataDir, "config.yaml")

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -316,8 +316,9 @@ func DefaultConfig(townRoot string) *Config {
 	// environment, daemon/daemon.env keeps the setting durable across restarts.
 	// A bad value is ignored with a diagnostic so a malformed override cannot
 	// prevent the server from starting or silently disable its guard.
-	config.ReadTimeoutMs = resolveListenerTimeoutMs(townRoot, "GT_DOLT_READ_TIMEOUT_MS", DefaultReadTimeoutMs)
-	config.WriteTimeoutMs = resolveListenerTimeoutMs(townRoot, "GT_DOLT_WRITE_TIMEOUT_MS", DefaultWriteTimeoutMs)
+	timeouts := ResolveListenerTimeouts(townRoot, DefaultReadTimeoutMs, DefaultWriteTimeoutMs)
+	config.ReadTimeoutMs = timeouts.ReadMs
+	config.WriteTimeoutMs = timeouts.WriteMs
 
 	// Optional override for the idle-session timeout. Negative values disable
 	// the override entirely (use Dolt's 8-hour default).
@@ -1665,14 +1666,7 @@ func writeServerConfig(config *Config, configPath string) error {
 	}
 
 	// Build timeout entries. Omit when 0 to use Dolt's defaults (not recommended).
-	readTimeoutLine := ""
-	if config.ReadTimeoutMs > 0 {
-		readTimeoutLine = fmt.Sprintf("\n  read_timeout_millis: %d", config.ReadTimeoutMs)
-	}
-	writeTimeoutLine := ""
-	if config.WriteTimeoutMs > 0 {
-		writeTimeoutLine = fmt.Sprintf("\n  write_timeout_millis: %d", config.WriteTimeoutMs)
-	}
+	timeouts := ListenerTimeouts{ReadMs: config.ReadTimeoutMs, WriteMs: config.WriteTimeoutMs}
 
 	maxConnLine := ""
 	if config.MaxConnections > 0 {
@@ -1712,7 +1706,7 @@ func writeServerConfig(config *Config, configPath string) error {
 log_level: %s
 
 listener:
-  port: %d%s%s%s%s
+  port: %d%s%s%s
 
 data_dir: "%s"
 
@@ -1723,8 +1717,7 @@ behavior:
 		config.Port,
 		hostLine,
 		maxConnLine,
-		readTimeoutLine,
-		writeTimeoutLine,
+		timeouts.YAML(),
 		filepath.ToSlash(config.DataDir),
 		eventSchedulerLine,
 		autoGcBlock,

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -158,6 +158,10 @@ const (
 	// for Dolt's default 8 hours. Set to match compactor GC timeout.
 	DefaultWriteTimeoutMs = 5 * 60 * 1000 // 5 minutes in milliseconds
 
+	// maxDoltListenerTimeoutMs is the largest millisecond value Dolt can safely
+	// convert to time.Duration without overflowing nanoseconds.
+	maxDoltListenerTimeoutMs int64 = (1<<63 - 1) / int64(time.Millisecond)
+
 	// DefaultWaitTimeoutSec is how long Dolt keeps an idle session alive before
 	// closing it. Dolt's MySQL-compat default is 28800s (8 hours). Under Gas
 	// Town load (mayor + deacon + witness + refinery + N polecats + dashboard
@@ -285,6 +289,8 @@ type Config struct {
 //   - GT_DOLT_USER → User
 //   - GT_DOLT_PASSWORD → Password
 //   - GT_DOLT_LOGLEVEL → LogLevel (trace, debug, info, warning, error, fatal)
+//   - GT_DOLT_READ_TIMEOUT_MS → ReadTimeoutMs (nonnegative milliseconds)
+//   - GT_DOLT_WRITE_TIMEOUT_MS → WriteTimeoutMs (nonnegative milliseconds)
 func DefaultConfig(townRoot string) *Config {
 	daemonDir := filepath.Join(townRoot, "daemon")
 	config := &Config{
@@ -304,6 +310,14 @@ func DefaultConfig(townRoot string) *Config {
 		DoltStatsEnabled: "0",
 		AutoGC:           "on",
 	}
+
+	// Listener timeouts are read from the process environment first. When the
+	// daemon starts `gt dolt` without inheriting the operator's shell
+	// environment, daemon/daemon.env keeps the setting durable across restarts.
+	// A bad value is ignored with a diagnostic so a malformed override cannot
+	// prevent the server from starting or silently disable its guard.
+	config.ReadTimeoutMs = resolveListenerTimeoutMs(townRoot, "GT_DOLT_READ_TIMEOUT_MS", DefaultReadTimeoutMs)
+	config.WriteTimeoutMs = resolveListenerTimeoutMs(townRoot, "GT_DOLT_WRITE_TIMEOUT_MS", DefaultWriteTimeoutMs)
 
 	// Optional override for the idle-session timeout. Negative values disable
 	// the override entirely (use Dolt's 8-hour default).
@@ -384,6 +398,46 @@ func readDaemonEnvVar(path, key string) string {
 		}
 	}
 	return ""
+}
+
+// resolveListenerTimeoutMs resolves a nonnegative listener timeout in
+// milliseconds. A nonempty process environment value takes precedence over
+// daemon/daemon.env; an absent value falls back to that durable file. Zero is
+// valid and means the generated Dolt config omits the field, allowing Dolt's
+// own default. Invalid, negative, and out-of-range values use defaultValue.
+func resolveListenerTimeoutMs(townRoot, key string, defaultValue int) int {
+	value, ok := os.LookupEnv(key)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		ok = false
+	}
+	if !ok {
+		if townRoot != "" {
+			value = strings.TrimSpace(readDaemonEnvVar(filepath.Join(townRoot, "daemon", "daemon.env"), key))
+			ok = value != ""
+		}
+	}
+	if !ok {
+		return defaultValue
+	}
+
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err == nil && parsed >= 0 && parsed <= maxDoltListenerTimeoutMs && parsed <= int64(^uint(0)>>1) {
+		return int(parsed)
+	}
+	if err == nil {
+		if parsed > maxDoltListenerTimeoutMs {
+			err = fmt.Errorf("must fit in Dolt's time.Duration when expressed in milliseconds")
+		} else if parsed > int64(^uint(0)>>1) {
+			err = fmt.Errorf("must fit in an int")
+		} else {
+			err = fmt.Errorf("must be nonnegative")
+		}
+	} else if parsed < 0 {
+		err = fmt.Errorf("must be nonnegative")
+	}
+	fmt.Fprintf(os.Stderr, "Warning: invalid %s=%q (%v); using default %d ms\n", key, value, err, defaultValue)
+	return defaultValue
 }
 
 // IsRemote returns true when the config points to a non-local Dolt server.
@@ -1651,6 +1705,7 @@ func writeServerConfig(config *Config, configPath string) error {
 # Do not edit manually; changes are overwritten on each server start.
 # To customize, set Gas Town environment variables:
 #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
+#   GT_DOLT_READ_TIMEOUT_MS, GT_DOLT_WRITE_TIMEOUT_MS (nonnegative milliseconds)
 #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
 #   GT_DOLT_AUTO_GC (on, off)
 

--- a/internal/doltserver/listener_timeout_native_test.go
+++ b/internal/doltserver/listener_timeout_native_test.go
@@ -1,0 +1,141 @@
+package doltserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestListenerTimeoutNativeDolt exercises the generated configuration with the
+// real consumer. Opt in with GT_TEST_NATIVE_DOLT=1; every server uses a fresh
+// data directory, isolated Dolt configuration, and an ephemeral loopback port.
+func TestListenerTimeoutNativeDolt(t *testing.T) {
+	if os.Getenv("GT_TEST_NATIVE_DOLT") != "1" {
+		t.Skip("set GT_TEST_NATIVE_DOLT=1 to test the installed Dolt binary")
+	}
+	dolt, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	version, err := exec.Command(dolt, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("dolt version: %v: %s", err, version)
+	}
+	t.Log(strings.TrimSpace(string(version)))
+	for _, tc := range []struct {
+		name, process string
+		cancel        bool
+		restarts      int
+	}{
+		{name: "process_overrides_durable", process: "1000", cancel: true, restarts: 1},
+		{name: "durable_without_shell_env", restarts: 2},
+		{name: "zero_uses_dolt_defaults", process: "0", restarts: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=28800000\nGT_DOLT_WRITE_TIMEOUT_MS=28800000\n")
+			for _, key := range []string{"GT_DOLT_READ_TIMEOUT_MS", "GT_DOLT_WRITE_TIMEOUT_MS"} {
+				unsetEnv(t, key)
+				if tc.process != "" {
+					t.Setenv(key, tc.process)
+				}
+			}
+			for attempt := 1; attempt <= tc.restarts; attempt++ {
+				t.Run(fmt.Sprintf("start_%d", attempt), func(t *testing.T) {
+					config := DefaultConfig(townRoot)
+					config.Host = "127.0.0.1"
+					listener, err := net.Listen("tcp", "127.0.0.1:0")
+					if err != nil {
+						t.Fatal(err)
+					}
+					config.Port = listener.Addr().(*net.TCPAddr).Port
+					if err := listener.Close(); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.MkdirAll(config.DataDir, 0700); err != nil {
+						t.Fatal(err)
+					}
+					configPath := filepath.Join(townRoot, "config.yaml")
+					if err := writeServerConfig(config, configPath); err != nil {
+						t.Fatal(err)
+					}
+					yaml, err := os.ReadFile(configPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Logf("Generated configuration consumed by dolt sql-server --config:\n%s", yaml)
+					// Do not inherit live endpoint, credential, or Dolt configuration
+					// overrides. DOLT_ROOT_PATH keeps global Dolt state isolated.
+					var childEnv []string
+					for _, entry := range os.Environ() {
+						if !strings.HasPrefix(entry, "DOLT_") && !strings.HasPrefix(entry, "GT_") && !strings.HasPrefix(entry, "BEADS_") {
+							childEnv = append(childEnv, entry)
+						}
+					}
+					childEnv = append(childEnv, "DOLT_ROOT_PATH="+townRoot)
+					logFile, err := os.Create(filepath.Join(t.TempDir(), "server.log"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer logFile.Close()
+					server := exec.Command(dolt, "sql-server", "--config", configPath)
+					server.Dir, server.Env = townRoot, childEnv
+					server.Stdout, server.Stderr = logFile, logFile
+					if err := server.Start(); err != nil {
+						t.Fatal(err)
+					}
+					done := make(chan error, 1)
+					go func() { done <- server.Wait() }()
+					defer func() {
+						_ = server.Process.Signal(os.Interrupt)
+						select {
+						case <-done:
+						case <-time.After(10 * time.Second):
+							_ = server.Process.Kill()
+							<-done
+						}
+						if t.Failed() {
+							logs, _ := os.ReadFile(logFile.Name())
+							t.Logf("isolated server log:\n%s", logs)
+						}
+					}()
+					query := func(sql string) ([]byte, error) {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						cmd := exec.CommandContext(ctx, dolt, "--host", config.Host, "--port", fmt.Sprint(config.Port), "--user", "root", "--password", "", "--no-tls", "sql", "-q", sql)
+						cmd.Dir, cmd.Env = townRoot, childEnv
+						return cmd.CombinedOutput()
+					}
+					deadline := time.Now().Add(20 * time.Second)
+					for {
+						output, err := query("SELECT 1")
+						if err == nil {
+							break
+						}
+						if time.Now().After(deadline) {
+							t.Fatalf("isolated server did not become ready: %v: %s", err, output)
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+					start := time.Now()
+					output, err := query("SELECT SLEEP(3)")
+					elapsed := time.Since(start)
+					t.Logf("dolt --host %s --port %d --user root --password '' --no-tls sql -q 'SELECT SLEEP(3)'\nElapsed: %s; error: %v\n%s", config.Host, config.Port, elapsed, err, output)
+					if tc.cancel {
+						if err == nil || !strings.Contains(strings.ToLower(string(output)), "connection timeout") || elapsed >= 3*time.Second {
+							t.Fatalf("1000ms listener should cancel the 3s query before completion")
+						}
+					} else if err != nil || elapsed < 3*time.Second {
+						t.Fatalf("3s query should complete with durable or Dolt-default listener limits")
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/doltserver/listener_timeout_test.go
+++ b/internal/doltserver/listener_timeout_test.go
@@ -216,3 +216,51 @@ func captureStderr(t *testing.T, fn func()) string {
 	}
 	return string(data)
 }
+
+func TestDefaultConfig_ListenerTimeoutGeneratedYAML(t *testing.T) {
+	for _, tt := range []struct {
+		name, read, write   string
+		wantRead, wantWrite int
+	}{
+		{name: "defaults", wantRead: 300000, wantWrite: 300000},
+		{name: "process precedence", read: "28800000", write: "900000", wantRead: 28800000, wantWrite: 900000},
+		{name: "write zero", read: "900000", write: "0", wantRead: 900000},
+		{name: "duration boundary", read: "9223372036854", write: "9223372036854", wantRead: 9223372036854, wantWrite: 9223372036854},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			t.Setenv("GT_DOLT_READ_TIMEOUT_MS", tt.read)
+			t.Setenv("GT_DOLT_WRITE_TIMEOUT_MS", tt.write)
+			if tt.name == "process precedence" {
+				writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=111\nGT_DOLT_WRITE_TIMEOUT_MS=222\n")
+			}
+			configPath := filepath.Join(townRoot, "config.yaml")
+			if err := writeServerConfig(DefaultConfig(townRoot), configPath); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var parsed struct {
+				Listener struct {
+					Read  *int `yaml:"read_timeout_millis"`
+					Write *int `yaml:"write_timeout_millis"`
+				} `yaml:"listener"`
+			}
+			if err := yaml.Unmarshal(data, &parsed); err != nil {
+				t.Fatal(err)
+			}
+			if parsed.Listener.Read == nil || *parsed.Listener.Read != tt.wantRead {
+				t.Errorf("read timeout = %v, want %d", parsed.Listener.Read, tt.wantRead)
+			}
+			if tt.wantWrite == 0 {
+				if parsed.Listener.Write != nil {
+					t.Errorf("write timeout should be omitted, got %d", *parsed.Listener.Write)
+				}
+			} else if parsed.Listener.Write == nil || *parsed.Listener.Write != tt.wantWrite {
+				t.Errorf("write timeout = %v, want %d", parsed.Listener.Write, tt.wantWrite)
+			}
+		})
+	}
+}

--- a/internal/doltserver/listener_timeout_test.go
+++ b/internal/doltserver/listener_timeout_test.go
@@ -1,0 +1,218 @@
+package doltserver
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDefaultConfig_ListenerTimeoutEnvOverridesDaemonEnv(t *testing.T) {
+	townRoot := t.TempDir()
+	writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=111\nGT_DOLT_WRITE_TIMEOUT_MS=222\n")
+	t.Setenv("GT_DOLT_READ_TIMEOUT_MS", "123456")
+	t.Setenv("GT_DOLT_WRITE_TIMEOUT_MS", "654321")
+
+	config := DefaultConfig(townRoot)
+	if config.ReadTimeoutMs != 123456 {
+		t.Fatalf("ReadTimeoutMs = %d, want 123456", config.ReadTimeoutMs)
+	}
+	if config.WriteTimeoutMs != 654321 {
+		t.Fatalf("WriteTimeoutMs = %d, want 654321", config.WriteTimeoutMs)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutFallsBackToDaemonEnv(t *testing.T) {
+	townRoot := t.TempDir()
+	writeDaemonEnv(t, townRoot, "# durable Dolt settings\nGT_DOLT_READ_TIMEOUT_MS=777777\nGT_DOLT_WRITE_TIMEOUT_MS=888888\n")
+	unsetEnv(t, "GT_DOLT_READ_TIMEOUT_MS")
+	unsetEnv(t, "GT_DOLT_WRITE_TIMEOUT_MS")
+
+	config := DefaultConfig(townRoot)
+	if config.ReadTimeoutMs != 777777 {
+		t.Fatalf("ReadTimeoutMs = %d, want 777777", config.ReadTimeoutMs)
+	}
+	if config.WriteTimeoutMs != 888888 {
+		t.Fatalf("WriteTimeoutMs = %d, want 888888", config.WriteTimeoutMs)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutDaemonEnvGeneratesDurableYAML(t *testing.T) {
+	townRoot := t.TempDir()
+	writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=900000\nGT_DOLT_WRITE_TIMEOUT_MS=1200000\n")
+	unsetEnv(t, "GT_DOLT_READ_TIMEOUT_MS")
+	unsetEnv(t, "GT_DOLT_WRITE_TIMEOUT_MS")
+
+	configPath := filepath.Join(townRoot, "config.yaml")
+	if err := writeServerConfig(DefaultConfig(townRoot), configPath); err != nil {
+		t.Fatalf("writeServerConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+	var parsed struct {
+		Listener struct {
+			ReadTimeoutMillis  int `yaml:"read_timeout_millis"`
+			WriteTimeoutMillis int `yaml:"write_timeout_millis"`
+		} `yaml:"listener"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is invalid YAML: %v", err)
+	}
+	if parsed.Listener.ReadTimeoutMillis != 900000 {
+		t.Errorf("listener.read_timeout_millis = %d, want 900000", parsed.Listener.ReadTimeoutMillis)
+	}
+	if parsed.Listener.WriteTimeoutMillis != 1200000 {
+		t.Errorf("listener.write_timeout_millis = %d, want 1200000", parsed.Listener.WriteTimeoutMillis)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutEmptyEnvUsesDaemonEnv(t *testing.T) {
+	townRoot := t.TempDir()
+	writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=333333\nGT_DOLT_WRITE_TIMEOUT_MS=444444\n")
+	t.Setenv("GT_DOLT_READ_TIMEOUT_MS", "")
+	t.Setenv("GT_DOLT_WRITE_TIMEOUT_MS", "")
+
+	config := DefaultConfig(townRoot)
+	if config.ReadTimeoutMs != 333333 || config.WriteTimeoutMs != 444444 {
+		t.Fatalf("empty process env should use daemon env, got read=%d write=%d", config.ReadTimeoutMs, config.WriteTimeoutMs)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutInvalidValuesUseDefaults(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		value string
+	}{
+		{name: "not a number", env: "GT_DOLT_READ_TIMEOUT_MS", value: "five minutes"},
+		{name: "negative", env: "GT_DOLT_WRITE_TIMEOUT_MS", value: "-1"},
+		{name: "overflow", env: "GT_DOLT_READ_TIMEOUT_MS", value: "999999999999999999999999999999"},
+		{name: "duration overflow", env: "GT_DOLT_WRITE_TIMEOUT_MS", value: "9223372036855"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			unsetEnv(t, "GT_DOLT_READ_TIMEOUT_MS")
+			unsetEnv(t, "GT_DOLT_WRITE_TIMEOUT_MS")
+			t.Setenv(tt.env, tt.value)
+
+			var config *Config
+			diagnostic := captureStderr(t, func() {
+				config = DefaultConfig(townRoot)
+			})
+			if config.ReadTimeoutMs != DefaultReadTimeoutMs {
+				t.Errorf("ReadTimeoutMs = %d, want default %d", config.ReadTimeoutMs, DefaultReadTimeoutMs)
+			}
+			if config.WriteTimeoutMs != DefaultWriteTimeoutMs {
+				t.Errorf("WriteTimeoutMs = %d, want default %d", config.WriteTimeoutMs, DefaultWriteTimeoutMs)
+			}
+			if !strings.Contains(diagnostic, tt.env) {
+				t.Errorf("diagnostic %q does not mention %s", diagnostic, tt.env)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutBlankEnvWithoutTownRootIsQuiet(t *testing.T) {
+	t.Setenv("GT_DOLT_READ_TIMEOUT_MS", "")
+	t.Setenv("GT_DOLT_WRITE_TIMEOUT_MS", "")
+
+	var config *Config
+	diagnostic := captureStderr(t, func() {
+		config = DefaultConfig("")
+	})
+	if config.ReadTimeoutMs != DefaultReadTimeoutMs || config.WriteTimeoutMs != DefaultWriteTimeoutMs {
+		t.Fatalf("blank env without durable fallback should use defaults, got read=%d write=%d", config.ReadTimeoutMs, config.WriteTimeoutMs)
+	}
+	if diagnostic != "" {
+		t.Fatalf("blank env without durable fallback emitted diagnostic %q", diagnostic)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutInvalidDaemonEnvUsesDefaults(t *testing.T) {
+	townRoot := t.TempDir()
+	writeDaemonEnv(t, townRoot, "GT_DOLT_READ_TIMEOUT_MS=negative\nGT_DOLT_WRITE_TIMEOUT_MS=-1\n")
+	unsetEnv(t, "GT_DOLT_READ_TIMEOUT_MS")
+	unsetEnv(t, "GT_DOLT_WRITE_TIMEOUT_MS")
+
+	var config *Config
+	diagnostic := captureStderr(t, func() {
+		config = DefaultConfig(townRoot)
+	})
+	if config.ReadTimeoutMs != DefaultReadTimeoutMs || config.WriteTimeoutMs != DefaultWriteTimeoutMs {
+		t.Fatalf("invalid daemon env should use defaults, got read=%d write=%d", config.ReadTimeoutMs, config.WriteTimeoutMs)
+	}
+	if !strings.Contains(diagnostic, "GT_DOLT_READ_TIMEOUT_MS") || !strings.Contains(diagnostic, "GT_DOLT_WRITE_TIMEOUT_MS") {
+		t.Fatalf("diagnostic %q does not mention both invalid daemon env values", diagnostic)
+	}
+}
+
+func TestDefaultConfig_ListenerTimeoutZeroOmittedFromGeneratedYAML(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_READ_TIMEOUT_MS", "0")
+	t.Setenv("GT_DOLT_WRITE_TIMEOUT_MS", "900000")
+
+	config := DefaultConfig(townRoot)
+	configPath := filepath.Join(townRoot, "config.yaml")
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatalf("writeServerConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read generated config: %v", err)
+	}
+	var parsed struct {
+		Listener struct {
+			ReadTimeoutMillis  *int `yaml:"read_timeout_millis"`
+			WriteTimeoutMillis *int `yaml:"write_timeout_millis"`
+		} `yaml:"listener"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is invalid YAML: %v", err)
+	}
+	if parsed.Listener.ReadTimeoutMillis != nil {
+		t.Fatalf("zero read timeout should be omitted, got %d", *parsed.Listener.ReadTimeoutMillis)
+	}
+	if parsed.Listener.WriteTimeoutMillis == nil || *parsed.Listener.WriteTimeoutMillis != 900000 {
+		t.Fatalf("configured write timeout = %v, want 900000", parsed.Listener.WriteTimeoutMillis)
+	}
+}
+
+func writeDaemonEnv(t *testing.T, townRoot, content string) {
+	t.Helper()
+	daemonDir := filepath.Join(townRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("mkdir daemon: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(daemonDir, "daemon.env"), []byte(content), 0600); err != nil {
+		t.Fatalf("write daemon.env: %v", err)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr pipe: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close captured stderr: %v", err)
+	}
+	return string(data)
+}

--- a/internal/doltserver/listener_timeouts.go
+++ b/internal/doltserver/listener_timeouts.go
@@ -1,0 +1,26 @@
+package doltserver
+
+import "fmt"
+
+type ListenerTimeouts struct {
+	ReadMs  int
+	WriteMs int
+}
+
+func ResolveListenerTimeouts(townRoot string, defaultReadMs, defaultWriteMs int) ListenerTimeouts {
+	return ListenerTimeouts{
+		ReadMs:  resolveListenerTimeoutMs(townRoot, "GT_DOLT_READ_TIMEOUT_MS", defaultReadMs),
+		WriteMs: resolveListenerTimeoutMs(townRoot, "GT_DOLT_WRITE_TIMEOUT_MS", defaultWriteMs),
+	}
+}
+
+func (t ListenerTimeouts) YAML() string {
+	lines := ""
+	if t.ReadMs > 0 {
+		lines += fmt.Sprintf("\n  read_timeout_millis: %d", t.ReadMs)
+	}
+	if t.WriteMs > 0 {
+		lines += fmt.Sprintf("\n  write_timeout_millis: %d", t.WriteMs)
+	}
+	return lines
+}

--- a/internal/doltserver/listener_timeouts.go
+++ b/internal/doltserver/listener_timeouts.go
@@ -2,11 +2,14 @@ package doltserver
 
 import "fmt"
 
+// ListenerTimeouts holds listener limits in milliseconds; zero selects Dolt's default.
 type ListenerTimeouts struct {
 	ReadMs  int
 	WriteMs int
 }
 
+// ResolveListenerTimeouts applies the shared override policy to caller-specific
+// defaults. See docs/design/dolt-storage.md#listener-timeouts for operator guidance.
 func ResolveListenerTimeouts(townRoot string, defaultReadMs, defaultWriteMs int) ListenerTimeouts {
 	return ListenerTimeouts{
 		ReadMs:  resolveListenerTimeoutMs(townRoot, "GT_DOLT_READ_TIMEOUT_MS", defaultReadMs),
@@ -14,6 +17,8 @@ func ResolveListenerTimeouts(townRoot string, defaultReadMs, defaultWriteMs int)
 	}
 }
 
+// YAML returns newline-prefixed fields indented for a listener mapping, omitting
+// nonpositive limits. Callers must validate limits before rendering.
 func (t ListenerTimeouts) YAML() string {
 	lines := ""
 	if t.ReadMs > 0 {

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -64,7 +64,7 @@ const (
 	DiskSpaceMinimumMB uint64 = 500
 
 	// DiskSpaceWarningMB is the threshold (in MB) at which warnings are emitted.
-	// At 1 GB free, the system is at risk and should shed load.
+	// Below 1 GB free, the system is at risk and should shed load.
 	DiskSpaceWarningMB uint64 = 1024
 
 	// DiskSpaceCriticalPercent is the usage percentage at or above which

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -67,9 +67,9 @@ const (
 	// At 1 GB free, the system is at risk and should shed load.
 	DiskSpaceWarningMB uint64 = 1024
 
-	// DiskSpaceCriticalPercent is the usage percentage above which operations
-	// should be blocked regardless of absolute free space.
-	DiskSpaceCriticalPercent float64 = 95.0
+	// DiskSpaceCriticalPercent is the usage percentage at or above which
+	// operations should be blocked regardless of absolute free space.
+	DiskSpaceCriticalPercent float64 = 97.5
 )
 
 // DiskSpaceLevel represents the severity of disk space status.
@@ -106,21 +106,24 @@ func CheckDiskSpace(path string) (DiskSpaceLevel, string, error) {
 		return DiskSpaceOK, "", err
 	}
 
+	level, message := evaluateDiskSpace(info)
+	return level, message, nil
+}
+
+func evaluateDiskSpace(info *DiskSpaceInfo) (DiskSpaceLevel, string) {
 	availMB := info.AvailableMB()
 
 	if availMB < DiskSpaceMinimumMB || info.UsedPercent >= DiskSpaceCriticalPercent {
 		return DiskSpaceCritical,
 			fmt.Sprintf("CRITICAL: only %s free (%.1f%% used) — disk space exhausted, operations blocked",
-				info.AvailableHuman(), info.UsedPercent),
-			nil
+				info.AvailableHuman(), info.UsedPercent)
 	}
 
 	if availMB < DiskSpaceWarningMB {
 		return DiskSpaceWarning,
 			fmt.Sprintf("WARNING: only %s free (%.1f%% used) — disk space low, reduce workload",
-				info.AvailableHuman(), info.UsedPercent),
-			nil
+				info.AvailableHuman(), info.UsedPercent)
 	}
 
-	return DiskSpaceOK, "", nil
+	return DiskSpaceOK, ""
 }

--- a/internal/util/diskspace_darwin_test.go
+++ b/internal/util/diskspace_darwin_test.go
@@ -124,11 +124,13 @@ func TestAPFSPurgeablePreventsBlock(t *testing.T) {
 			float64(info.AvailableBytes)/float64(GB), float64(containerFree)/float64(GB))
 	}
 
-	// Old code would have used statfs Bavail (~41 GB) → 95.6% → CRITICAL block.
+	// Old code used a 95% threshold with statfs Bavail (~41 GB), so 95.6%
+	// produced a false-positive CRITICAL block.
+	const historicalCriticalPercent = 95.0
 	oldUsed := containerTotal - statfsFree
 	oldPct := float64(oldUsed) / float64(containerTotal) * 100
-	if oldPct < DiskSpaceCriticalPercent {
-		t.Errorf("test setup broken: old code would show %.1f%% (expected >= %.1f%%)", oldPct, DiskSpaceCriticalPercent)
+	if oldPct < historicalCriticalPercent {
+		t.Errorf("test setup broken: old code would show %.1f%% (expected >= %.1f%%)", oldPct, historicalCriticalPercent)
 	}
 
 	// New code must be below the critical threshold.

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -119,6 +119,35 @@ func TestCheckDiskSpace_InvalidPath(t *testing.T) {
 	}
 }
 
+func TestEvaluateDiskSpaceThresholds(t *testing.T) {
+	const MB = uint64(1024 * 1024)
+	tests := []struct {
+		name        string
+		availableMB uint64
+		usedPercent float64
+		want        DiskSpaceLevel
+	}{
+		{name: "below percentage limit", availableMB: 1024, usedPercent: 97.49, want: DiskSpaceOK},
+		{name: "at percentage limit", availableMB: 1024, usedPercent: 97.5, want: DiskSpaceCritical},
+		{name: "below absolute floor", availableMB: 499, usedPercent: 10, want: DiskSpaceCritical},
+		{name: "below warning floor", availableMB: 900, usedPercent: 10, want: DiskSpaceWarning},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &DiskSpaceInfo{
+				AvailableBytes: tt.availableMB * MB,
+				TotalBytes:     100 * 1024 * MB,
+				UsedPercent:    tt.usedPercent,
+			}
+			got, _ := evaluateDiskSpace(info)
+			if got != tt.want {
+				t.Fatalf("evaluateDiskSpace() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDiskSpaceLevel_String(t *testing.T) {
 	tests := []struct {
 		level DiskSpaceLevel

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -105,6 +105,12 @@ func TestCheckDiskSpace_CurrentDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckDiskSpace(\".\") failed: %v", err)
 	}
+	info, err := GetDiskSpace(".")
+	if err != nil {
+		t.Fatalf("GetDiskSpace(\".\") failed: %v", err)
+	}
+	t.Logf("current filesystem: %s free, %.2f%% used => level=%s message=%q",
+		info.AvailableHuman(), info.UsedPercent, level, msg)
 
 	// In a normal test environment, disk should be OK
 	if level == DiskSpaceCritical {
@@ -129,8 +135,11 @@ func TestEvaluateDiskSpaceThresholds(t *testing.T) {
 	}{
 		{name: "below percentage limit", availableMB: 1024, usedPercent: 97.49, want: DiskSpaceOK},
 		{name: "at percentage limit", availableMB: 1024, usedPercent: 97.5, want: DiskSpaceCritical},
+		{name: "above percentage limit", availableMB: 1024, usedPercent: 97.51, want: DiskSpaceCritical},
 		{name: "below absolute floor", availableMB: 499, usedPercent: 10, want: DiskSpaceCritical},
-		{name: "below warning floor", availableMB: 900, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "at absolute floor", availableMB: 500, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "below warning floor", availableMB: 1023, usedPercent: 10, want: DiskSpaceWarning},
+		{name: "at warning floor", availableMB: 1024, usedPercent: 10, want: DiskSpaceOK},
 	}
 
 	for _, tt := range tests {
@@ -140,10 +149,12 @@ func TestEvaluateDiskSpaceThresholds(t *testing.T) {
 				TotalBytes:     100 * 1024 * MB,
 				UsedPercent:    tt.usedPercent,
 			}
-			got, _ := evaluateDiskSpace(info)
+			got, message := evaluateDiskSpace(info)
 			if got != tt.want {
 				t.Fatalf("evaluateDiskSpace() = %s, want %s", got, tt.want)
 			}
+			t.Logf("available=%d MB used=%.2f%% => level=%s message=%q",
+				tt.availableMB, tt.usedPercent, got, message)
 		})
 	}
 }


### PR DESCRIPTION
## Intent

Recover the Gas Town/Gas City control plane toward Beads 1.2.2 everywhere, with one pinned source revision that supports database schema v65. This gate owns ONLY the durable Gas Town listener-timeout source fix. The Mayor separately owns fleet inventory, binary provenance and platform builds, native snapshots, isolated v53/v65 migration tests, coordinated quiescence, staged server restarts, migration, normal Dolt synchronization, atomic binary installation, and eventual resumption of eligible existing convoys/polecats. Do not perform any of those live operational actions from this pipeline. Preserve all unrelated dirty worktrees, stashes, retained identities, and Dolt files. Never send SIGQUIT, run concurrent migrators, bypass schema guards, or rewrite Git main or a Dolt remote. Source is based on the currently installed bb09c07075 and intentionally preserves the already-installed two disk-guard commits after upstream649b832b. Fix the generated-YAML seam rather than hand-editing live config: support validated GT_DOLT_READ_TIMEOUT_MS and GT_DOLT_WRITE_TIMEOUT_MS overrides, process environment before durable daemon/daemon.env fallback, preserve existing five-minute defaults, let zero omit fields for Dolt defaults, reject negative/malformed/overflow values with diagnostics and safe defaults. Tests must demonstrate env precedence, persistence without shell env, valid generated YAML, zero omission, quiet empty values, and prevention of duration overflow. Focused native ICU tests pass; isolated Dolt2.3.2 SELECT SLEEP(3) is canceled at1.18s with1000ms listener limits and succeeds at3.30s with28800000ms. Installed shared server at3309 must not be used for tests; use isolated test environments. ICU headers/libs are at /opt/homebrew/opt/icu4c@78; cap Go concurrency GOMAXPROCS=2 and -p=2. The user limits remote CI checks to at most once every five minutes: the built-in CI monitor is omitted from this run because it polls faster; Mayor will perform the remote CI acceptance gate manually at that cadence and will not claim release-ready merely from this pipeline result. Push only the feature branch to the configured rhar1511/gastown fork; do not merge main. Latest human priority is to resolve this first critical escalation, then remaining GT launch gates before resuming eligible convoys and slings.

## What Changed

- Apply `GT_DOLT_READ_TIMEOUT_MS` and `GT_DOLT_WRITE_TIMEOUT_MS` to generated CLI and daemon YAML, with process environment taking precedence over durable `daemon/daemon.env` settings.
- Preserve existing startup defaults, omit timeout fields for zero, quietly skip empty values, and warn and use safe defaults for invalid or overflowing values. Document the policy and add YAML, precedence, persistence, and isolated native Dolt tests.
- Raise the disk-usage blocking threshold from 95% to 97.5%, retain absolute free-space guards, and add threshold boundary coverage.

## Risk Assessment

✅ Low: Both startup paths now share validated timeout resolution and YAML emission while preserving their defaults, daemon settings, and required disk-guard changes.

## Testing

Focused ICU and disk-guard tests passed, pre-fix checks reproduced ignored overrides, and isolated Dolt 2.3.2 SQL evidence verified timeout cancellation, durable restart behavior, and zero omission after resolving harness and cache setup issues; temporary testing data was removed.

<details>
<summary>Evidence: Generated YAML and isolated Dolt SQL transcript</summary>

`Dolt 2.3.2: 1000 ms limits canceled SELECT SLEEP(3) at 1.12s. Durable 28800000 ms limits succeeded at 3.38s and 3.18s across restart. Zero omission succeeded at 3.12s.`

```text
=== RUN   TestListenerTimeoutNativeDolt
    listener_timeout_native_test.go:30: dolt version 2.3.2
=== RUN   TestListenerTimeoutNativeDolt/process_overrides_durable
=== RUN   TestListenerTimeoutNativeDolt/process_overrides_durable/start_1
    listener_timeout_native_test.go:72: Generated configuration consumed by dolt sql-server --config:
        # Dolt SQL server configuration — managed by Gas Town (gt dolt start)
        # Do not edit manually; changes are overwritten on each server start.
        # To customize, set Gas Town environment variables:
        #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
        #   GT_DOLT_READ_TIMEOUT_MS, GT_DOLT_WRITE_TIMEOUT_MS (nonnegative milliseconds)
        #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
        #   GT_DOLT_AUTO_GC (on, off)
        
        log_level: warning
        
        listener:
          port: 59496
          host: 127.0.0.1
          max_connections: 1000
          read_timeout_millis: 1000
          write_timeout_millis: 1000
        
        data_dir: "/var/folders/qk/3f18t4qd2jn72k9bpbjykcq80000gn/T/TestListenerTimeoutNativeDoltprocess_overrides_durable41800867/001/.dolt-data"
        
        behavior:
          dolt_transaction_commit: false
          event_scheduler: "OFF"
          auto_gc_behavior:
            enable: true
            archive_level: 1
        
        system_variables:
          dolt_stats_enabled: 0
    listener_timeout_native_test.go:129: dolt --host 127.0.0.1 --port 59496 --user root --password '' --no-tls sql -q 'SELECT SLEEP(3)'
        Elapsed: 1.11748725s; error: exit status 1
        error on line 1 for query SELECT SLEEP(3): Error 1105 (HY000): row read wait bigger than connection timeout
=== RUN   TestListenerTimeoutNativeDolt/durable_without_shell_env
=== RUN   TestListenerTimeoutNativeDolt/durable_without_shell_env/start_1
    listener_timeout_native_test.go:72: Generated configuration consumed by dolt sql-server --config:
        # Dolt SQL server configuration — managed by Gas Town (gt dolt start)
        # Do not edit manually; changes are overwritten on each server start.
        # To customize, set Gas Town environment variables:
        #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
        #   GT_DOLT_READ_TIMEOUT_MS, GT_DOLT_WRITE_TIMEOUT_MS (nonnegative milliseconds)
        #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
        #   GT_DOLT_AUTO_GC (on, off)
        
        log_level: warning
        
        listener:
          port: 59512
          host: 127.0.0.1
          max_connections: 1000
          read_timeout_millis: 28800000
          write_timeout_millis: 28800000
        
        data_dir: "/var/folders/qk/3f18t4qd2jn72k9bpbjykcq80000gn/T/TestListenerTimeoutNativeDoltdurable_without_shell_env2388851900/001/.dolt-data"
        
        behavior:
          dolt_transaction_commit: false
          event_scheduler: "OFF"
          auto_gc_behavior:
            enable: true
            archive_level: 1
        
        system_variables:
          dolt_stats_enabled: 0
    listener_timeout_native_test.go:129: dolt --host 127.0.0.1 --port 59512 --user root --password '' --no-tls sql -q 'SELECT SLEEP(3)'
        Elapsed: 3.377740083s; error: <nil>
        +----------+
        | SLEEP(3) |
        +----------+
        | 0        |
        +----------+
        
=== RUN   TestListenerTimeoutNativeDolt/durable_without_shell_env/start_2
    listener_timeout_native_test.go:72: Generated configuration consumed by dolt sql-server --config:
        # Dolt SQL server configuration — managed by Gas Town (gt dolt start)
        # Do not edit manually; changes are overwritten on each server start.
        # To customize, set Gas Town environment variables:
        #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
        #   GT_DOLT_READ_TIMEOUT_MS, GT_DOLT_WRITE_TIMEOUT_MS (nonnegative milliseconds)
        #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
        #   GT_DOLT_AUTO_GC (on, off)
        
        log_level: warning
        
        listener:
          port: 59520
          host: 127.0.0.1
          max_connections: 1000
          read_timeout_millis: 28800000
          write_timeout_millis: 28800000
        
        data_dir: "/var/folders/qk/3f18t4qd2jn72k9bpbjykcq80000gn/T/TestListenerTimeoutNativeDoltdurable_without_shell_env2388851900/001/.dolt-data"
        
        behavior:
          dolt_transaction_commit: false
          event_scheduler: "OFF"
          auto_gc_behavior:
            enable: true
            archive_level: 1
        
        system_variables:
          dolt_stats_enabled: 0
    listener_timeout_native_test.go:129: dolt --host 127.0.0.1 --port 59520 --user root --password '' --no-tls sql -q 'SELECT SLEEP(3)'
        Elapsed: 3.176997125s; error: <nil>
        +----------+
        | SLEEP(3) |
        +----------+
        | 0        |
        +----------+
        
=== RUN   TestListenerTimeoutNativeDolt/zero_uses_dolt_defaults
=== RUN   TestListenerTimeoutNativeDolt/zero_uses_dolt_defaults/start_1
    listener_timeout_native_test.go:72: Generated configuration consumed by dolt sql-server --config:
        # Dolt SQL server configuration — managed by Gas Town (gt dolt start)
        # Do not edit manually; changes are overwritten on each server start.
        # To customize, set Gas Town environment variables:
        #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
        #   GT_DOLT_READ_TIMEOUT_MS, GT_DOLT_WRITE_TIMEOUT_MS (nonnegative milliseconds)
        #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
        #   GT_DOLT_AUTO_GC (on, off)
        
        log_level: warning
        
        listener:
          port: 59535
          host: 127.0.0.1
          max_connections: 1000
        
        data_dir: "/var/folders/qk/3f18t4qd2jn72k9bpbjykcq80000gn/T/TestListenerTimeoutNativeDoltzero_uses_dolt_defaults1891741384/001/.dolt-data"
        
        behavior:
          dolt_transaction_commit: false
          event_scheduler: "OFF"
          auto_gc_behavior:
            enable: true
            archive_level: 1
        
        system_variables:
          dolt_stats_enabled: 0
    listener_timeout_native_test.go:129: dolt --host 127.0.0.1 --port 59535 --user root --password '' --no-tls sql -q 'SELECT SLEEP(3)'
        Elapsed: 3.122734667s; error: <nil>
        +----------+
        | SLEEP(3) |
        +----------+
        | 0        |
        +----------+
        
--- PASS: TestListenerTimeoutNativeDolt (13.89s)
    --- PASS: TestListenerTimeoutNativeDolt/process_overrides_durable (1.74s)
        --- PASS: TestListenerTimeoutNativeDolt/process_overrides_durable/start_1 (1.73s)
    --- PASS: TestListenerTimeoutNativeDolt/durable_without_shell_env (8.45s)
        --- PASS: TestListenerTimeoutNativeDolt/durable_without_shell_env/start_1 (4.02s)
        --- PASS: TestListenerTimeoutNativeDolt/durable_without_shell_env/start_2 (4.43s)
    --- PASS: TestListenerTimeoutNativeDolt/zero_uses_dolt_defaults (3.56s)
        --- PASS: TestListenerTimeoutNativeDolt/zero_uses_dolt_defaults/start_1 (3.56s)
PASS
ok  	github.com/steveyegge/gastown/internal/doltserver	15.937s
```
</details>
- Outcome: ⚠️ 1 info across 1 run (34m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8bc7e77535b38bded31582036df620ec3cd70df5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/doltserver/doltserver.go:319` - The required “durable Gas Town listener-timeout source fix” remains incomplete: this hunk resolves overrides only in DefaultConfig. With daemon management enabled and daemon.env timeouts set to 28800000, CLI startup honors them, but a subsequent daemon restart follows EnsureRunning → restartWithBackoff → startLocked → writeDaemonDoltConfig, which overwrites config.yaml with hardcoded 30000ms limits (internal/daemon/dolt.go:887). Long migrations can therefore time out again. Route both startup paths through shared timeout resolution and YAML emission, preserving the daemon’s endpoint and data-directory settings.

🔧 Fix: Preserve Dolt listener timeout overrides across daemon restarts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/doltserver/listener_timeout_native_test.go` - new test file written by agent: internal/doltserver/listener_timeout_native_test.go
- <code>Native Go settings: `GOMAXPROCS=2 CGO_ENABLED=1 CGO_CFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_CXXFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_LDFLAGS=-L/opt/homebrew/opt/icu4c@78/lib`. The initial build omitted CGO_CXXFLAGS; corrected and retried.</code>
- `go test -p=2 -vet=off ./internal/doltserver ./internal/daemon -run 'Test(DefaultConfig_ListenerTimeout|WriteDaemonDoltConfig|WriteServerConfig_)' -count=1`
- <code>`go test -p=2 -vet=off -overlay .test-phase-baseline/overlay.json ./internal/doltserver -run &#39;^TestDefaultConfig_ListenerTimeout(EnvOverridesDaemonEnv|FallsBackToDaemonEnv)$&#39; -count=1`: both failed as expected against pre-fix bb09c070 source.</code>
- `go test -p=2 -vet=off ./internal/util -run '^Test(EvaluateDiskSpaceThresholds|APFSPurgeablePreventsBlock)$' -count=1`
- <code>`GT_TEST_NATIVE_DOLT=1 go test -p=2 -vet=off ./internal/doltserver -run &#39;^TestListenerTimeoutNativeDolt$&#39; -count=1 -v`: passed after correcting client setup and timeout-diagnostic assertion, then isolating GOCACHE and GOMODCACHE inside the worktree.</code>
- <code>Saved generated-YAML and SQL output to the evidence directory, removed temporary overlays and caches, and verified `git status --short` showed only the new integration test.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
